### PR TITLE
fix: exclude non-snapshot ledger rows from convergence_health trajectory (#1)

### DIFF
--- a/scripts/convergence_health.py
+++ b/scripts/convergence_health.py
@@ -185,76 +185,86 @@ def _churn(ledger: list) -> dict:
 
 
 def assess(ledger: list) -> dict:
+    # #1: rollup/operator-action rows share the ledger but are events, not
+    # snapshots — no open_count, so they must not enter the trajectory.
+    snaps = [e for e in ledger if "type" not in e and "open_count" in e]
+    non_snapshot_rows = len(ledger) - len(snaps)
+
+    ledger = _dedup_consecutive(snaps)
     if not ledger:
-        return {"verdict": "NO_DATA", "exit_code": EXIT_NO_DATA,
-                "action": "No ledger yet. Run convergence_check.py at least once per turn to build history."}
-
-    ledger = _dedup_consecutive(ledger)
-    if len(ledger) < 3:
-        return {"verdict": "HEALTHY", "exit_code": EXIT_HEALTHY,
-                "action": f"Warming up ({len(ledger)} snapshots). Need 3+ to judge a trend.",
-                "rounds": len(ledger)}
-
-    flatline = _flatline_run(ledger)
-    stuck = _stuck_claims(ledger)
-    churn = _churn(ledger)
-    first_open = ledger[0]["open_count"]
-    last_open = ledger[-1]["open_count"]
-    open_delta = last_open - first_open
-    rounds = len(ledger)
-
-    # v1.9.29: a converged loop is NOT spinning. SPINNING/STALLED mean open
-    # work is flat — the loop finished (open_count=0) and then sat idle across
-    # sessions is a completed state, not a stuck one. Without this guard, a
-    # finished loop's trailing CONVERGED snapshots trigger flatline >= 8 and
-    # block ALL dispatches (including unrelated research agents).
-    if last_open == 0:
-        verdict, exit_code = "HEALTHY", EXIT_HEALTHY
-    elif flatline >= SPINNING_FLATLINE or churn["is_churning"]:
-        verdict, exit_code = "SPINNING", EXIT_SPINNING
-    elif flatline >= STALLED_FLATLINE or stuck:
-        verdict, exit_code = "STALLED", EXIT_STALLED
+        r = {"verdict": "NO_DATA", "exit_code": EXIT_NO_DATA,
+             "action": "No ledger yet. Run convergence_check.py at least once per turn to build history."}
+    elif len(ledger) < 3:
+        r = {"verdict": "HEALTHY", "exit_code": EXIT_HEALTHY,
+             "action": f"Warming up ({len(ledger)} snapshots). Need 3+ to judge a trend.",
+             "rounds": len(ledger)}
     else:
-        verdict, exit_code = "HEALTHY", EXIT_HEALTHY
+        flatline = _flatline_run(ledger)
+        stuck = _stuck_claims(ledger)
+        churn = _churn(ledger)
+        first_open = ledger[0]["open_count"]
+        last_open = ledger[-1]["open_count"]
+        open_delta = last_open - first_open
+        rounds = len(ledger)
 
-    if verdict == "SPINNING":
-        stuck_ids = [s["claim"] for s in stuck] or (ledger[-1].get("open_ids") or [])[:3]
-        flat_desc = f"{last_open}→{first_open}" if first_open == last_open else f"{first_open}→{last_open}"
-        action = (
-            f"STOP dispatching. The loop has flatlined {flatline} rounds with "
-            f"{churn['facts_delta']} new facts but open_count {flat_desc}. "
-            f"For each stuck claim ({', '.join(stuck_ids) or 'none named'}), pick ONE: "
-            f"escalate tier (T1→T2→T3) / reformulate the claim / decompose into smaller / "
-            f"DEFER with rationale / escalate to user with a specific question. "
-            f"Re-dispatching the same claim >3x without a status change is FORBIDDEN."
-        )
-    elif verdict == "STALLED":
-        stuck_ids = [s["claim"] for s in stuck]
-        action = (
-            f"Diagnose before dispatching again. Flat {flatline} rounds; "
-            f"stuck claims: {stuck_ids or 'none named'}. Re-read each stuck claim's definition + "
-            f"gathered facts, then ask: 'what evidence would actually close this?' "
-            f"If the tier is exhausted, reformulate or decompose. Do NOT re-dispatch unchanged."
-        )
-    else:
-        action = (
-            f"Converging: open_count {first_open}→{last_open} over {rounds} rounds "
-            f"(D{open_delta:+d}). Keep dispatching via convergence_check.py."
-        )
+        # v1.9.29: a converged loop is NOT spinning. SPINNING/STALLED mean open
+        # work is flat — the loop finished (open_count=0) and then sat idle across
+        # sessions is a completed state, not a stuck one. Without this guard, a
+        # finished loop's trailing CONVERGED snapshots trigger flatline >= 8 and
+        # block ALL dispatches (including unrelated research agents).
+        if last_open == 0:
+            verdict, exit_code = "HEALTHY", EXIT_HEALTHY
+        elif flatline >= SPINNING_FLATLINE or churn["is_churning"]:
+            verdict, exit_code = "SPINNING", EXIT_SPINNING
+        elif flatline >= STALLED_FLATLINE or stuck:
+            verdict, exit_code = "STALLED", EXIT_STALLED
+        else:
+            verdict, exit_code = "HEALTHY", EXIT_HEALTHY
 
-    return {
-        "verdict": verdict,
-        "exit_code": exit_code,
-        "action": action,
-        "rounds": rounds,
-        "first_open_count": first_open,
-        "last_open_count": last_open,
-        "open_delta": open_delta,
-        "flatline_run": flatline,
-        "stuck_claims": stuck,
-        "churn": churn,
-        "last_snapshot": ledger[-1],
-    }
+        if verdict == "SPINNING":
+            stuck_ids = [s["claim"] for s in stuck] or (ledger[-1].get("open_ids") or [])[:3]
+            flat_desc = f"{last_open}→{first_open}" if first_open == last_open else f"{first_open}→{last_open}"
+            action = (
+                f"STOP dispatching. The loop has flatlined {flatline} rounds with "
+                f"{churn['facts_delta']} new facts but open_count {flat_desc}. "
+                f"For each stuck claim ({', '.join(stuck_ids) or 'none named'}), pick ONE: "
+                f"escalate tier (T1→T2→T3) / reformulate the claim / decompose into smaller / "
+                f"DEFER with rationale / escalate to user with a specific question. "
+                f"Re-dispatching the same claim >3x without a status change is FORBIDDEN."
+            )
+        elif verdict == "STALLED":
+            stuck_ids = [s["claim"] for s in stuck]
+            action = (
+                f"Diagnose before dispatching again. Flat {flatline} rounds; "
+                f"stuck claims: {stuck_ids or 'none named'}. Re-read each stuck claim's definition + "
+                f"gathered facts, then ask: 'what evidence would actually close this?' "
+                f"If the tier is exhausted, reformulate or decompose. Do NOT re-dispatch unchanged."
+            )
+        else:
+            action = (
+                f"Converging: open_count {first_open}→{last_open} over {rounds} rounds "
+                f"(D{open_delta:+d}). Keep dispatching via convergence_check.py."
+            )
+
+        r = {
+            "verdict": verdict,
+            "exit_code": exit_code,
+            "action": action,
+            "rounds": rounds,
+            "first_open_count": first_open,
+            "last_open_count": last_open,
+            "open_delta": open_delta,
+            "flatline_run": flatline,
+            "stuck_claims": stuck,
+            "churn": churn,
+            "last_snapshot": ledger[-1],
+        }
+
+    # surface excluded event rows — observability over silence; absent when 0
+    # so pure-snapshot ledgers keep their exact prior output shape (#1)
+    if non_snapshot_rows:
+        return {**r, "non_snapshot_rows": non_snapshot_rows}
+    return r
 
 
 def _human(r: dict) -> str:

--- a/tests/test_convergence_health_rollup.py
+++ b/tests/test_convergence_health_rollup.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+"""Issue #1: convergence_health crashes with KeyError: 'open_count' on mixed ledgers.
+
+The convergence ledger is shared: convergence_check._append_ledger writes
+snapshot rows (no "type" key, carries open_count/open_ids), while
+rollup.py and convergence_check.record_operator_action append
+OPERATOR_ACTION rows (type="operator_action", NO open_count).
+assess() assumed every row was a snapshot → KeyError on the first
+non-snapshot row.
+
+Covers:
+  RED1: snapshots + rollup row + operator-action row → verdict, no crash,
+        trajectory computed from snapshot rows only, count surfaced
+  RED2: rollup row BETWEEN identical snapshots → flatline run not broken
+        (verdict must stay STALLED, not degrade to HEALTHY)
+  RED3: pure snapshot ledger → output shape unchanged (no extra keys)
+  RED4: ledger with ONLY non-snapshot rows → NO_DATA, not a crash
+  RED5: non-snapshot rows surfaced on the warming-up early-return path too
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from convergence_health import EXIT_NO_DATA, EXIT_STALLED, assess
+from status_defs import LedgerLineType
+
+
+BASE = datetime(2026, 9, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _snap(i: int, open_count: int, open_ids: list[str], facts_total: int = 5) -> dict:
+    """One ledger snapshot row, mirroring convergence_check._append_ledger."""
+    return {
+        "ts": (BASE + timedelta(seconds=60 * i)).isoformat(),
+        "decision": "DISPATCH",
+        "open_count": open_count,
+        "open_ids": open_ids,
+        "partial_count": 0,
+        "active_workers": 1,
+        "blockers": [],
+        "facts_total": facts_total,
+    }
+
+
+def _rollup(i: int, claim_id: str = "C-1") -> dict:
+    """One rollup row, mirroring scripts/rollup.py's _append_ledger call."""
+    return {
+        "type": LedgerLineType.OPERATOR_ACTION,
+        "action": "rollup",
+        "actor": "orchestrator",
+        "claim_id": claim_id,
+        "terminal_status": "PROVEN",
+        "captured_outcomes": {},
+        "lessons_written": 1,
+        "lessons_skipped": 0,
+        "queue_added": 0,
+        "checkpoint_commit": "abc1234",
+        "ts": (BASE + timedelta(seconds=60 * i)).isoformat(),
+    }
+
+
+def _operator_action(i: int, action: str = "defer", claim_id: str = "C-2") -> dict:
+    """One operator-action row, mirroring convergence_check.record_operator_action."""
+    return {
+        "type": LedgerLineType.OPERATOR_ACTION,
+        "action": action,
+        "actor": "orchestrator",
+        "claim_id": claim_id,
+        "reason": "hard target, waiting",
+        "before": "OPEN",
+        "after": "DEFERRED",
+        "ts": (BASE + timedelta(seconds=60 * i)).isoformat(),
+    }
+
+
+# =====================================================================
+# RED1: mixed ledger (snapshots + rollup + operator action) → no crash
+# =====================================================================
+
+def test_mixed_ledger_assess_no_keyerror(tmp_path):
+    """Snapshots + one rollup row + one operator-action row: assess() must
+    return a verdict (no KeyError), compute the trajectory from snapshot
+    rows only, and surface the excluded-row count."""
+    ledger = [
+        _snap(0, 5, ["C-1", "C-2", "C-3", "C-4", "C-5"]),
+        _rollup(1),                      # event, not a snapshot
+        _snap(2, 4, ["C-3", "C-4", "C-5", "C-6"]),
+        _operator_action(3),             # event, not a snapshot
+        _snap(4, 3, ["C-6", "C-7", "C-8"]),
+        _snap(5, 2, ["C-7", "C-8"]),
+    ]
+    r = assess(ledger)  # KeyError: 'open_count' before the fix
+    assert r["verdict"] == "HEALTHY", f"converging snapshots → HEALTHY, got {r['verdict']}"
+    # trajectory from snapshots ONLY (4 of them, 60s apart → no dedup collapse)
+    assert r["rounds"] == 4, f"expected 4 snapshot rounds, got {r['rounds']}"
+    assert r["first_open_count"] == 5
+    assert r["last_open_count"] == 2
+    assert r["open_delta"] == -3
+    # observability: excluded rows are counted, not silently dropped
+    assert r.get("non_snapshot_rows") == 2, \
+        f"expected non_snapshot_rows=2, got {r.get('non_snapshot_rows')}"
+    # last_snapshot must be a real snapshot row, never an event row
+    assert "open_count" in r["last_snapshot"]
+    assert r["last_snapshot"].get("type") is None
+
+
+# =====================================================================
+# RED2: rollup row BETWEEN identical snapshots must not break the run
+# =====================================================================
+
+def test_rollup_between_snapshots_does_not_break_flatline():
+    """6 identical snapshots (60s apart) → STALLED via flatline >= 5.
+    A rollup row interleaved mid-run must not split the run: counting it
+    (or None-filling its open_count) would truncate the trailing run to 3
+    and wrongly return HEALTHY."""
+    ledger = [
+        _snap(0, 3, ["C-1", "C-2", "C-3"]),
+        _snap(1, 3, ["C-1", "C-2", "C-3"]),
+        _snap(2, 3, ["C-1", "C-2", "C-3"]),
+        _rollup(3),                      # event in the middle of the flatline
+        _snap(4, 3, ["C-1", "C-2", "C-3"]),
+        _snap(5, 3, ["C-1", "C-2", "C-3"]),
+        _snap(6, 3, ["C-1", "C-2", "C-3"]),
+    ]
+    r = assess(ledger)  # KeyError: 'open_count' before the fix
+    assert r["verdict"] == "STALLED", \
+        f"flatline of 6 identical snapshots must stay STALLED across the " \
+        f"rollup row, got {r['verdict']}"
+    assert r["flatline_run"] == 6, \
+        f"rollup row must not break the flatline run, got {r['flatline_run']}"
+    assert r["exit_code"] == EXIT_STALLED
+
+
+# =====================================================================
+# RED3: pure snapshot ledger → behavior unchanged
+# =====================================================================
+
+def test_pure_snapshot_ledger_output_unchanged():
+    """No non-snapshot rows → verdicts identical to today and NO extra key
+    in the result (output stays byte-identical for pure ledgers)."""
+    ledger = [
+        _snap(0, 4, ["C-1", "C-2", "C-3", "C-4"], facts_total=4),
+        _snap(1, 3, ["C-1", "C-2", "C-3"], facts_total=5),
+        _snap(2, 2, ["C-1", "C-2"], facts_total=6),
+        _snap(3, 0, [], facts_total=7),
+    ]
+    r = assess(ledger)
+    assert r["verdict"] == "HEALTHY"  # last_open == 0 guard
+    assert "non_snapshot_rows" not in r, \
+        "pure snapshot ledger must not gain a non_snapshot_rows key"
+
+
+# =====================================================================
+# RED4: ledger with ONLY non-snapshot rows → NO_DATA, not a crash
+# =====================================================================
+
+def test_only_non_snapshot_rows_is_no_data():
+    """A ledger of only rollup/operator rows has no trajectory to judge."""
+    ledger = [_rollup(0), _operator_action(1, action="override_proven")]
+    r = assess(ledger)
+    assert r["verdict"] == "NO_DATA"
+    assert r["exit_code"] == EXIT_NO_DATA
+    assert r.get("non_snapshot_rows") == 2
+
+
+# =====================================================================
+# RED5: excluded rows surfaced on the warming-up path too
+# =====================================================================
+
+def test_warming_up_surfaces_non_snapshot_rows():
+    """Fewer than 3 snapshots → warming-up verdict, but the excluded count
+    must still be surfaced."""
+    ledger = [_snap(0, 2, ["C-1", "C-2"]), _rollup(1), _snap(2, 1, ["C-1"])]
+    r = assess(ledger)
+    assert r["verdict"] == "HEALTHY"
+    assert r["rounds"] == 2
+    assert r.get("non_snapshot_rows") == 1


### PR DESCRIPTION
## Summary

`convergence_health.py` crashed with `KeyError: 'open_count'` whenever the
convergence ledger contained a non-snapshot row (rollup rows from
`rollup.py`, operator-action rows from `record_operator_action`) — those are
EVENT rows and carry no `open_count`. The fix filters rows by shape at the
top of `assess()`: only snapshot rows (no `type` key AND `open_count`
present) feed the trajectory (dedup / flatline / stuck-claims / churn);
event rows are excluded and their count is surfaced as `non_snapshot_rows`
in the output (only when > 0, so pure-snapshot output stays byte-identical).

Bonus repair: `scripts/kunglao-monitor.py:201` wraps `assess()` in a
try/except that was masking this KeyError as a false HEALTHY — with the fix,
monitor's verdicts become real.

Closes #1

Milestone: v0.1.5 (milestone #1)

## Anti-orphan gate (REQUIRED)

- Added code: row filter + `non_snapshot_rows` field in `assess()`
  (scripts/convergence_health.py), 5 tests
  (tests/test_convergence_health_rollup.py).
- Code moved/deleted: none. `assess()` signature and return keys unchanged;
  consumers: `main()` (same file), `kunglao-monitor.py` (verdict now correct),
  3 existing test files (all green).

## Test plan

- [x] RED first: 4 failed pre-fix with `KeyError: 'open_count'` reproduced
      (tests/test_convergence_health_rollup.py)
- [x] GREEN: 5/5 pass, incl. pure-snapshot regression guard (output
      byte-identical, 11-key dict unchanged)
- [x] Regression neighborhood (rollup + completeness + core-loop +
      ws_layout delegation): 35 passed
- [x] Full suite: 5290 passed, 38 failed — the 37-test failing set verified
      identical on clean dev HEAD 589a3a3 via stash control (decide
      regression anchors / deploy / resume / event-stream); the 38th was a
      cross-suite machine-lock contention flake (passes uncontended)
- [x] `ruff check` clean on both changed files
