### PR TITLE
fix: heartbeat continuity evaluates a sliding window, not full history (#4)

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -355,7 +355,7 @@ files:
   - src: scripts/heartbeat.py
     dest: .claude/scripts/heartbeat.py
     kind: scaffold
-    sha256: 9a9e66050845325b7278221d7e64f0c25b22cf6e36209fe05c65a197a882f200
+    sha256: d6dcf3a993fcfc2c81e56d000e034d518a70c81795b84118e56ba8414ca6532f
   - src: scripts/heartbeat_loop_prompt.py
     dest: .claude/scripts/heartbeat_loop_prompt.py
     kind: scaffold
@@ -503,7 +503,7 @@ files:
   - src: scripts/liveness_policy.py
     dest: .claude/scripts/liveness_policy.py
     kind: scaffold
-    sha256: 659fc114337ee68dcba999e15ea1d47a0d4be579e1a52790f4f1156a6e36532c
+    sha256: e15b465f2193dc5ed82ad2e318c5492326517541426a533a86164bc1d720b9be
   - src: scripts/local_gate.py
     dest: .claude/scripts/local_gate.py
     kind: scaffold

--- a/scripts/heartbeat.py
+++ b/scripts/heartbeat.py
@@ -18,7 +18,9 @@ from _hooks_path import load_module_by_path  # #863 Family B: loader delegation 
 # A 5-min cron tick should refresh .heartbeat.json continuously; >35 min
 # stale (5-min interval + jitter margin) means monitoring is NOT running.
 # #597: value single-sourced in liveness_policy (THE liveness-minutes source).
-from liveness_policy import STALE_MINUTES, TICK_INTERVAL_DEFAULT_MIN  # noqa: E402
+from liveness_policy import (CONTINUITY_WINDOW_HOURS,  # noqa: E402  (#4 window)
+                             CONTINUITY_WINDOW_TICKS,
+                             STALE_MINUTES, TICK_INTERVAL_DEFAULT_MIN)
 from kunglao_log import iter_jsonl  # noqa: E402  (#863 Family K single source)
 
 # #461: the cron-registration marker. --heartbeat-on alone proves only that
@@ -161,15 +163,27 @@ def _parse_hb_ts(value):
 def evaluate_tick_continuity(state: dict, *,
                              now: datetime | None = None,
                              stale_minutes: int = STALE_MINUTES,
-                             log_path=None) -> tuple[bool, str]:
+                             log_path=None,
+                             window_ticks: int = CONTINUITY_WINDOW_TICKS,
+                             window_hours: int = CONTINUITY_WINDOW_HOURS
+                             ) -> tuple[bool, str]:
     """#754 E2: THE liveness verdict shared by gate / check / verify.
 
     Alive requires ALL of:
       1. tick_history carries >= 2 parseable ticks (a lone registration tick,
          however fresh, is the #754 blind spot);
-      2. every adjacent gap <= 2 * interval_min (interval read from the file,
-         default 5min — one missed tick is jitter, two is a dead cron);
+      2. every adjacent gap INSIDE THE WINDOW <= 2 * interval_min (interval
+         read from the file, default 5min — one missed tick is jitter, two
+         is a dead cron);
       3. the newest tick <= stale_minutes old (the pre-existing 35-min line).
+
+    #4 sliding window: the verdict reads only RECENT ticks — among the last
+    window_ticks OR within the last window_hours (defaults in liveness_policy,
+    sized to the 5-min cadence). History outside the window is NOT deleted —
+    the durable sidecar stays append-only — it just stops participating, so
+    one mid-life stall (laptop asleep over a weekend) ages out instead of
+    re-rejecting the workspace forever. Aged-out stalls are counted and
+    surfaced in the detail text: no silent history rewriting.
 
     STRICT legacy handling (adjudicated): files WITHOUT tick_history REJECT —
     that format-shape IS the incident file, and a compatibility pass would
@@ -227,7 +241,23 @@ def evaluate_tick_continuity(state: dict, *,
     except (TypeError, ValueError, OverflowError):
         interval = float(TICK_INTERVAL_DEFAULT_MIN)
     max_gap = timedelta(minutes=2 * interval)
-    for prev, nxt in zip(stamps, stamps[1:]):
+    # #4: sliding window over the sorted history — union of "recent N ticks"
+    # and "recent M hours". The tick-count bound caps the scan for slow
+    # cadences; the age bound guarantees any stall ages out within ~a day.
+    n = max(1, int(window_ticks))
+    cutoff = moment - timedelta(hours=max(0, int(window_hours)))
+    window = [t for i, t in enumerate(stamps)
+              if i >= len(stamps) - n or t >= cutoff]
+    in_window = set(window)
+    # Stalls (oversized adjacent gaps) that no longer participate: the pair
+    # is not fully inside the window, so the gap loop below never sees it.
+    # Counted here so the verdict can surface them — no silent rewriting.
+    aged_out = sum(1 for prev, nxt in zip(stamps, stamps[1:])
+                   if nxt - prev > max_gap
+                   and (prev not in in_window or nxt not in in_window))
+    aged_note = (f"; window: last {len(window)} ticks (older history excluded: "
+                 f"{aged_out} stall(s) aged out)") if aged_out else ""
+    for prev, nxt in zip(window, window[1:]):
         gap = nxt - prev
         if gap > max_gap:
             return (False, durable_prefix +
@@ -235,16 +265,17 @@ def evaluate_tick_continuity(state: dict, *,
                     f"> {int(2 * interval)} min = 2x{interval:g}m): "
                     f"{prev.strftime('%Y-%m-%dT%H:%M:%SZ')} -> "
                     f"{nxt.strftime('%Y-%m-%dT%H:%M:%SZ')} - the cron stalled mid-life; re-arm with "
-                    "heartbeat_tick.py <ws> or re-register the /loop")
+                    "heartbeat_tick.py <ws> or re-register the /loop" + aged_note)
     age = moment - stamps[-1]
     if age > timedelta(minutes=stale_minutes):
         return (False, durable_prefix +
                 f"heartbeat STALE (last tick {int(age.total_seconds()//60)} min ago > "
-                f"{stale_minutes}) - continuous-tick history present but the loop died")
+                f"{stale_minutes}) - continuous-tick history present but the loop died"
+                + aged_note)
     return (True, durable_prefix +
-            f"continuous ticks OK ({len(stamps)} in window, latest "
+            f"continuous ticks OK ({len(window)} in window, latest "
             f"{stamps[-1].strftime('%Y-%m-%dT%H:%M:%SZ')}, cadence <= "
-            f"{int(2 * interval)}m)")
+            f"{int(2 * interval)}m)" + aged_note)
 
 
 from harness_common import utc_now_z as utc_now  # #863 Family F: single source (was a local def)

--- a/scripts/liveness_policy.py
+++ b/scripts/liveness_policy.py
@@ -78,6 +78,17 @@ HEARTBEAT_STALE_MINUTES = 35
 # this value is NEW in #754, not a surveyed pre-existing constant.
 TICK_INTERVAL_DEFAULT_MIN = 5
 
+# scripts/heartbeat.py (#4): the continuity verdict reads a SLIDING WINDOW,
+# not the whole durable tick sidecar - a tick participates when it is among
+# the last CONTINUITY_WINDOW_TICKS OR within the last CONTINUITY_WINDOW_HOURS;
+# older ticks stay on disk (append-only, nothing deleted) but stop voting.
+# Sized to the real cadence above (5m): 12 ticks ~= 1 hour of normal
+# operation, so ordinary jitter never trips it, while any historical stall
+# stops counting within ~a day (24h age bound) instead of re-rejecting the
+# workspace forever after one mid-life gap.
+CONTINUITY_WINDOW_TICKS = 12
+CONTINUITY_WINDOW_HOURS = 24
+
 # ---------------------------------------------------------------------------
 # Hook-activation TTL (the enforcement-liveness threshold, value 30)
 # ---------------------------------------------------------------------------

--- a/tests/test_heartbeat_window_4.py
+++ b/tests/test_heartbeat_window_4.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+"""tests/test_heartbeat_window_4.py - issue #4 heartbeat continuity window.
+
+RED contract: the #754 continuity evaluator scanned the ENTIRE durable tick
+sidecar, so ONE mid-life stall (laptop asleep over a weekend) re-rejected
+the workspace forever - every later evaluation re-read the same historical
+gap and no sanctioned recovery path existed. The verdict now reads a
+SLIDING WINDOW (recent N ticks OR recent M hours); older ticks stay on disk
+(append-only sidecar, nothing deleted) but stop participating in the
+verdict, and aged-out stalls are surfaced in the detail text.
+
+  W1  early-history stall + recent continuous ticks -> PASS (was REJECT)
+  W2  stall INSIDE the window -> still REJECT (fix must not weaken
+      in-window detection: a recent cadence hole, and a too-recent stall
+      with too few resumed ticks, both keep rejecting)
+  W3  brand-new workspace (2 clean ticks, both branches) -> PASS as before
+  W4  aged-out stalls counted and surfaced in the verdict detail
+  W5  window knobs are policy constants + function parameters; an override
+      that widens the window to everything restores the legacy full-history
+      verdict
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import heartbeat as hb_mod  # noqa: E402
+
+NOW = datetime.now(timezone.utc)
+
+
+def _ts(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _mk_ws(tmp_path: Path) -> Path:
+    ws = tmp_path / "ws"
+    (ws / "runs").mkdir(parents=True, exist_ok=True)
+    return ws
+
+
+def _write_sidecar(ws: Path, stamps: list[datetime]) -> Path:
+    log = ws / "runs" / ".heartbeat.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    with log.open("a", encoding="utf-8") as fh:
+        for dt in stamps:
+            fh.write(json.dumps({"ts": _ts(dt), "actor": "test"}) + "\n")
+    return log
+
+
+def _cache_state(history: list[str]) -> dict:
+    return {"started_ts": _ts(NOW - timedelta(days=7)),
+            "interval_min": 5,
+            "loop_registered": True,
+            "last_tick_ts": history[-1] if history else _ts(NOW),
+            "tick_history": list(history)}
+
+
+def _recent_block(ticks: int = 12, newest_ago_min: int = 5,
+                  cadence_min: int = 5) -> list[datetime]:
+    """A clean continuous block ending newest_ago_min before NOW."""
+    return [NOW - timedelta(minutes=newest_ago_min + cadence_min * i)
+            for i in range(ticks - 1, -1, -1)]
+
+
+# ===========================================================================
+# W1 - the issue itself: a mid-life stall must age out
+# ===========================================================================
+
+class TestMidlifeStallAgesOut:
+    def test_durable_branch_old_stall_plus_recent_continuity_passes(
+            self, tmp_path):
+        """THE incident: a weekend stall 3 days back + a clean recent block
+        must be ALIVE - the historical gap no longer participates."""
+        ws = _mk_ws(tmp_path)
+        old = [NOW - timedelta(days=3, minutes=5), NOW - timedelta(days=3)]
+        log = _write_sidecar(ws, old + _recent_block())
+        alive, detail = hb_mod.evaluate_tick_continuity(
+            _cache_state([]), log_path=log, now=NOW)
+        assert alive is True, detail
+        assert "aged out" in detail, detail
+
+    def test_cache_history_branch_windows_too(self, tmp_path):
+        """The window applies to the .heartbeat.json tick_history branch as
+        well (no log_path) - same verdict, same aged-out surfacing."""
+        hist = [_ts(NOW - timedelta(days=3, minutes=5)),
+                _ts(NOW - timedelta(days=3))]
+        hist += [_ts(t) for t in _recent_block()]
+        alive, detail = hb_mod.evaluate_tick_continuity(
+            _cache_state(hist), now=NOW)
+        assert alive is True, detail
+        assert "aged out" in detail, detail
+
+
+# ===========================================================================
+# W2 - the fix must not weaken in-window detection
+# ===========================================================================
+
+class TestInWindowStillRejects:
+    def test_recent_cadence_hole_inside_window_rejects(self, tmp_path):
+        ws = _mk_ws(tmp_path)
+        stamps = [NOW - timedelta(minutes=m) for m in (60, 55, 25, 20, 5)]
+        log = _write_sidecar(ws, stamps)  # 30-min hole between -55 and -25
+        alive, detail = hb_mod.evaluate_tick_continuity(
+            _cache_state([]), log_path=log, now=NOW)
+        assert alive is False, detail
+        assert "gap" in detail.lower() or "cadence" in detail.lower(), detail
+        assert "aged out" not in detail, detail
+
+    def test_stall_with_too_few_resumed_ticks_still_rejects(self, tmp_path):
+        """Recovery needs a full window: a 3h-old stall with only 4 resumed
+        ticks is still inside the window (last-12 and 24h both reach it)."""
+        ws = _mk_ws(tmp_path)
+        pre = [NOW - timedelta(hours=3), NOW - timedelta(hours=3) +
+               timedelta(minutes=5)]
+        log = _write_sidecar(ws, pre + _recent_block(ticks=4))
+        alive, detail = hb_mod.evaluate_tick_continuity(
+            _cache_state([]), log_path=log, now=NOW)
+        assert alive is False, detail
+
+    def test_brand_new_two_tick_durable_passes(self, tmp_path):
+        """W3: a brand-new workspace keeps passing (no regression)."""
+        ws = _mk_ws(tmp_path)
+        log = _write_sidecar(ws, [NOW - timedelta(minutes=6),
+                                  NOW - timedelta(minutes=1)])
+        alive, detail = hb_mod.evaluate_tick_continuity(
+            _cache_state([]), log_path=log, now=NOW)
+        assert alive is True, detail
+        assert "aged out" not in detail, detail
+
+    def test_brand_new_two_tick_cache_passes(self):
+        hist = [_ts(NOW - timedelta(minutes=6)), _ts(NOW - timedelta(minutes=1))]
+        alive, detail = hb_mod.evaluate_tick_continuity(
+            _cache_state(hist), now=NOW)
+        assert alive is True, detail
+
+
+# ===========================================================================
+# W4 - aged-out stalls are counted and surfaced (no silent rewriting)
+# ===========================================================================
+
+class TestAgedOutSurfacing:
+    def test_two_aged_out_stalls_counted(self, tmp_path):
+        ws = _mk_ws(tmp_path)
+        d3 = NOW - timedelta(days=3)
+        old = [d3, d3 + timedelta(minutes=30), d3 + timedelta(minutes=35)]
+        log = _write_sidecar(ws, old + _recent_block())
+        alive, detail = hb_mod.evaluate_tick_continuity(
+            _cache_state([]), log_path=log, now=NOW)
+        assert alive is True, detail
+        m = re.search(r"older history excluded: (\d+) stall", detail)
+        assert m, f"aged-out count missing from detail: {detail}"
+        assert m.group(1) == "2", detail
+
+    def test_clean_long_history_no_aged_out_note(self, tmp_path):
+        """Old out-of-window ticks with NO stall anywhere: verdict stays
+        clean - no spurious aged-out claim. Uninterrupted ~25h of 5-min
+        ticking: ticks older than the 24h bound drop out of the window, but
+        no gap in the raw history ever exceeds 2x the interval."""
+        ws = _mk_ws(tmp_path)
+        stamps = [NOW - timedelta(minutes=5 * i) for i in range(307, 0, -1)]
+        log = _write_sidecar(ws, stamps)
+        alive, detail = hb_mod.evaluate_tick_continuity(
+            _cache_state([]), log_path=log, now=NOW)
+        assert alive is True, detail
+        assert "aged out" not in detail, detail
+
+
+# ===========================================================================
+# W5 - window knobs: policy constants + overridable parameters
+# ===========================================================================
+
+class TestWindowKnobs:
+    def test_defaults_are_policy_module_constants(self):
+        from liveness_policy import (CONTINUITY_WINDOW_HOURS,
+                                     CONTINUITY_WINDOW_TICKS)
+        assert hb_mod.CONTINUITY_WINDOW_TICKS == CONTINUITY_WINDOW_TICKS
+        assert hb_mod.CONTINUITY_WINDOW_HOURS == CONTINUITY_WINDOW_HOURS
+        assert CONTINUITY_WINDOW_TICKS >= 1 and CONTINUITY_WINDOW_HOURS >= 1
+
+    def test_widened_window_restores_legacy_full_history_verdict(
+            self, tmp_path):
+        """Operator escape hatch: a window wide enough to hold everything
+        re-judges the historical gap (pre-#4 behavior, opt-in)."""
+        ws = _mk_ws(tmp_path)
+        old = [NOW - timedelta(days=3, minutes=5), NOW - timedelta(days=3)]
+        log = _write_sidecar(ws, old + _recent_block())
+        alive, detail = hb_mod.evaluate_tick_continuity(
+            _cache_state([]), log_path=log, now=NOW,
+            window_ticks=10 ** 6, window_hours=10 ** 6)
+        assert alive is False, detail


### PR DESCRIPTION
## Summary

Heartbeat continuity now evaluates a sliding window (last 12 ticks OR last
24 hours, union) instead of the full append-only tick history. One historical
stall (e.g. a weekend with the laptop asleep) no longer REJECTs the workspace
forever; the stall ages out of the window while in-window detection is
unchanged.

- Evaluator: `evaluate_tick_continuity` (scripts/heartbeat.py). Root cause was
  the durable sidecar branch — `runs/.heartbeat.log` is append-only with no
  rotation, so any oversized adjacent gap re-triggered REJECT on every future
  evaluation. The in-memory `tick_history` already self-healed (pruned,
  cap-12); only the sidecar path was permanent.
- Window constants (`CONTINUITY_WINDOW_TICKS = 12`, `CONTINUITY_WINDOW_HOURS
  = 24`) live in `scripts/liveness_policy.py` per the #597
  single-source-for-thresholds convention. 12 ticks ~= 1h at the observed
  5-min cadence; the 24h bound guarantees any stall ages out within a day.
- History is NOT deleted — only excluded from the verdict. The detail line
  surfaces aged-out stalls: `window: last N ticks (older history excluded:
  X stall(s) aged out)`.

Closes #4

Milestone: v0.1.5 (milestone #1)

## Anti-orphan gate (REQUIRED)

- Added code: window constants + windowed evaluation helper + 10 tests
  (tests/test_heartbeat_window_4.py). No new deploy surface (scripts/ already
  deployed); constants consumed in-repo by heartbeat.py.
- Code moved/deleted: none. Full-history read replaced by windowed read
  inside `evaluate_tick_continuity`; all verdict consumers
  (`hooks/worker_budget_sinks.check_heartbeat_alive`, `heartbeat_check` CLI,
  `verify_loop` rc 6) keep their interfaces unchanged.

## Test plan

- [x] `uv run python -m pytest tests/test_heartbeat_window_4.py -q` — 10/10
      (RED first: 6 failed pre-fix with the permanent-REJECT repro)
- [x] In-window detection unchanged: recent cadence holes and too-recent
      stalls still reject (guard tests)
- [x] Targeted heartbeat neighborhood (14 files): 256 passed
- [x] Full suite: 5297 passed, 37 failed — all 37 verified pre-existing on
      clean dev HEAD 589a3a3 (stash + re-run comparison): 31x decide
      frozen-snapshot `value_signals` drift, 2x deploy-manifest digest, 2x
      event-stream flake under parallel-suite load, 2x resume read-only
- [x] `ruff check` clean on all changed files
