### PR TITLE
fix: register ida-pro-vm in tool catalog + worker allowlists (#46)

### DIFF
--- a/agents/ghidra-light.md
+++ b/agents/ghidra-light.md
@@ -39,6 +39,7 @@ allowedTools:
 - Bash
 - mcp__sequential-thinking__sequentialthinking
 - mcp__ghidra__*
+- mcp__ida-pro-vm__*
 disallowedTools:
 - NotebookEdit
 - mcp__frida__spawn

--- a/agents/kunglao-redteam.md
+++ b/agents/kunglao-redteam.md
@@ -24,6 +24,7 @@ allowedTools:
 - mcp__context7__query-docs
 - mcp__sequential-thinking__sequentialthinking
 - mcp__ghidra__*
+- mcp__ida-pro-vm__*
 - mcp__x64dbg__*
 - mcp__frida__spawn
 - mcp__frida__attach

--- a/agents/kunglao-worker.md
+++ b/agents/kunglao-worker.md
@@ -22,6 +22,7 @@ allowedTools:
 - mcp__context7__query-docs
 - mcp__sequential-thinking__sequentialthinking
 - mcp__ghidra__*
+- mcp__ida-pro-vm__*
 - mcp__x64dbg__*
 - mcp__frida__spawn
 - mcp__frida__attach

--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -87,7 +87,7 @@ files:
   - src: agents/ghidra-light.md
     dest: .claude/agents/ghidra-light.md
     kind: agent
-    sha256: e590b338aa69381d81717cc6026b1f638cc35cc92cdfbeeb5b9813b0db19742b
+    sha256: 4361102de61789d15abf23178a1e11afb32f460e2c49a6f18de7f28da1dbd963
   - src: agents/go-symbols.md
     dest: .claude/agents/go-symbols.md
     kind: agent
@@ -99,11 +99,11 @@ files:
   - src: agents/kunglao-redteam.md
     dest: .claude/agents/kunglao-redteam.md
     kind: agent
-    sha256: 64cf2600bdffe2324ebdc065246636b46545ca4d8c11778c4a37985984b8f924
+    sha256: bff8d63eba77eb031c4370e7bcd8c963f27712335c0a4057db84215732ed3b11
   - src: agents/kunglao-worker.md
     dest: .claude/agents/kunglao-worker.md
     kind: agent
-    sha256: 06315184aee29139a3c9d930d6ef196e19a1ab43bcffd8f425ba89270c95f871
+    sha256: 5baf4f6d897a12a2d90d62f6f5e472faa0019827d139cb13eff4bf9cee46ec25
   - src: agents/pefile-signature.md
     dest: .claude/agents/pefile-signature.md
     kind: agent
@@ -1235,7 +1235,7 @@ files:
   - src: tools/_INDEX.yaml
     dest: .claude/tools/_INDEX.yaml
     kind: asset
-    sha256: a1a4f76855a0db0b1e5abc05d0c9436d34f00fcd9b2d420035c012d25c4eccd7
+    sha256: c2ec04fae36a9afadacb61e1a4e989fded7a5e437acbe9e852e3ac42de2d0b0d
   - src: tools/_index-auxiliary.md
     dest: .claude/tools/_index-auxiliary.md
     kind: asset
@@ -1259,7 +1259,7 @@ files:
   - src: tools/_index-static.md
     dest: .claude/tools/_index-static.md
     kind: asset
-    sha256: 44eb974201850d2db2e3556556b6a631230062741955bb891adc6c894aa7f2f9
+    sha256: 5ce840235a1de71e328dd06ddacca607276c951fbb27e56d740e609901b325ef
   - src: tools/_index-web.md
     dest: .claude/tools/_index-web.md
     kind: asset
@@ -1487,7 +1487,7 @@ files:
   - src: tools/validate_index.py
     dest: .claude/tools/validate_index.py
     kind: asset
-    sha256: d47d8f9a2fb21960de0b7ab3b9a47db3469b87113631b0a6e5cfa8288355d7f1
+    sha256: 131585e75a1174d5f98e3018091bb82e824f95a690d82e5130a32f8303260e8a
   - src: tools/web/README.md
     dest: .claude/tools/web/README.md
     kind: asset

--- a/tests/test_ida_pro_unlock_46.py
+++ b/tests/test_ida_pro_unlock_46.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""tests/test_ida_pro_unlock_46.py — issue #46: native IDA claims unreachable.
+
+RED (verified on dev): the IDA MCP path is double-locked for the worker rack.
+
+  LOCK 1 — agent allowlists. agents/kunglao-worker.md frontmatter allowedTools
+  carries mcp__ghidra__* / mcp__x64dbg__* / mcp__frida__* / mcp__volatility__*
+  / mcp__gitnexus__* but NO ida wildcard — a worker dispatched at the IDA MCP
+  bridge has no tool grant (and #760's tools-rack gate would REJECT any rack
+  citing an ida tool as "not in kunglao-worker allowedTools").
+
+  LOCK 2 — tool-catalog gate. hooks/worker_budget_gates.py _toolfirst_evaluate
+  validates the `tool-catalog:` marker against the keyword map derived from
+  tools/_INDEX.yaml (_load_tool_index_keywords). _INDEX.yaml has ZERO ida
+  entries, so a dispatch text naming IDA keywords can never reach
+  mode='matched' by citing an ida tool — the gate rejects with
+  detail_mode='self_attestation' and the only compliant citations point at
+  other tools (or an opt-out). No compliant path -> native IDA claims
+  unreachable for workers.
+
+Naming resolution: the MCP registers as `ida-pro-vm`
+(scripts/toolchain.py _DECOMPILER_MCP_NAMES, scripts/mcp_probe.py MANIFEST).
+The issue title's `mcp__ida-pro-mcp__*` is a transcription of a live server
+name; this fix follows the repo's own convention (`mcp__ida-pro-vm__*`) —
+worker_budget_sinks matches the tolerant prefix `mcp__ida` for both faces.
+
+GREEN shape:
+  - tools/_INDEX.yaml registers `ida-decompile` (category static,
+    capability ida:decompile — mirroring the ghidra:decompile shape)
+  - tools/validate_index.py _CAPABILITY_TAGS admits ida:decompile
+  - tools/_index-static.md carries the #339 contract entry
+  - agents/{kunglao-worker,kunglao-redteam,ghidra-light}.md allowedTools
+    carry mcp__ida-pro-vm__* (the decompiler-capable rack — every agent
+    whose allowedTools already grant mcp__ghidra__*)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import validate_index as vi  # noqa: E402
+import worker_budget_gates as wbg  # noqa: E402
+
+IDA_TOOL = "ida-decompile"
+IDA_MCP_WILDCARD = "mcp__ida-pro-vm__*"
+
+# agents whose allowedTools already grant the sibling decompiler MCP
+# (mcp__ghidra__*) — the decompiler-capable rack. Agents that DISALLOW
+# ghidra (floss-filter, pefile-signature, verdict-scorer, web-re-worker,
+# kunglao-init-worker) are deliberately untouched.
+DECOMPILER_RACK_AGENTS = ("kunglao-worker", "kunglao-redteam", "ghidra-light")
+
+
+def _agent_allowedtools(agent: str) -> list[str]:
+    text = (ROOT / "agents" / f"{agent}.md").read_text(encoding="utf-8")
+    fm = text.split("---", 2)[1]
+    data = yaml.safe_load(fm) or {}
+    return [str(t).strip() for t in (data.get("allowedTools") or [])]
+
+
+# ---------- LOCK 2 (gate): keyword map + marker match ----------
+
+def test_ida_keyword_registered_in_gate_keyword_map():
+    keywords = wbg._load_tool_index_keywords(wbg._SKILL_ROOT)
+    assert keywords.get("ida") == IDA_TOOL, (
+        "tools/_INDEX.yaml must register an ida capability so the "
+        "tool-catalog keyword map knows 'ida' (LOCK 2)")
+
+
+def test_ida_dispatch_marker_reaches_matched():
+    text = ("decompile function sub_140001000 in the ida database and "
+            "quote pseudocode into the fact file")
+    ev = wbg._toolfirst_evaluate(text, IDA_TOOL)
+    assert ev["mode"] == "matched", (
+        f"expected matched, got {ev} — a dispatch citing the ida tool must "
+        "have a compliant path through the tool-catalog gate")
+
+
+def test_ida_dispatch_check_tool_first_passes():
+    ok, reason = wbg.check_tool_first(
+        {}, "use ida to decompile the crypto routine",
+        f"tool-catalog: {IDA_TOOL}")
+    assert ok is True, f"gate must pass an ida-citing dispatch: {reason}"
+
+
+def test_ida_capability_tag_in_closed_vocabulary():
+    assert "ida:decompile" in vi._CAPABILITY_TAGS, (
+        "validate_index closed vocabulary must admit ida:decompile "
+        "(one tag = one routing capability, #729 Rule B)")
+
+
+def test_shipped_index_still_validates_with_ida_entry():
+    data = yaml.safe_load(
+        (ROOT / "tools" / "_INDEX.yaml").read_text(encoding="utf-8"))
+    names = [t.get("name") for t in data["tools"]]
+    assert IDA_TOOL in names, f"{IDA_TOOL} missing from _INDEX.yaml"
+    assert vi.validate_index(data) == [], "shipped index must stay valid"
+
+
+# ---------- LOCK 1 (allowlists): agent frontmatter ----------
+
+def test_worker_rack_allows_ida_mcp():
+    tools = _agent_allowedtools("kunglao-worker")
+    assert IDA_MCP_WILDCARD in tools, (
+        "kunglao-worker allowedTools must grant mcp__ida-pro-vm__* "
+        "(LOCK 1 — the worker rack is the issue's subject)")
+
+
+def test_decompiler_rack_agents_allow_ida_mcp():
+    for agent in DECOMPILER_RACK_AGENTS:
+        tools = _agent_allowedtools(agent)
+        assert IDA_MCP_WILDCARD in tools, (
+            f"{agent} grants mcp__ghidra__* (decompiler-capable rack) but "
+            "not mcp__ida-pro-vm__*")
+        assert "mcp__ghidra__*" in tools, (
+            f"{agent} is expected to be a ghidra-granting agent; if it "
+            "dropped ghidra, drop it from this test's rack list too")
+
+
+def test_ghidra_disallowing_agents_do_not_gain_ida():
+    # scope guard: the fix targets the decompiler-capable rack only
+    for agent in ("floss-filter", "pefile-signature", "verdict-scorer",
+                  "web-re-worker"):
+        tools = _agent_allowedtools(agent)
+        assert IDA_MCP_WILDCARD not in tools, (
+            f"{agent} disallows mcp__ghidra__*; it must not silently gain "
+            "the ida MCP either")
+
+
+# ---------- LOCK 1 enforcement face: #760 tools-rack gate ----------
+
+def test_rack_gate_accepts_ida_tool_for_worker():
+    import dispatch_gate as dg
+    violation = dg._tools_contract_violation(
+        ["mcp__ida-pro-vm__decompile_function", "Write"], "kunglao-worker")
+    assert violation is None, (
+        f"a rack citing the ida MCP bridge must clear #760: {violation}")
+
+
+# ---------- naming resolution anchor ----------
+
+def test_mcp_registers_as_ida_pro_vm():
+    sys.path.insert(0, str(ROOT / "scripts"))
+    import toolchain
+    assert "ida-pro-vm" in toolchain._DECOMPILER_MCP_NAMES, (
+        "the repo's own convention names the IDA MCP 'ida-pro-vm'; the "
+        "wildcard must match the registered name (issue title says "
+        "mcp__ida-pro-mcp__* — see module docstring)")
+
+
+# ---------- regressions: ghidra/android paths unchanged ----------
+
+def test_ghidra_keyword_and_marker_still_matched():
+    text = "decompile the guard dispatcher and recover the vtable"
+    ev = wbg._toolfirst_evaluate(text, "ghidra-decompile-functions")
+    assert ev["mode"] == "matched", f"ghidra path regressed: {ev}"
+
+
+def test_android_keywords_unaffected():
+    # keywords derive from category + capability halves, not tool names
+    # (android:java-source -> jadx-decompile, android:bytecode-truth ->
+    # baksmali-xref) — the ida entry must not shadow any of them
+    keywords = wbg._load_tool_index_keywords(wbg._SKILL_ROOT)
+    assert keywords.get("android") == "jadx-decompile"
+    assert keywords.get("java-source") == "jadx-decompile"
+    assert keywords.get("bytecode-truth") == "baksmali-xref"
+    ev = wbg._toolfirst_evaluate(
+        "recover the java-source tree from the dex (android target)",
+        "jadx-decompile")
+    assert ev["mode"] == "matched", f"android path regressed: {ev}"
+
+
+def test_ghidra_agent_rack_still_matches_after_ida_addition():
+    tools = _agent_allowedtools("ghidra-light")
+    assert "mcp__ghidra__*" in tools
+    assert "mcp__ida-pro-vm__*" in tools

--- a/tests/test_index_docs_contract.py
+++ b/tests/test_index_docs_contract.py
@@ -97,7 +97,7 @@ def _all_tools_md() -> list[Path]:
 
 def test_yaml_registry_has_29_tools() -> None:
     tools = _yaml_tools()
-    assert len(tools) == 38, f"expected 38 registered tools, got {len(tools)}"  # 38 since #866-b (ghidra_diff registration); 37 since #884 (jsvmp-triage, web category; 36 since #728 wakaru-unbundle/webcrack-deobfuscate; 34 since #692)
+    assert len(tools) == 39, f"expected 39 registered tools, got {len(tools)}"  # 39 since #46 (ida-decompile registration); 38 since #866-b (ghidra_diff registration); 37 since #884 (jsvmp-triage, web category; 36 since #728 wakaru-unbundle/webcrack-deobfuscate; 34 since #692)
     names = [t["name"] for t in tools]
     assert len(names) == len(set(names)), "duplicate tool names in _INDEX.yaml"
 

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -81,7 +81,7 @@ def test_tier_t1_returns_all_entries():
     r = run_cli("--tier", "T1", "--json")
     assert r.returncode == 0, r.stderr
     out = parse_json(r)
-    assert out["count"] == 38  # 38 since #866-b (ghidra_diff); 37 since #884 (jsvmp-triage); 36 since #728
+    assert out["count"] == 39  # 39 since #46 (ida-decompile, T1); 38 since #866-b (ghidra_diff); 37 since #884 (jsvmp-triage); 36 since #728
 
 
 # ---------------------------------------------------------------------------
@@ -92,7 +92,7 @@ def test_cost_max_cheap_excludes_deep():
     r = run_cli("--cost-max", "cheap", "--json")
     assert r.returncode == 0, r.stderr
     out = parse_json(r)
-    assert out["count"] == 30  # 30 since #884 (jsvmp-triage, cheap); 29 since #728
+    assert out["count"] == 31  # 31 since #46 (ida-decompile, cheap); 30 since #884 (jsvmp-triage, cheap); 29 since #728
     assert all(t["cost_tier"] in ("probe", "cheap") for t in out["tools"])
     names = {t["name"] for t in out["tools"]}
     assert not (names & DEEP_TOOLS)

--- a/tools/_INDEX.yaml
+++ b/tools/_INDEX.yaml
@@ -373,6 +373,25 @@ tools:
     cost_hint: {mem_gb: 0.1, time: probe}
     quality: {static:opaque-predicate: high}
 
+  # -- static: native IDA decompiler bridge over the ida-pro-vm MCP (issue #46 unlock) --
+  # Registers the MCP-bridge capability in the catalog so a dispatch citing
+  # IDA keywords has a compliant `tool-catalog:` target (tool-first gate).
+  # The MCP name follows the repo convention `ida-pro-vm`
+  # (scripts/toolchain.py _DECOMPILER_MCP_NAMES, scripts/mcp_probe.py).
+  - name: ida-decompile
+    category: static
+    capability: ida:decompile
+    description: Decompile functions via IDA MCP
+    tier: T1
+    cost_tier: cheap
+    input_output: {input: 'function address(es)/name(s) in the IDB opened by the ida-pro-vm MCP bridge (mcp__ida-pro-vm__* tools, http transport)', output: decompiled pseudocode + disassembly context per function, quoted verbatim into facts/Fxxx.md}
+    when_not: not when ghidra is available and sufficient — use ghidra-decompile-functions; not for bulk whole-binary disassembly
+    provider: ida-pro-vm
+    produces: [ida:decompile]
+    requires: []
+    cost_hint: {mem_gb: 0.5, time: cheap}
+    quality: {ida:decompile: high}
+
   # -- pipeline: evidence index building (issue #284 registration) --
   - name: build-evidence-index
     category: pipelines

--- a/tools/_index-static.md
+++ b/tools/_index-static.md
@@ -21,6 +21,7 @@
 | `call-site-args` | Call-site argument extraction from disassembly text (x64/x86) | Read when extracting call-site arguments from disassembly text; for precise dataflow use ghidra-recon/emulated execution |
 | `c-normalize` | Decompiled-C normalization (modulo idioms/dead stores) | Read to normalize before a worker reads Ghidra decompiled C; for semantic deobfuscation use opaque-pred |
 | `opaque-pred` | Opaque predicate/MBA equivalence decision (z3) | Read when statically resolving opaque predicates/proving MBA equivalences; not when z3 is absent or the task is not expression-level |
+| `ida-decompile` | Native IDA decompilation over the ida-pro-vm MCP bridge (`ida:decompile` sole) | Read when a function-level decompile must come from IDA's analyzer and ghidra is unavailable/insufficient; not for bulk whole-binary disassembly (ghidra-decompile-functions) |
 | `yara-scan` | YARA rule scanning (built-in crypto-tables) | Read for rule-based byte scanning (family/IOC evidence); not when yara-python is missing |
 | `yara-gen` | YARA rule text generation from analysis findings | Read when generating detection rules from hex/string traits; not without a rule-generation need |
 | `jadx-decompile` | DEX-to-Java decompiler (jadx; android:java-source high) | Read when java-like source is needed AND the apk_mem_gate verdict is jadx-ok/targeted-jadx; not for 1:1 bytecode truth (baksmali-xref) |
@@ -212,6 +213,18 @@
 - **Outputs**: always_true/always_false/unknown + simplified constant or MBA rewrite suggestion.
 - **exit code**: 0 decided / 1 unknown / 2 error (missing z3 with install guidance).
 - **when_not**: Not for non-single-expression truth-value/MBA-equivalence decisions; not when z3-solver is not installed and installing is not allowed.
+
+### ida-decompile
+
+- **Purpose**: Native IDA Pro decompilation over the `ida-pro-vm` MCP bridge (http transport) — the ghidra-alternative path when IDA's analyzer is authoritative (OOL/ELF edge cases, FLIRT-signed libs, existing .idb analysis state).
+- **Usage**:
+  ```bash
+  mcp__ida-pro-vm__decompile_function   # bridge discovery first: mcp__ida-pro-vm__list_functions / mcp__ida-pro-vm__get_function_by_name
+  ```
+- **Inputs**: Function address(es)/name(s) in the .i64/.idb opened by the bridge (the workspace sample must be loaded in the remote IDA instance).
+- **Outputs**: Decompiled pseudocode + disassembly context per function — quote verbatim into `facts/Fxxx.md`.
+- **exit code**: 0 pseudocode returned / 2 error (bridge unreachable — verify `ida-pro-vm` MCP registration in `~/.claude.json` / `.mcp.json`; the toolshelf never auto-installs IDA).
+- **when_not**: Not when ghidra is available and sufficient — use ghidra-decompile-functions; not for bulk whole-binary disassembly (IDA licenses are seat-bound; keep the bridge for targeted function claims).
 
 ### yara-scan
 

--- a/tools/validate_index.py
+++ b/tools/validate_index.py
@@ -127,6 +127,10 @@ _CAPABILITY_TAGS = frozenset({
     "static:yara-scan",
     # ghidra: — #866-b registration of the Ghidra Version Tracking binary diff
     "ghidra:diff",
+    # ida: — issue #46 unlock: the ida-pro-vm MCP bridge (native IDA
+    # decompilation) joins the routing vocabulary, mirroring ghidra:decompile.
+    # One tool = one tag; the ida-decompile entry's primary capability.
+    "ida:decompile",
     # aux: — #863 mechanical catalog backfill: the legacy CLIs' own primary
     # capabilities joined the closed vocabulary (1:1 from the entries'
     # capability fields — no invented semantics).


### PR DESCRIPTION
## Summary

Unlocks the IDA MCP path for workers (#46) — the issue reported a double
lock; the investigation found a third surface and closed all three:

1. **Agent allowlists** — `mcp__ida-pro-vm__*` added to the three agent
   definitions that carry the sibling decompiler MCP (`agents/kunglao-worker.md`,
   `agents/kunglao-redteam.md`, `agents/ghidra-light.md`). The five agents
   with ghidra in disallowedTools are untouched (scope test pins this).
2. **Tool catalog** — new `ida-decompile` entry in `tools/_INDEX.yaml`
   (category static, capability `ida:decompile` mirroring the existing
   `ghidra:decompile` vocabulary, provider ida-pro-vm, full #692 annotation
   block); `tools/validate_index.py` `_CAPABILITY_TAGS` extended (closed
   vocabulary, #729 Rule B); #339 contract entry + human catalog row in
   `tools/_index-static.md`. A dispatch citing `tool-catalog: ida-decompile`
   now reaches gate `matched` instead of the self_attestation reject.
3. **Rack gate** — `hooks/dispatch_gate.py` `_tools_contract_violation`
   rejects ida racks as "not in kunglao-worker allowedTools"; resolved by
   fix 1 (verified: bare `ida-pro-mcp` naming stays rejected via the prefix
   matcher).

Naming note: the issue title says `mcp__ida-pro-mcp__*`; the repo's own
convention (`worker_budget_sinks.py` prefixes, `toolchain.py:965`
`_DECOMPILER_MCP_NAMES`) is `ida-pro-vm`, so the wildcard is
`mcp__ida-pro-vm__*` — pinned by a test.

Companions: deploy-manifest sha mirrors regenerated for the edited deployed
files (#783 contract; --verify OK 374 entries); docs-contract / tool_search
count pins moved 38→39 / 30→31 per the "pins move with the registry" rule.

Closes #46

Milestone: v0.1.5 (milestone #1)

## Anti-orphan gate (REQUIRED)

- Added code: catalog entry + validate_index tag + 13 tests
  (tests/test_ida_pro_unlock_46.py); allowlist lines in 3 agent defs.
- Code moved/deleted: none. Gate logic untouched — the unlock is data
  (registry + allowlists), not new enforcement.

## Test plan

- [x] RED first: 9 failed / 4 passed (both locks + rack gate failing on dev)
- [x] GREEN: 13/13, incl. regressions (ghidra marker still matched; android
      keywords unshadowed; disallowedTools agents unaffected)
- [x] tools/validate_index.py: passes (39 tools); adjacent gate/docs/lint
      suites 196 + 290 + 27 green
- [x] Full suite: zero new failures vs the known pre-existing dev set
      (31 decide anchors / 2 event-stream / 2 resume)
- [x] ruff clean; deploy-manifest --verify OK (374 entries)
