### PR TITLE
fix: heartbeat_tick validates argv — --help no longer creates a directory (#6)

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -363,7 +363,7 @@ files:
   - src: scripts/heartbeat_tick.py
     dest: .claude/scripts/heartbeat_tick.py
     kind: scaffold
-    sha256: a987bd4952fc5123e5c46065882814f1e329957a8e4e124ead427c276b012626
+    sha256: d3dcd09d052c990d192f4f0216e6f7eee8d3999ee9376cb4937ba934fdeec596
   - src: scripts/heartbeat_touch.py
     dest: .claude/scripts/heartbeat_touch.py
     kind: scaffold

--- a/scripts/heartbeat_tick.py
+++ b/scripts/heartbeat_tick.py
@@ -42,7 +42,10 @@ Steps executed (idempotent, all safe to re-run):
 
 Output: runs/.heartbeat-tick.json (report) + stdout summary. Exit 0 = all OK,
 1 = heartbeat stale, project hooks missing, or selfcheck failed (LLM must act;
-the report's per-step stderr tails carry the failure text).
+the report's per-step stderr tails carry the failure text), 2 = usage error
+(#6: unknown flag rejected by argparse, or a workspace path that does not
+exist — the tick runs on an INITIALIZED workspace and never creates one, so a
+typo'd/flag arg can no longer be materialized as a garbage directory tree).
 
 The report carries `action_taken` (issue #237): the orchestrator fills what
 convergence action this tick produced (dispatched/verified/solved/reactivated);
@@ -50,6 +53,7 @@ an empty field means the tick idled — a fault signal (tokens burned).
 
 Usage: python heartbeat_tick.py <workspace>
 """
+import argparse
 import json
 import subprocess
 import sys
@@ -273,7 +277,31 @@ def main(argv: list[str] | None = None) -> int:
     except (AttributeError, ValueError):
         pass  # captured stream without reconfigure (pytest capsys)
     args = sys.argv[1:] if argv is None else argv
-    ws = _resolve_ws(args[0] if args else None)
+    # #6: argparse owns the CLI boundary — flags (--help, --anything) can no
+    # longer be swallowed by _resolve_ws as a workspace path and mkdir'd into
+    # a garbage tree. --help prints usage + exits 0 with zero side effects;
+    # an unknown flag is a usage error (stderr + exit 2, argparse default).
+    parser = argparse.ArgumentParser(
+        prog="heartbeat_tick.py",
+        description="ONE-command heartbeat tick (mechanical part): "
+                    "selfcheck/reconcile/renew/heartbeat-check/oracle-check/"
+                    "mechanisms against an initialized kunglao workspace.")
+    parser.add_argument(
+        "workspace", nargs="?", default=None,
+        help="initialized workspace directory (default: probe cwd, then "
+             "cwd/<workspace_dir>; never created — init owns that)")
+    parsed = parser.parse_args(args)
+    ws_arg = parsed.workspace or None
+    # A path-shaped positional must EXIST: the tick writes telemetry into the
+    # ws (runs/ via the report write + noop_breaker), so a nonexistent path
+    # would otherwise be materialized as a garbage directory tree. Exit 2
+    # keeps the #228 strict family's "never guess a workspace" semantics.
+    if ws_arg is not None and not Path(ws_arg).is_dir():
+        print(f"ERROR: workspace {ws_arg!r} is not an existing directory — "
+              "heartbeat_tick runs on an initialized workspace and never "
+              "creates one (run kunglao init first)", file=sys.stderr)
+        return 2
+    ws = _resolve_ws(ws_arg)
     # action_taken (issue #237): the tick MUST produce a convergence action or a
     # mechanical convergence argument. The orchestrator fills this field after
     # reading the report — what it dispatched / verified / solved / reactivated.

--- a/tests/test_heartbeat_tick_argv.py
+++ b/tests/test_heartbeat_tick_argv.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+"""tests/test_heartbeat_tick_argv.py — CLI boundary argv validation (issue #6).
+
+heartbeat_tick.py fed the raw first argv token into
+ws_layout.resolve_strict, which resolves ANY token (flags included) as the
+workspace path. Running ``heartbeat_tick.py --help`` therefore ran the whole
+tick against a path literally named ``--help`` and materialized it
+(noop_breaker mkdirs ``<ws>/runs`` for the no-progress state) — a classic
+missing input-validation gate at the CLI boundary (#6).
+
+Contract locked here:
+  * ``--help``           → usage on stdout, exit 0, ZERO side effects
+  * unknown flag         → argparse-style error, non-zero exit, zero effects
+  * nonexistent path     → clear stderr error, non-zero exit, NOTHING created
+                           (the tick runs on INITIALIZED workspaces only; the
+                           mkdirs in noop_breaker / report-write are telemetry
+                           for an existing ws, never workspace bootstrap —
+                           creation is init's job)
+  * existing directory   → unchanged tick behavior (rc 0/1 + report on disk)
+
+Subprocess-driven like tests/test_heartbeat_tick.py (same convention, #365).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TICK = ROOT / "scripts" / "heartbeat_tick.py"
+
+
+def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(TICK), *args],
+        capture_output=True, text=True,
+        encoding="utf-8", errors="replace", timeout=180, cwd=str(cwd),
+    )
+
+
+def _make_ws(tmp_path: Path) -> Path:
+    """Minimal workspace (claim-register.yaml so the chain scripts accept it)."""
+    ws = tmp_path / "ws"
+    (ws / "runs").mkdir(parents=True)
+    (ws / "claim-register.yaml").write_text("claims: []\n", encoding="utf-8")
+    return ws
+
+
+class TestHelpZeroSideEffects:
+    def test_help_exits_zero_prints_usage_creates_nothing(self, tmp_path):
+        """#6 core: --help must be a pure query — usage on stdout, exit 0,
+        and the cwd byte-identical afterwards (no directory named --help)."""
+        before = sorted(p.name for p in tmp_path.iterdir())
+        r = _run(["--help"], tmp_path)
+        assert r.returncode == 0, (
+            f"--help must exit 0: rc={r.returncode} "
+            f"stderr={r.stderr[:300]}")
+        assert "usage:" in r.stdout, f"usage text expected on stdout: {r.stdout[:300]}"
+        after = sorted(p.name for p in tmp_path.iterdir())
+        assert after == before, (
+            f"--help must have ZERO side effects: cwd went {before} -> {after}")
+
+    def test_unknown_flag_errors_without_side_effects(self, tmp_path):
+        """--nonsense is a usage error, not a workspace named --nonsense:
+        non-zero exit, the error names the flag, cwd untouched."""
+        r = _run(["--nonsense"], tmp_path)
+        assert r.returncode != 0, (
+            f"unknown flag must fail: rc={r.returncode} stdout={r.stdout[:300]}")
+        assert "--nonsense" in (r.stderr + r.stdout), (
+            f"error must name the bad flag: stderr={r.stderr[:300]}")
+        assert not (tmp_path / "--nonsense").exists(), (
+            "an unknown flag must never be materialized as a directory")
+        assert sorted(p.name for p in tmp_path.iterdir()) == [], (
+            "unknown flag must have zero side effects on cwd")
+
+    def test_nonexistent_workspace_path_creates_nothing(self, tmp_path):
+        """A path-shaped but nonexistent positional gets a clear stderr error
+        and a non-zero exit — the tick never bootstraps a workspace."""
+        ghost = tmp_path / "ghost-ws"
+        r = _run([str(ghost)], tmp_path)
+        assert r.returncode != 0, (
+            f"nonexistent workspace must fail: rc={r.returncode} "
+            f"stdout={r.stdout[:300]}")
+        assert r.stderr.strip(), "clear error required on stderr"
+        assert not ghost.exists(), (
+            "tick must never create the workspace dir (init's job)")
+        assert sorted(p.name for p in tmp_path.iterdir()) == [], (
+            "failed resolution must have zero side effects on cwd")
+
+
+class TestExistingWorkspaceUnchanged:
+    def test_existing_workspace_runs_normal_tick(self, tmp_path):
+        """Regression guard: a valid existing directory keeps the documented
+        tick contract — rc 0/1, report on disk naming the workspace."""
+        ws = _make_ws(tmp_path)
+        r = _run([str(ws)], tmp_path)
+        assert r.returncode in (0, 1), (
+            f"documented tick exit semantics: rc={r.returncode} "
+            f"stderr={r.stderr[:300]}")
+        report_path = ws / "runs" / ".heartbeat-tick.json"
+        assert report_path.exists(), "tick report must land in the workspace"
+        data = json.loads(report_path.read_text(encoding="utf-8"))
+        assert data["workspace"] == str(ws.resolve())


### PR DESCRIPTION
## Summary

`heartbeat_tick.py` fed the raw first argv token into `ws_layout.resolve_strict`,
which resolves any token — flags included — as a workspace path. Running
`heartbeat_tick.py --help` therefore executed the whole tick against a path
literally named `--help` and materialized it (`noop_breaker` mkdirs `<ws>/runs`,
plus the report write). Classic missing input validation at the CLI boundary.

Fix: argparse now owns the CLI boundary.

- `--help` → usage on stdout, rc 0, ZERO side effects (cwd byte-identical)
- unknown flag → argparse error, non-zero exit, nothing created
- nonexistent path → rc 2 with clear stderr; the tick runs on INITIALIZED
  workspaces and never creates one (`kunglao init` owns bootstrap), so the
  positional must exist — keeps the #228 strict "never guess a workspace"
  semantics
- existing directory → unchanged rc 0/1 contract, `main(argv=None)`
  source-compatible for all callers

Companion change: `deploy-manifest.yaml` sha256 mirror regenerated for
`heartbeat_tick.py` (repo's own #783 digest contract; 374 entries verified).

Closes #6

Milestone: v0.1.5 (milestone #1)

## Anti-orphan gate (REQUIRED)

- Added code: argparse boundary in `scripts/heartbeat_tick.py main()`, 4
  subprocess-driven tests (tests/test_heartbeat_tick_argv.py).
- Code moved/deleted: none. Manifest sha mirror updated per deploy contract.

## Test plan

- [x] RED first: 3 failed pre-fix (`--help` created dir; `--nonsense`
      materialized; nonexistent path ran the chain) — existing-workspace
      guard passed both sides
- [x] GREEN: 4/4, including zero-side-effect assertions on cwd
- [x] Affected neighborhood (argv + deploy + heartbeat/router/delegation/
      env_manifest/statusline): 137 passed; deploy files 18/18
- [x] Full suite: 5291 passed / 37 failed — 35 verified pre-existing on
      pristine dev HEAD (baseline log kept); the 2-test delta was the
      manifest digest, fixed by the regeneration above
- [x] `ruff check` clean on changed files

## Notes for reviewers

Siblings sharing the same raw-argv-into-resolve pattern (noted, NOT fixed
here — separate issues): `scripts/hooks_selfcheck.py:146`, `scripts/heartbeat_touch.py:29`,
`scripts/statusline_snapshot.py:685`.
