### PR TITLE
fix: sanctioned recovery path for stale CLAUDE.md after refused merge (#5)

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -451,7 +451,7 @@ files:
   - src: scripts/kunglao.py
     dest: .claude/scripts/kunglao.py
     kind: scaffold
-    sha256: 6db2869bbfd8136a37582d53d3144c9b9445c789aed7cad4cf8e8e5f6e841c6b
+    sha256: d37b01cd36c72d1308247ae4534f875f4f8bb88f1b9d9d315243ea69869a5d90
   - src: scripts/kunglao_eval.py
     dest: .claude/scripts/kunglao_eval.py
     kind: scaffold
@@ -479,7 +479,7 @@ files:
   - src: scripts/kunglao_upgrade.py
     dest: .claude/scripts/kunglao_upgrade.py
     kind: scaffold
-    sha256: 03fe337a33c8fb2c3a874a62a8892b16704b67336e28e59106be5988f6db5ff1
+    sha256: 7f6adf34da41c41a870f5740176882b656ee00f704854d165d72a99c7555bb44
   - src: scripts/kunglao_verify.py
     dest: .claude/scripts/kunglao_verify.py
     kind: scaffold

--- a/scripts/kunglao.py
+++ b/scripts/kunglao.py
@@ -119,6 +119,35 @@ def cmd_health(args) -> int:
     return r["exit_code"]
 
 
+def _load_upgrade_module():
+    """#863 Family B loader (same pattern cmd_upgrade uses): the #5
+    pending-merge marker contract (path constants + record reader/clearer)
+    is single-sourced in kunglao_upgrade; check-stale borrows it instead of
+    duplicating the relpaths."""
+    mod_path = Path(__file__).resolve().parent / "kunglao_upgrade.py"
+    return load_module_by_path("kunglao_upgrade", mod_path)
+
+
+def _resolve_pending_merge(ws: Path) -> int:
+    """#5 explicit escape hatch: clear the pending CLAUDE.md manual-merge
+    marker. Idempotent — no marker is a clean rc 0."""
+    up = _load_upgrade_module()
+    if up.pending_merge_record(ws) is None:
+        print(f"no pending CLAUDE.md merge marker under {ws} — nothing to "
+              f"resolve (check-stale semantics unchanged)")
+        return 0
+    try:
+        up.clear_pending_merge(ws)
+    except OSError as exc:
+        print(f"kunglao: FAILED to remove {up.PENDING_MERGE_REL} under "
+              f"{ws} ({exc}) — remove it by hand", file=sys.stderr)
+        return 1
+    print(f"cleared {up.PENDING_MERGE_REL} under {ws} — now finish the "
+          f"refresh: run /kunglao-agent:upgrade {ws}, then check-stale "
+          f"to confirm")
+    return 0
+
+
 def cmd_check_stale(args) -> int:
     """#748: stale-workspace gate — emit a JSON envelope and exit 5 when the
     workspace stamp is older than the active skill version (or missing
@@ -128,14 +157,25 @@ def cmd_check_stale(args) -> int:
     JSON envelope:
 
         {
-          "status":     "stale" | "current" | "no-stamp" | "deploy-drift",
+          "status":     "stale" | "current" | "no-stamp" | "deploy-drift"
+                      | "manual-merge-pending",
           "rc":         0 | 5,
           "workspace_stamp": "0.1.0" | null,
           "skill_version":   "0.1.3",
           "advice":     "run /kunglao-agent:upgrade <workspace> first" | null
         }
+
+    #5: a `manual-merge-pending` status replaces the endless stale loop when
+    a previous upgrade's CLAUDE.md collect-and-merge REFUSED a user-edited
+    body (upgrade leaves runs/claudemd-pending-merge.yaml + a diff report).
+    The rc stays 5 — the frame IS still stale — but the advice is now the
+    sanctioned recovery path: review the diff, merge manually, clear the
+    marker with `check-stale --resolve`, re-run the upgrade. `--resolve`
+    alone clears the marker (rc 0) and restores normal semantics.
     """
     ws = Path(args.workspace).resolve()
+    if getattr(args, "resolve", False):
+        return _resolve_pending_merge(ws)
     skill_v = template_version.read_skill_version()
     ws_v = template_version.read_workspace_version(ws)
     if ws_v is None:
@@ -163,6 +203,37 @@ def cmd_check_stale(args) -> int:
         print(json.dumps(envelope, ensure_ascii=False))
         return RC_STALE_WORKSPACE
     if ws_key < skill_key:
+        # #5: a pending manual-merge marker means a previous upgrade run
+        # already REFUSED here — repeating "run /upgrade first" would loop
+        # forever (the merge refusal is exactly what keeps the stamp stale).
+        # Surface the sanctioned recovery path instead.
+        up = _load_upgrade_module()
+        pending = up.pending_merge_record(ws)
+        if pending is not None:
+            diff_rel = str(pending.get("diff_report")
+                           or up.PENDING_MERGE_DIFF_REL)
+            diff_path = Path(diff_rel)
+            if not diff_path.is_absolute():
+                diff_path = ws / diff_path
+            reason = str(pending.get("reason") or "(unspecified)")
+            envelope = {
+                "status": "manual-merge-pending",
+                "rc": RC_STALE_WORKSPACE,
+                "workspace_stamp": ws_v,
+                "skill_version": skill_v,
+                "pending_since": pending.get("created"),
+                "pending_reason": reason,
+                "diff_report": str(diff_path),
+                "advice": (
+                    "CLAUDE.md auto-merge was refused during a previous "
+                    f"upgrade ({reason}); review the diff at {diff_path}, "
+                    "merge it into CLAUDE.md manually, then clear the "
+                    "marker: python scripts/kunglao.py check-stale "
+                    f"--resolve {ws} — and re-run /kunglao-agent:upgrade "
+                    f"{ws}"),
+            }
+            print(json.dumps(envelope, ensure_ascii=False))
+            return RC_STALE_WORKSPACE
         envelope = {
             "status": "stale",
             "rc": RC_STALE_WORKSPACE,
@@ -391,6 +462,10 @@ def main() -> int:
              "/kunglao-agent:analysis or /kunglao-agent:resume on a "
              "workspace whose template stamp may trail the skill")
     p_check_stale.add_argument("workspace", nargs="?", default=".")
+    p_check_stale.add_argument("--resolve", action="store_true",
+                               help="clear a pending CLAUDE.md manual-merge "
+                                    "marker (#5) instead of running the "
+                                    "staleness check")
     p_check_stale.set_defaults(func=cmd_check_stale)
 
     p_up = sub.add_parser("upgrade",

--- a/scripts/kunglao_upgrade.py
+++ b/scripts/kunglao_upgrade.py
@@ -84,6 +84,14 @@ USER_DATA_DIRS: tuple[str, ...] = (
 # refresh never trips the iron rule (design D4).
 _STAMP_CARRIERS = ("facts/_INDEX.md", "claim-register.yaml")
 
+# #5 pending-manual-merge artifacts (upgrade telemetry, D4-exempt below):
+# written when the G3 collect-and-merge REFUSES a user-edited body, so
+# check-stale can point at a sanctioned recovery path instead of looping on
+# "run /kunglao-agent:upgrade first" forever. Presence of the marker IS the
+# whole state machine; the diff report is the operator's review artifact.
+PENDING_MERGE_REL = "runs/claudemd-pending-merge.yaml"
+PENDING_MERGE_DIFF_REL = "runs/claudemd-pending-merge.diff.patch"
+
 RC_OK = 0
 RC_UNKNOWN_ORIGIN = 3
 RC_IRON_RULE = 4
@@ -408,6 +416,109 @@ def _frame_label(before: str, after: str) -> str:
     return f"+{adds}/-{removed}"
 
 
+def _pending_merge_diff(ws: Path, current: str, reason: str,
+                        req_block: str | None) -> str:
+    """#5 review artifact: unified diff of the current workspace body
+    (left) vs the incoming frame the refused merge would have written
+    (right). A render failure must not take the marker down with it — the
+    marker, not the diff, IS the state machine."""
+    import difflib
+    head = (
+        "# CLAUDE.md pending manual merge (issue #5)\n"
+        f"# reason: {reason}\n"
+        "# left  = current workspace body\n"
+        "# right = incoming frame the refused upgrade merge would have\n"
+        "#        written. Merge the needful changes into CLAUDE.md by\n"
+        "#        hand, then clear the marker and finish the refresh:\n"
+        "#   python scripts/kunglao.py check-stale --resolve <workspace>\n"
+        "#   python scripts/kunglao.py upgrade <workspace>\n"
+    )
+    try:
+        incoming = claudemd_frame.wrap_frame(
+            _build_current_frame(ws, current, req_block))
+    except Exception as exc:  # noqa: BLE001 — report survives, marker rules
+        return head + f"(incoming frame render failed: {exc})\n"
+    version = template_version.read_skill_version()
+    lines = difflib.unified_diff(
+        current.splitlines(), incoming.splitlines(),
+        fromfile="CLAUDE.md (current workspace body)",
+        tofile=f"CLAUDE.md (incoming frame v{version})", lineterm="")
+    return head + "\n".join(lines) + "\n"
+
+
+def _write_pending_merge(ws: Path, current: str, reason: str,
+                         req_block: str | None = None) -> str:
+    """#5 upgrade face of the deadlock breaker: a refused G3 merge used to
+    leave NOTHING behind, so the G4 gate honestly kept the old stamp and
+    check-stale looped on "run /upgrade first" forever. Leave an explicit
+    pending-manual-merge state instead. Returns the diff-report relpath
+    (also recorded inside the marker)."""
+    ws = Path(ws)
+    ws.joinpath("runs").mkdir(parents=True, exist_ok=True)
+    _atomic_write_bytes(
+        ws / PENDING_MERGE_DIFF_REL,
+        _pending_merge_diff(ws, current, reason,
+                            req_block).encode("utf-8"))
+    record = {
+        "schema": "kunglao.claudemd-pending-merge/1",
+        "created": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "skill_version": template_version.read_skill_version(),
+        "workspace_stamp": template_version.read_workspace_version(ws),
+        "reason": reason,
+        "diff_report": PENDING_MERGE_DIFF_REL,
+        "resolve_command": ("python scripts/kunglao.py check-stale "
+                            "--resolve <workspace>"),
+    }
+    _atomic_write_bytes(
+        ws / PENDING_MERGE_REL,
+        yaml.safe_dump(record, sort_keys=False,
+                       allow_unicode=True).encode("utf-8"))
+    return PENDING_MERGE_DIFF_REL
+
+
+def pending_merge_record(ws: Path) -> dict | None:
+    """#5 check-stale face: read the pending-merge marker. None = no
+    pending state. Presence is the whole state machine — a marker that
+    fails to parse still counts as pending (a malformed record must never
+    masquerade as a clean workspace); only its fields degrade."""
+    p = Path(ws) / PENDING_MERGE_REL
+    if not p.is_file():
+        return None
+    try:
+        data = yaml.safe_load(p.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001 — presence beats parse failures
+        return {"reason": "(unreadable pending-merge marker)"}
+    if not isinstance(data, dict):
+        return {"reason": "(malformed pending-merge marker)"}
+    rec = {str(k): v for k, v in data.items()}
+    rec.setdefault("reason", "(unspecified)")
+    return rec
+
+
+def clear_pending_merge(ws: Path) -> bool:
+    """#5: remove the pending-merge marker (explicit `check-stale
+    --resolve`, or a subsequent successful merge). True when a marker was
+    removed, False when none existed; OSError propagates — callers own the
+    user-facing failure face (never silently swallowed)."""
+    try:
+        (Path(ws) / PENDING_MERGE_REL).unlink()
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def _clear_pending_merge_quiet(ws: Path) -> None:
+    """Best-effort marker clear once a merge SUCCEEDS (applied or
+    fixed-point noop): the pending state is resolved. A removal failure is
+    a WARN, never a merge failure — a marker left behind only keeps
+    check-stale's recovery advice alive, which is the safe direction."""
+    try:
+        clear_pending_merge(ws)
+    except OSError as exc:
+        _warn_line(f"kunglao-upgrade: WARN — could not remove "
+                   f"{PENDING_MERGE_REL} ({exc}); remove it by hand")
+
+
 def _item_claudemd_merge(ws: Path, dry: bool) -> str:
     """#755 G3 (T2/A3): three-segment collect-and-merge. Rebuild ONLY the
     frame from the CURRENT template; 需求段 (task_spec constraint block) and
@@ -415,7 +526,12 @@ def _item_claudemd_merge(ws: Path, dry: bool) -> str:
     in place; stray prose relocated with new-frame dedup). When even the
     conservative heading-walk cannot place every current heading, the merge
     REFUSES: skip + WARN, body untouched — 宁可旧也不要错删 (#758 posture).
-    After an applied merge the G4 stamp gate's positive path is unlocked."""
+    After an applied merge the G4 stamp gate's positive path is unlocked.
+
+    #5: a refusal is no longer a silent skip — it leaves the explicit
+    pending-manual-merge state (runs/claudemd-pending-merge.yaml marker +
+    .diff.patch report) that check-stale turns into the sanctioned recovery
+    path; a subsequent successful merge clears the marker again."""
     current = _claudemd_read(ws)
     if current is None:
         return "claudemd_merge(noop: no CLAUDE.md)"
@@ -428,11 +544,21 @@ def _item_claudemd_merge(ws: Path, dry: bool) -> str:
         return ("claudemd_merge(dry)" if parts.status == "applied"
                 else f"claudemd_merge(dry-skipped: {parts.reason})")
     if parts.status != "applied":
+        # #5 deadlock breaker: leave the explicit pending state (marker +
+        # diff report) instead of a bare skip — the G4 gate still honestly
+        # keeps the old stamp, but check-stale can now hand the operator a
+        # sanctioned recovery path instead of an endless stale loop.
+        diff_rel = _write_pending_merge(ws, current, parts.reason,
+                                        parts.req_block)
         _warn(f"kunglao-upgrade: WARN — CLAUDE.md merge skipped "
-              f"({parts.reason}); legacy body left untouched (G3)",
+              f"({parts.reason}); legacy body left untouched (G3); "
+              f"manual merge pending — review {diff_rel}, merge it into "
+              f"CLAUDE.md, then run: python scripts/kunglao.py "
+              f"check-stale --resolve {ws}",
               parts.reason, "claudemd_merge", ws,
-              ledger_detail=f"skipped:{parts.reason}")
-        return f"claudemd_merge(skipped: {parts.reason})"
+              ledger_detail=f"pending-merge:{parts.reason}")
+        return (f"claudemd_merge(skipped: {parts.reason}; "
+                f"pending-merge={PENDING_MERGE_REL})")
     frame_inner = _build_current_frame(ws, current, parts.req_block)
     # Fixed-point hygiene: a rebuilt frame can legitimately CONTAIN blocks
     # the classifier flagged as user content (parametric headings such as
@@ -453,12 +579,14 @@ def _item_claudemd_merge(ws: Path, dry: bool) -> str:
     merged = claudemd_frame.assemble(parts,
                                      claudemd_frame.wrap_frame(frame_inner))
     if merged == current:
+        _clear_pending_merge_quiet(ws)
         return "claudemd_merge(noop)"
     target = ws / "CLAUDE.md"
     tmp = target.with_name(target.name + ".tmp755")
     tmp.write_text(merged, encoding="utf-8")
     import os as _os
     _os.replace(tmp, target)
+    _clear_pending_merge_quiet(ws)  # #5: a successful merge resolves pending
     detail = f"{_frame_label(current, merged)} sections={len(parts.user_sections)}"
     _emit_event("claudemd_merge", "ok", detail)
     _emit(ws, "claudemd_merge", detail)
@@ -528,7 +656,12 @@ def _vkey(version: str) -> tuple[int, ...]:
 #   runs/logs/kunglao-*.jsonl       #726 emits ONLY its own actor lines —
 #                                   line-filtered, analysis events stay
 #                                   byte-protected
-_EXEMPT_EXACT = ("runs/.init-report.json",)
+#   runs/claudemd-pending-merge.*   #5 refused-merge marker + diff report
+_EXEMPT_EXACT = (
+    "runs/.init-report.json",
+    PENDING_MERGE_REL,
+    PENDING_MERGE_DIFF_REL,
+)
 
 
 def _is_exempt(rel: str) -> bool:

--- a/tests/test_claudemd_pending_merge_5.py
+++ b/tests/test_claudemd_pending_merge_5.py
@@ -1,0 +1,291 @@
+# -*- coding: utf-8 -*-
+"""tests/test_claudemd_pending_merge_5.py — issue #5: sanctioned recovery
+path for a workspace CLAUDE.md left permanently stale after a refused
+upgrade merge.
+
+The three-component deadlock (each correct in isolation):
+  1. kunglao_upgrade._item_claudemd_merge REFUSES a user-edited body
+     (宁可旧也不要错删, #758 posture) — skip + WARN, body untouched.
+  2. the G4 stamp gate (_guarded_stamp_refresh) then honestly keeps the old
+     stamp: a fresh stamp may only ride a CURRENT frame.
+  3. check-stale sees stamp < skill and advises "run /kunglao-agent:upgrade
+     first" — which can now never succeed → stale forever, no sanctioned
+     escape; the operator must hand-edit files with no diff to work from.
+
+The fix turns the refusal into an explicit pending-merge state:
+  - upgrade writes runs/claudemd-pending-merge.yaml (machine-readable
+    marker; presence IS the state machine) plus
+    runs/claudemd-pending-merge.diff.patch (incoming frame vs current body)
+    instead of leaving nothing behind;
+  - check-stale reports status=manual-merge-pending (rc 5, honest — the
+    frame IS still stale) with the full recovery instruction: review the
+    diff, merge manually, clear the marker with `check-stale --resolve`;
+  - the marker is cleared by an explicit --resolve or by any later
+    SUCCESSFUL merge (applied or fixed-point noop); absence restores the
+    normal check-stale semantics.
+"""
+from __future__ import annotations
+
+import collections
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / "scripts"
+KUNGLAO_PY = SCRIPTS / "kunglao.py"
+
+import template_version as tv  # noqa: E402
+from _factories import seed_bins  # noqa: E402
+
+CUR_VERSION = tv.read_skill_version()
+STAMP_KEY = tv.STAMP_KEY
+
+MARKER_REL = "runs/claudemd-pending-merge.yaml"
+DIFF_REL = "runs/claudemd-pending-merge.diff.patch"
+
+SKILL_SENTINEL = Path("/kunglao/skill-sentinel")
+PAYLOAD = b"MZ\x90\x00" + b"\x00" * 64
+SAMPLE_SHA = hashlib.sha256(PAYLOAD).hexdigest()
+
+
+def _load_upgrade():
+    spec = importlib.util.spec_from_file_location(
+        "kunglao_upgrade", SCRIPTS / "kunglao_upgrade.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_init():
+    spec = importlib.util.spec_from_file_location(
+        "kunglao_init_pending5", SCRIPTS / "kunglao-init.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod.SKILL_DIR = SKILL_SENTINEL
+    return mod
+
+
+@pytest.fixture
+def pinned_vi(monkeypatch):
+    """Pin the interpreter series the renders echo (see g2g3 fixture)."""
+    VI = collections.namedtuple("VI", "major minor micro release serial")
+    real = sys.version_info
+    monkeypatch.setattr(sys, "version_info", VI(3, 11, 0, "final", 0))
+    yield
+    monkeypatch.setattr(sys, "version_info", real)
+
+
+def _stamp_line(v: str) -> str:
+    return f"# {STAMP_KEY}: {v}"
+
+
+def _refusing_ws(tmp: Path) -> Path:
+    """A workspace whose hand-written CLAUDE.md can never place the current
+    frame (the #5 user journey: real user edits in a legacy body)."""
+    ws = tmp / "ws"
+    ws.mkdir()
+    (ws / "CLAUDE.md").write_text(
+        _stamp_line("0.1.2") + "\n\n# my own workspace notes\nkeep hands off\n",
+        encoding="utf-8")
+    # one real user-data file under runs/ so the iron-rule digest has
+    # non-exempt company for the marker the upgrade is about to write
+    (ws / "runs").mkdir()
+    (ws / "runs" / "worker-status-C001.txt").write_text("status line",
+                                                        encoding="utf-8")
+    return ws
+
+
+def _rendered_ws(tmp: Path) -> tuple[Path, str]:
+    """ws carrying a fresh init-style render (the mergeable body class)."""
+    init = _load_init()
+    ws = tmp / "ws"
+    seed_bins(ws, payload=PAYLOAD)
+    target = init.write_claudemd(ws, "sample.exe", SAMPLE_SHA,
+                                 project_type="windows")
+    return ws, target.read_text(encoding="utf-8")
+
+
+def _cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(KUNGLAO_PY), *args],
+        capture_output=True, text=True, timeout=120,
+        encoding="utf-8", errors="replace",
+    )
+
+
+def _envelope(proc: subprocess.CompletedProcess) -> dict:
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+# ------------------------------------------------------------- upgrade face
+
+class TestRefusalLeavesPendingState:
+    def test_refusal_writes_marker_and_diff(self, tmp_path):
+        ws = _refusing_ws(tmp_path)
+        claudemd = ws / "CLAUDE.md"
+        before = claudemd.read_bytes()
+
+        up = _load_upgrade()
+        label = up._item_claudemd_merge(ws, False)
+
+        assert "skip" in label.lower(), label
+        marker = ws / MARKER_REL
+        diff = ws / DIFF_REL
+        assert marker.is_file(), \
+            "a refused merge must leave the pending-merge marker"
+        assert diff.is_file() and diff.read_text(encoding="utf-8").strip(), \
+            "a refused merge must leave a reviewable diff report"
+        rec = yaml.safe_load(marker.read_text(encoding="utf-8"))
+        assert str(rec["schema"]).startswith("kunglao.claudemd-pending-merge/")
+        assert rec["skill_version"] == CUR_VERSION
+        assert rec["workspace_stamp"] == "0.1.2"
+        assert rec["reason"], "the refusal reason must be recorded"
+        assert rec["diff_report"] == DIFF_REL
+        assert "--resolve" in rec["resolve_command"]
+        dtext = diff.read_text(encoding="utf-8")
+        assert "incoming" in dtext
+        assert "---" in dtext and "+++" in dtext, "unified diff shape"
+        # 宁可旧也不要错删 still holds: the body itself is untouched
+        assert claudemd.read_bytes() == before
+
+    def test_refusal_label_names_the_marker(self, tmp_path):
+        ws = _refusing_ws(tmp_path)
+        up = _load_upgrade()
+        label = up._item_claudemd_merge(ws, False)
+        assert "claudemd_merge(skipped" in label, \
+            "existing runtime-version pin must survive"
+        assert MARKER_REL in label, \
+            "the skip label must point at the pending marker"
+
+    def test_dry_run_refusal_writes_nothing(self, tmp_path):
+        ws = _refusing_ws(tmp_path)
+        up = _load_upgrade()
+        up._item_claudemd_merge(ws, True)
+        assert not (ws / MARKER_REL).exists()
+        assert not (ws / DIFF_REL).exists()
+
+    def test_full_upgrade_keeps_iron_rule_and_honest_stamp(self, tmp_path):
+        """The end-to-end #5 run: rc 0, marker written, stamp honestly NOT
+        refreshed, and the marker/diff under runs/ never trip the iron
+        rule (they are upgrade telemetry, D4-exempt)."""
+        ws = _refusing_ws(tmp_path)
+        up = _load_upgrade()
+        pre = up.user_data_digest(ws)
+        rc = up.main([str(ws)])
+        assert rc == 0
+        assert (ws / MARKER_REL).is_file()
+        assert (ws / DIFF_REL).is_file()
+        text = (ws / "CLAUDE.md").read_text(encoding="utf-8")
+        assert _stamp_line("0.1.2") in text, "old stamp stays honest"
+        assert _stamp_line(CUR_VERSION) not in text
+        assert up.user_data_digest(ws) == pre, \
+            "marker + diff are exempt upgrade telemetry, not user data"
+
+
+class TestCleanMergeRegression:
+    def test_automerge_of_mergeable_body_writes_no_marker(self, tmp_path,
+                                                          pinned_vi):
+        """Regression guard: the normal collect-and-merge path must not
+        grow a pending state."""
+        ws, original = _rendered_ws(tmp_path)
+        (ws / "CLAUDE.md").write_text(
+            _stamp_line("0.1.2") + "\n\n" + original, encoding="utf-8")
+        up = _load_upgrade()
+        label = up._item_claudemd_merge(ws, False)
+        assert "applied" in label or "noop" in label, label
+        assert not (ws / MARKER_REL).exists()
+        assert not (ws / DIFF_REL).exists()
+
+    def test_successful_merge_clears_a_stale_marker(self, tmp_path,
+                                                    pinned_vi):
+        """The operator merged by hand (or a later upgrade can place the
+        frame): any successful merge (applied or fixed-point noop) must
+        clear the pending marker."""
+        ws = _refusing_ws(tmp_path)
+        up = _load_upgrade()
+        up._item_claudemd_merge(ws, False)
+        assert (ws / MARKER_REL).is_file()
+        # operator's manual merge lands a body the frame walker CAN place
+        # (render into a sibling dir: init never clobbers an existing
+        # CLAUDE.md, so the same dir would return None)
+        _, merged = _rendered_ws(tmp_path / "merged-src")
+        (ws / "CLAUDE.md").write_text(merged, encoding="utf-8")
+        label = up._item_claudemd_merge(ws, False)
+        assert "applied" in label or "noop" in label, label
+        assert not (ws / MARKER_REL).exists(), \
+            "a successful merge resolves the pending state"
+
+
+# --------------------------------------------------------- check-stale face
+
+class TestCheckStalePendingMerge:
+    def _ws_with_marker(self, tmp_path: Path) -> Path:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        (ws / "CLAUDE.md").write_text(
+            _stamp_line("0.1.2") + "\n# my own workspace notes\n",
+            encoding="utf-8")
+        up = _load_upgrade()
+        up._write_pending_merge(ws, "# my own workspace notes\n",
+                                "current frame does not place in order")
+        return ws
+
+    def test_pending_marker_reports_manual_merge_pending(self, tmp_path):
+        ws = self._ws_with_marker(tmp_path)
+        proc = _cli("check-stale", str(ws))
+        assert proc.returncode == 5, proc.stdout + proc.stderr
+        env = _envelope(proc)
+        assert env["status"] == "manual-merge-pending", env
+        assert env["rc"] == 5
+        assert env["workspace_stamp"] == "0.1.2"
+        assert env["skill_version"] == CUR_VERSION
+        assert env["pending_reason"] == \
+            "current frame does not place in order"
+        assert env["diff_report"] == str(ws / DIFF_REL)
+        advice = env["advice"] or ""
+        assert str(ws / DIFF_REL) in advice, \
+            "the recovery instruction must point at the diff report"
+        assert "--resolve" in advice, \
+            "the recovery instruction must name the marker-clearing command"
+        assert "upgrade" in advice, \
+            "the recovery path ends with re-running the upgrade"
+
+    def test_resolve_clears_marker_and_restores_normal_semantics(
+            self, tmp_path):
+        ws = self._ws_with_marker(tmp_path)
+        proc = _cli("check-stale", str(ws), "--resolve")
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert not (ws / MARKER_REL).exists(), \
+            "--resolve must remove the marker"
+        # idempotent: resolving with no marker is a clean rc 0
+        proc_again = _cli("check-stale", str(ws), "--resolve")
+        assert proc_again.returncode == 0
+        # normal semantics restored: honest generic stale, no pending fields
+        proc_after = _cli("check-stale", str(ws))
+        assert proc_after.returncode == 5
+        env = _envelope(proc_after)
+        assert env["status"] == "stale", env
+        assert "manual-merge" not in json.dumps(env)
+        assert "/kunglao-agent:upgrade" in (env["advice"] or "")
+
+    def test_current_stamp_with_leftover_marker_stays_current(self,
+                                                              tmp_path):
+        """A leftover marker must never poison an already-current
+        workspace: the pending branch only lives on the stale path."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        (ws / "CLAUDE.md").write_text(
+            _stamp_line(CUR_VERSION) + "\n# body\n", encoding="utf-8")
+        up = _load_upgrade()
+        up._write_pending_merge(ws, "whatever\n", "reason-x")
+        proc = _cli("check-stale", str(ws))
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        env = _envelope(proc)
+        assert env["status"] == "current", env


### PR DESCRIPTION
## Summary

Breaks the permanent stale-stamp deadlock after a refused CLAUDE.md merge
during kunglao_upgrade. The three deadlock links (merge refusal silently
skipped -> stamp refresh skipped on frame-drift -> check-stale failing forever
with un-actionable advice) are now connected by a sanctioned recovery path:

- On refusal, kunglao_upgrade writes `<ws>/runs/claudemd-pending-merge.yaml`
  (schema `kunglao.claudemd-pending-merge/1`) plus a unified diff report
  (`claudemd-pending-merge.diff.patch`: current body vs the incoming frame).
- `kunglao.py check-stale` recognizes the marker and reports
  `manual-merge-pending` with the diff path and the exact `--resolve`
  command, instead of the dead-end "run upgrade first" advice.
- The marker clears via `kunglao.py check-stale <ws> --resolve` (idempotent)
  or automatically on any later successful merge. A leftover marker never
  poisons a current-stamped workspace (pending branch only lives on the
  stale path).
- Marker + diff are D4-exempt from the iron-rule digest. deploy-manifest
  sha256 mirrors regenerated for the two edited scaffold scripts (#783
  contract).

Closes #5

Milestone: v0.1.5 (milestone #1)

## Anti-orphan gate (REQUIRED)

- Added code: marker/diff writer in `scripts/kunglao_upgrade.py`
  (`_item_claudemd_merge` refusal branch), pending branch + `--resolve`
  subcommand in `scripts/kunglao.py cmd_check_stale`, 9 tests
  (tests/test_claudemd_pending_merge_5.py).
- Code moved/deleted: none. WARN ledger detail changed
  `skipped:<reason>` -> `pending-merge:<reason>`; all existing test pins on
  the old strings survive byte-identical.

## Test plan

- [x] `uv run python -m pytest tests/test_claudemd_pending_merge_5.py -q` —
      9/9 (RED first: 7 failed pre-fix; the 2 initial passes are regression
      guards for dry-run and clean auto-merge)
- [x] Real-CLI e2e: user-edited CLAUDE.md + upgrade -> WARN + marker + diff;
      check-stale -> manual-merge-pending with diff path + --resolve;
      resolve -> cleared; hand-merge + re-upgrade -> 0.1.2 -> 0.1.4 stamped,
      marker auto-cleared; check-stale -> current rc 0
- [x] Targeted neighborhood rerun (pending-5 + g2g3/726/748/758/783): 75 passed
- [x] Full suite: 5298 passed, 35 failed — all 35 verified pre-existing on
      clean dev HEAD 589a3a3 via stash comparison (19 unique IDs: decide
      regression anchors, event-stream adoption, resume suites)
- [x] `ruff check` clean on changed files; `deploy_manifest.py --verify` OK
      (374 entries)

## Notes for reviewers

- `manual-merge-pending` deliberately keeps rc = 5: the frame genuinely is
  stale and the #748 entry-gate posture (user must explicitly act) is
  preserved — the fix replaces dead-end advice with a workable path, it does
  not relax the verdict.
- `--resolve` removes only the marker; the diff report intentionally
  survives as the operator's review artifact.
