### PR TITLE
fix: normalize datetimes before canonical-sha of oracle sanction; precise block diagnostics (#47)

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -11,7 +11,7 @@ files:
   - src: hooks/completion_gate.py
     dest: .claude/hooks/completion_gate.py
     kind: hook
-    sha256: 3c17673b23209499168cc69377fccc06ec3d4f8d636b17ae7f6f4a6f0fe589da
+    sha256: 9b48b55b096099fd21a6f3025ede52fa76d1f5c3b323ba75d277cb67c456f297
   - src: hooks/cost_input_capture.py
     dest: .claude/hooks/cost_input_capture.py
     kind: hook

--- a/hooks/completion_gate.py
+++ b/hooks/completion_gate.py
@@ -49,7 +49,7 @@ from __future__ import annotations
 import hashlib
 import json
 import sys
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 from _path_hygiene import load_module_by_path, scripts_on_path  # #671 sys.path hygiene authority
@@ -69,9 +69,35 @@ EXIT_SUMMARY_FAKE = 7
 SECOND_STOP_EVENT = "second_stop_pass"
 
 
+def _json_safe(obj):
+    """#47: recursive normalization at the json serialization boundary.
+    yaml.safe_load turns an UNQUOTED timestamp (last_decision_at:
+    2026-09-04T10:00:00Z) into a datetime object, which json.dumps refuses.
+    datetime/date → isoformat() string: deterministic and stable, so the
+    canonical sha form is "json with datetimes as isoformat strings" and a
+    record read as a datetime anchors to the SAME sha as the same record
+    written as an isoformat string. No yaml representer is touched — this
+    changes only what json.dumps sees, never what safe_load returns."""
+    if obj is None or isinstance(obj, (str, bool, int, float)):
+        return obj
+    if isinstance(obj, dict):
+        return {(k if isinstance(k, str) else _json_safe(k)): _json_safe(v)
+                for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_json_safe(v) for v in obj]
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if isinstance(obj, date):
+        return obj.isoformat()
+    return str(obj)
+
+
 def _secondstop_record_sha(adj: dict) -> str:
-    """Canonical sha256 of the oracle's stop_hook_active adjudication map."""
-    canonical = json.dumps(adj, sort_keys=True, ensure_ascii=False)
+    """Canonical sha256 of the oracle's stop_hook_active adjudication map.
+    Canonical form: sort_keys json over the #47-normalized map — datetime/
+    date values become isoformat strings (#47), so json-native maps keep
+    their exact pre-#47 sha (existing ledger anchors stay valid)."""
+    canonical = json.dumps(_json_safe(adj), sort_keys=True, ensure_ascii=False)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
@@ -196,7 +222,15 @@ def process_event(payload: dict) -> int:
                     "stop_hook_active") or {}
                 if (isinstance(adj, dict) and adj.get("second_stop")
                         and adj.get("last_decision") == "PASS"):
-                    allow, why = _secondstop_anchor(ws_early, adj)
+                    try:
+                        allow, why = _secondstop_anchor(ws_early, adj)
+                    except Exception as exc:  # noqa: BLE001 — #47: an anchor
+                        # failure is fail-closed WITH the real cause; letting
+                        # it escape would hit main()'s silent fail-open (rc 0)
+                        # and the sanction would neither pass nor be diagnosed.
+                        allow = False
+                        why = (f"second-stop sanction anchor failed - "
+                               f"{type(exc).__name__}: {exc} (#47)")
                     if allow:
                         return 0
                     reason = why

--- a/tests/test_sanction_datetime_47.py
+++ b/tests/test_sanction_datetime_47.py
@@ -1,0 +1,273 @@
+# -*- coding: utf-8 -*-
+"""tests/test_sanction_datetime_47.py — #47 second-stop sanction datetime crash.
+
+Crash chain (issue #47, Doubao live evidence):
+  task-oracle.yaml records an UNQUOTED timestamp (last_decision_at:
+  2026-09-04T10:00:00Z) → yaml.safe_load returns a datetime.datetime →
+  hooks/completion_gate._secondstop_record_sha json.dumps(adj) raises
+  TypeError: Object of type datetime is not JSON serializable → the
+  sanctioned second stop could not be reconciled against the ledger.
+
+Contract:
+  B1 _secondstop_record_sha accepts datetime values (normalizes at the
+     json boundary — NO yaml representer, NO hand-edited yaml)
+  B2 sha stability: the datetime OBJECT and its isoformat() STRING anchor
+     to the SAME sha (records written after the fix and re-read through
+     either path are the same record)
+  B3 end-to-end: unquoted last_decision_at + sanctioned PASS → rc 0 AND
+     the ledger anchor row is written (pre-fix the TypeError escaped and
+     the anchor silently never happened)
+  B4 error precision: an anchor-path failure BLOCKS with the underlying
+     exception class/message in the reason — never the generic
+     "without oracle sanction" text, never a silent fail-open
+  B5 regression: quoted-string timestamp still works; missing
+     last_decision_at still works; OSError-class ledger failures still
+     carry their class name (#831 behavior preserved)
+"""
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import importlib.util
+import io
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOKS = ROOT / "hooks"
+
+SECOND_STOP_EVENT = "second_stop_pass"
+
+UNQUOTED_ORACLE = """\
+task_text: x
+adjudication:
+  stop_hook_active:
+    second_stop: true
+    last_decision: PASS
+    last_decision_at: 2026-09-04T10:00:00Z
+"""
+
+QUOTED_ORACLE = """\
+task_text: x
+adjudication:
+  stop_hook_active:
+    second_stop: true
+    last_decision: PASS
+    last_decision_at: "2026-09-04T10:00:00Z"
+"""
+
+MISSING_TS_ORACLE = """\
+task_text: x
+adjudication:
+  stop_hook_active:
+    second_stop: true
+    last_decision: PASS
+"""
+
+
+def _load_shim():
+    name = "completion_gate_hook_47"
+    mod = sys.modules.get(name)
+    if mod is None:
+        spec = importlib.util.spec_from_file_location(
+            name, HOOKS / "completion_gate.py")
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+    return mod
+
+
+def _plain_sha(adj: dict) -> str:
+    """Pre-#47 canonical form (json over JSON-native values only)."""
+    return hashlib.sha256(json.dumps(
+        adj, sort_keys=True, ensure_ascii=False).encode("utf-8")).hexdigest()
+
+
+def _mk_ws_raw(tmp_path: Path, oracle_text: str) -> Path:
+    """Workspace with a RAW task-oracle.yaml (no yaml.safe_dump round-trip —
+    the whole point is the unquoted scalar that safe_load turns into a
+    datetime)."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "claim-register.yaml").write_text("claims: []\n", encoding="utf-8")
+    (ws / "task-oracle.yaml").write_text(oracle_text, encoding="utf-8")
+    return ws
+
+
+def _run(ws: Path) -> tuple[int, str]:
+    mod = _load_shim()
+    payload = {"hook_event_name": "Stop", "session_id": "t",
+               "cwd": str(ws), "stop_hook_active": True}
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = mod.main(io.StringIO(json.dumps(payload)))
+    return rc, buf.getvalue()
+
+
+def _anchor_rows(ws: Path) -> list[dict]:
+    p = ws / ".convergence_ledger.jsonl"
+    if not p.exists():
+        return []
+    rows = []
+    for line in p.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if row.get("type") == SECOND_STOP_EVENT:
+            rows.append(row)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# B1 — the crash point: _secondstop_record_sha with a datetime value
+# ---------------------------------------------------------------------------
+
+def test_record_sha_accepts_datetime_value():
+    mod = _load_shim()
+    dt = datetime(2026, 9, 4, 10, 0, 0, tzinfo=timezone.utc)
+    adj = {"second_stop": True, "last_decision": "PASS", "last_decision_at": dt}
+    # Pre-fix: TypeError: Object of type datetime is not JSON serializable
+    sha = mod._secondstop_record_sha(adj)
+    assert isinstance(sha, str) and len(sha) == 64
+    # deterministic: fresh equal object → same sha
+    again = mod._secondstop_record_sha(
+        {"second_stop": True, "last_decision": "PASS",
+         "last_decision_at": datetime(2026, 9, 4, 10, 0, 0, tzinfo=timezone.utc)})
+    assert sha == again
+
+
+def test_record_sha_naive_datetime_and_date_and_nested():
+    mod = _load_shim()
+    adj = {"second_stop": True, "last_decision": "PASS",
+           "last_decision_at": datetime(2026, 9, 4, 10, 0, 0),
+           "window": {"from": datetime(2026, 9, 3), "notes": ["a", "b"]}}
+    sha = mod._secondstop_record_sha(adj)
+    assert isinstance(sha, str) and len(sha) == 64
+
+
+# ---------------------------------------------------------------------------
+# B2 — compatibility anchor: datetime object ≡ isoformat string
+# ---------------------------------------------------------------------------
+
+def test_sha_datetime_object_equals_isoformat_string():
+    mod = _load_shim()
+    dt = datetime(2026, 9, 4, 10, 0, 0, tzinfo=timezone.utc)
+    as_obj = mod._secondstop_record_sha(
+        {"second_stop": True, "last_decision": "PASS", "last_decision_at": dt})
+    as_str = mod._secondstop_record_sha(
+        {"second_stop": True, "last_decision": "PASS",
+         "last_decision_at": dt.isoformat()})
+    assert as_obj == as_str
+
+
+def test_json_native_adj_sha_unchanged():
+    """A JSON-native adjudication map (everything the pre-fix path could
+    anchor) must keep its exact pre-#47 sha — normalization must not shift
+    existing ledger anchors."""
+    mod = _load_shim()
+    adj = {"second_stop": True, "last_decision": "PASS",
+           "last_decision_at": "2026-09-04T10:00:00Z", "notes": None}
+    assert mod._secondstop_record_sha(adj) == _plain_sha(adj)
+
+
+# ---------------------------------------------------------------------------
+# B3 — end-to-end: unquoted timestamp no longer blocks/loses the anchor
+# ---------------------------------------------------------------------------
+
+def test_unquoted_timestamp_sanctioned_pass_anchors(tmp_path):
+    ws = _mk_ws_raw(tmp_path, UNQUOTED_ORACLE)
+    # fixture guard: the unquoted scalar REALLY parses into a datetime
+    adj = yaml.safe_load((ws / "task-oracle.yaml").read_text(
+        encoding="utf-8"))["adjudication"]["stop_hook_active"]
+    assert isinstance(adj["last_decision_at"], datetime), adj
+    rc, out = _run(ws)
+    # sanctioned PASS goes through — no block JSON, no generic reason
+    assert rc == 0, out
+    assert out == "", out
+    rows = _anchor_rows(ws)
+    assert len(rows) == 1, rows
+    assert rows[0]["record_sha256"] == mod_sha(adj)
+    # idempotent second sighting — same record → same sha → no duplicate
+    rc2, out2 = _run(ws)
+    assert rc2 == 0, out2
+    assert len(_anchor_rows(ws)) == 1
+
+
+def mod_sha(adj: dict) -> str:
+    """Expected anchor sha: the #47 canonical form — json with datetimes as
+    isoformat strings (computed independently of the shim)."""
+    def norm(o):
+        if isinstance(o, dict):
+            return {k: norm(v) for k, v in o.items()}
+        if isinstance(o, (list, tuple)):
+            return [norm(v) for v in o]
+        if isinstance(o, (datetime,)):
+            return o.isoformat()
+        import datetime as _dtmod
+        if isinstance(o, _dtmod.date):
+            return o.isoformat()
+        return o
+    return _plain_sha(norm(adj))
+
+
+# ---------------------------------------------------------------------------
+# B4 — error precision: anchor-path failure carries the real cause
+# ---------------------------------------------------------------------------
+
+def test_unexpected_anchor_error_blocks_with_real_cause(tmp_path, monkeypatch):
+    mod = _load_shim()
+    ws = _mk_ws_raw(tmp_path, QUOTED_ORACLE)
+    monkeypatch.setattr(mod, "_secondstop_record_sha",
+                        lambda adj: (_ for _ in ()).throw(
+                            RuntimeError("boom ledger codec")))
+    rc, out = _run(ws)
+    # fail-closed: BLOCK, not the old silent fail-open (rc 0), and the
+    # reason names the underlying exception — not the generic sanction text
+    assert rc == 1, out
+    d = json.loads(out)
+    assert d["decision"] == "block"
+    assert "RuntimeError" in d["reason"] and "boom ledger codec" in d["reason"]
+    assert "without oracle sanction" not in d["reason"]
+
+
+def test_oserror_ledger_failure_still_names_class(tmp_path):
+    """#831 regression: ledger unreadable (dir where the file belongs) →
+    BLOCK carrying the OSError class (#47 adds precision, keeps posture)."""
+    ws = _mk_ws_raw(tmp_path, QUOTED_ORACLE)
+    (ws / ".convergence_ledger.jsonl").mkdir()
+    rc, out = _run(ws)
+    assert rc == 1
+    d = json.loads(out)
+    assert "IsADirectoryError" in d["reason"]
+    assert "without oracle sanction" not in d["reason"]
+
+
+# ---------------------------------------------------------------------------
+# B5 — regressions: quoted string + missing timestamp still work
+# ---------------------------------------------------------------------------
+
+def test_quoted_timestamp_still_passes_and_anchors(tmp_path):
+    ws = _mk_ws_raw(tmp_path, QUOTED_ORACLE)
+    adj = yaml.safe_load((ws / "task-oracle.yaml").read_text(
+        encoding="utf-8"))["adjudication"]["stop_hook_active"]
+    assert isinstance(adj["last_decision_at"], str)
+    rc, out = _run(ws)
+    assert rc == 0, out
+    rows = _anchor_rows(ws)
+    assert len(rows) == 1
+    assert rows[0]["record_sha256"] == _plain_sha(adj)
+
+
+def test_missing_last_decision_at_still_passes(tmp_path):
+    ws = _mk_ws_raw(tmp_path, MISSING_TS_ORACLE)
+    rc, out = _run(ws)
+    assert rc == 0, out
+    assert len(_anchor_rows(ws)) == 1


### PR DESCRIPTION
## Summary

Fixes the second-stop sanction false-block (#47) — and a worse variant found
during the fix.

Crash chain (hooks/completion_gate.py):

1. `task-oracle.yaml` with an UNQUOTED `last_decision_at` → `yaml.safe_load`
   yields a `datetime.datetime` (the scaffold writes a quoted empty string,
   so only hand/agent-filled records trip this — Doubao live evidence).
2. `_secondstop_record_sha` (line 74) does `json.dumps(adj, sort_keys=True)`
   → `TypeError: Object of type datetime is not JSON serializable`.
3. The call site (line 199) sits OUTSIDE the yaml-load try/except, so on
   current dev the TypeError escapes `process_event` into `main`'s blanket
   `except Exception → return 0` — a SILENT FAIL-OPEN: the unsanctionable
   second stop passes and the ledger anchor is never written. (On the pinned
   older deployment the same trigger surfaced as the issue's generic block.)

Fix:

- `_json_safe()` recursion normalizes datetime/date → ISO-8601 strings at the
  canonical-sha boundary; deterministic and stable (a record serialized with
  the datetime OBJECT and the same value as an isoformat STRING hash
  identically — compatibility anchor test included).
- The second-stop consumption path now fail-closes with a PRECISE reason
  (carries the actual exception class/message) instead of the silent
  fail-open — restoring the posture `_secondstop_anchor`'s docstring already
  promised.
- Audited for sibling yaml→json sites: only `_secondstop_record_sha` was
  genuine (external_kicker's json.dumps sites are unreachable from yaml
  datetimes — noted, left as-is).
- deploy-manifest sha mirror regenerated for hooks/completion_gate.py (#783
  contract; --verify OK, 374 entries).

Closes #47

Milestone: v0.1.5 (milestone #1)

## Anti-orphan gate (REQUIRED)

- Added code: `_json_safe` + wrap in completion_gate.py; 9 tests
  (tests/test_sanction_datetime_47.py).
- Code moved/deleted: none. Only the second-stop branch's failure posture
  changed (silent rc 0 → precise BLOCK), matching the documented contract.

## Test plan

- [x] RED first: 5 failed pre-fix (3x TypeError on sha tests, e2e unquoted-ts
      silently skipped the anchor, forced anchor error returned rc 0)
- [x] GREEN: 9/9 new + 64/64 completion-gate family regression
- [x] Live subprocess repro of the Doubao scenario: rc 0 sanctioned pass,
      anchor row written, idempotent on re-run
- [x] Full suite: 35 failed / 5298 passed — exactly the known pre-existing
      dev families (decide anchors / event-stream / resume), zero delta
- [x] ruff clean; deploy-manifest --verify OK (374 entries)
