### PR TITLE
fix: distinct crash exit code 4 for convergence_health; hook fails open with visible message (#3)

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -63,7 +63,7 @@ files:
   - src: hooks/worker_budget_core.py
     dest: .claude/hooks/worker_budget_core.py
     kind: hook
-    sha256: ee7e79dba539bdc4e2bb335e4edb078cb2e3ca0afdbd3f68aafc40052ea2bebb
+    sha256: 269221d8ffdc239466dc3c9eb3d319f5475432633ed0ba9e4aa02a518fbd390e
   - src: hooks/worker_budget_gates.py
     dest: .claude/hooks/worker_budget_gates.py
     kind: hook
@@ -243,7 +243,7 @@ files:
   - src: scripts/convergence_health.py
     dest: .claude/scripts/convergence_health.py
     kind: scaffold
-    sha256: 5fd9090f6db39bdb954cc8a509acc05df4a99d64c7c7eb66a2709351f8ac3583
+    sha256: fc9e9bd89efd6778a4ed8eb61ca467849c7ddc913b3f3c86422762ccc05d49ce
   - src: scripts/cost_estimate.py
     dest: .claude/scripts/cost_estimate.py
     kind: scaffold

--- a/hooks/worker_budget_core.py
+++ b/hooks/worker_budget_core.py
@@ -177,6 +177,15 @@ def check_convergence_health(paths):
         return False, "convergence STALLED - diagnose before dispatching"
     if r.returncode == 2:
         return False, "convergence SPINNING - STOP dispatching"
+    if r.returncode == 4:
+        # #3: the check crashed — rc=4 is NOT a stall. FAIL OPEN (the same
+        # owner-sanctioned broken-gate posture as the _run_py/resolve
+        # fail-opens above) but never silently: the message is returned as
+        # the hook's reason text and echoed to stderr.
+        msg = ("convergence health check crashed (rc=4) — failing open; "
+               "investigate scripts/convergence_health.py")
+        print(f'[kunglao-agent] {msg}', file=sys.stderr)
+        return True, msg
     return True, ''
 
 

--- a/scripts/convergence_health.py
+++ b/scripts/convergence_health.py
@@ -19,6 +19,14 @@ Three verdicts:
 Recovery protocol is printed alongside the verdict — this is NOT a "flag and
 walk away" tool. STALLED/SPINNING come with a concrete next action.
 
+Exit codes (machine-readable for hooks):
+  0 = HEALTHY   (keep dispatching)
+  1 = STALLED   (diagnose before dispatching)
+  2 = SPINNING  (stop dispatching)
+  3 = NO_DATA   (no ledger yet — run convergence_check.py per turn)
+  4 = CRASHED   (#3: unexpected error — the check itself is broken; hooks
+      must FAIL OPEN on 4, a crashed gate must never masquerade as STALLED)
+
 Why this exists: v1.9.0-1 made convergence-driven dispatch the default, but
 a busy loop can fake convergence (DISPATCH every turn, open_count never drops).
 Without a trajectory metric + detector, idle-waiting (the "just wait"
@@ -65,6 +73,7 @@ EXIT_HEALTHY = 0
 EXIT_STALLED = 1
 EXIT_SPINNING = 2
 EXIT_NO_DATA = 3
+EXIT_CRASHED = 4  # #3: unexpected error in the check itself — hooks fail open
 
 
 def _resolve_ws(arg):
@@ -341,11 +350,20 @@ def main() -> int:
         print(f"FAIL: no {LEDGER_NAME} under {workspace} (run convergence_check.py first)", file=sys.stderr)
         return EXIT_NO_DATA
 
-    r = assess(ledger)
-    if args.json:
-        print(json.dumps(r, indent=2, ensure_ascii=False))
-    else:
-        print(_human(r))
+    # #3: a crashed check must not exit 1 — the dispatch gate reads rc=1 as
+    # STALLED and blocks dispatch, so an unexpected exception (corrupt ledger
+    # row past what iter_jsonl skips, bad JSON shape, ...) would masquerade
+    # as a stalled mission. Exit 4 (distinct from the 0/1/2/3 protocol);
+    # consumer fails open on it. argparse + the no-ledger path stay outside.
+    try:
+        r = assess(ledger)
+        if args.json:
+            print(json.dumps(r, indent=2, ensure_ascii=False))
+        else:
+            print(_human(r))
+    except Exception as exc:  # noqa: BLE001 — the crash IS the signal (exit 4)
+        print(f"convergence_health crashed: {exc!r}", file=sys.stderr, flush=True)
+        return EXIT_CRASHED
     return r["exit_code"]
 
 

--- a/tests/test_convergence_health_crash_3.py
+++ b/tests/test_convergence_health_crash_3.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+"""Issue #3: a crashed convergence_health exits 1, which the dispatch gate
+misreads as STALLED.
+
+main() had no crash guard: any unexpected exception propagates and Python
+exits 1. iter_jsonl only skips UNPARSEABLE lines — a valid-JSON row with a
+wrong value shape (open_count as a string, null, ...) flows straight into
+assess() and raises. hooks/worker_budget_core.check_convergence_health
+reads rc==1 as "convergence STALLED - diagnose before dispatching" and
+blocks all dispatch: a broken gate masquerades as a stalled mission.
+
+Fix: EXIT_CRASHED = 4 (next free value; the 0/1/2/3 protocol is untouched),
+a minimal guard in main() around the assess/print section (argparse and the
+explicit no-ledger exit-3 path stay outside), and the consumer FAILS OPEN
+on rc==4 with a visible message — mirroring worker_budget_core's existing
+fail-open posture for broken gates.
+
+Covers:
+  RED1: corrupt ledger (valid JSON, wrong value shape) -> exit 4, not 1
+  RED2: monkeypatched assess() crash -> main() exits 4, stderr diagnostic
+  RED3: consumer rc=4 -> (True, visible fail-open message)
+  PINS: rc protocol 0/1/2/3 unchanged; consumer rc=1/rc=2 reject pins;
+        no-ledger path still exits 3 on its own
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import convergence_health as ch  # noqa: E402
+# worker_budget_core resolves via pytest.ini pythonpath (hooks root);
+# a toplevel hooks/ sys.path.insert is forbidden here (#671/#770 guard).
+import worker_budget_core as wbc  # noqa: E402
+
+BASE = datetime(2026, 9, 3, 12, 0, 0, tzinfo=timezone.utc)
+SCRIPT = ROOT / "scripts" / "convergence_health.py"
+
+
+def _snap(i, open_count, open_ids, facts_total=5) -> dict:
+    return {
+        "ts": (BASE + timedelta(seconds=60 * i)).isoformat(),
+        "decision": "DISPATCH",
+        "open_count": open_count,
+        "open_ids": open_ids,
+        "partial_count": 0,
+        "active_workers": 1,
+        "blockers": [],
+        "facts_total": facts_total,
+    }
+
+
+def _write_ledger(ws: Path, rows: list[dict]) -> None:
+    lines = [json.dumps(r, ensure_ascii=False) for r in rows]
+    (ws / ".convergence_ledger.jsonl").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _run(ws: Path):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(ws)],
+        capture_output=True, text=True, timeout=60)
+
+
+# =====================================================================
+# RED1: corrupt ledger (valid JSON, wrong value shape) -> exit 4, not 1
+# =====================================================================
+
+def test_corrupt_ledger_exits_4_not_1(tmp_path):
+    """open_count "3" (string) passes the snapshot filter and raises
+    TypeError inside assess(). Before the fix the traceback exited 1 —
+    exactly the STALLED masquerade the dispatch gate acts on."""
+    ws = tmp_path / "corrupt"
+    ws.mkdir()
+    _write_ledger(ws, [
+        _snap(0, "3", ["C-1"]),
+        _snap(1, "3", ["C-1"]),
+        _snap(2, "3", ["C-1"]),
+        _snap(3, "3", ["C-1"]),
+    ])
+    r = _run(ws)
+    assert r.returncode == 4, (
+        f"a crashed health check must exit 4 (crashed), not 1 (STALLED "
+        f"masquerade); got rc={r.returncode}, stderr: {r.stderr[:300]}")
+    assert "convergence_health crashed" in r.stderr, \
+        f"crash must print a one-line diagnostic, got: {r.stderr[:300]}"
+
+
+# =====================================================================
+# RED2: monkeypatched assess() crash -> main() exits 4 with diagnostic
+# =====================================================================
+
+def test_assess_crash_exits_4_with_stderr_diagnostic(tmp_path, monkeypatch, capsys):
+    ws = tmp_path / "synthetic"
+    ws.mkdir()
+    _write_ledger(ws, [_snap(i, 2, ["C-1"]) for i in range(4)])
+
+    def boom(_ledger):
+        raise RuntimeError("synthetic assess failure (#3)")
+
+    monkeypatch.setattr(ch, "assess", boom)
+    monkeypatch.setattr(sys, "argv", ["convergence_health.py", str(ws)])
+    rc = ch.main()
+    assert rc == 4, f"main() must return EXIT_CRASHED (4), got {rc}"
+    err = capsys.readouterr().err
+    assert "convergence_health crashed" in err, f"missing diagnostic, got: {err}"
+    assert "RuntimeError" in err, "diagnostic must carry the exception repr"
+
+
+# =====================================================================
+# RED3: consumer rc=4 -> fail open with a visible message
+# =====================================================================
+
+def test_consumer_rc4_fails_open_with_visible_message(monkeypatch):
+    monkeypatch.setattr(
+        wbc, "_run_py",
+        lambda args, cwd=None: SimpleNamespace(returncode=4, stdout="", stderr="boom"))
+    ok, msg = wbc.check_convergence_health({"workspace": "/tmp/whatever-ws"})
+    assert ok is True, "rc=4 is a crashed gate, not a stalled mission — fail OPEN"
+    assert "crashed (rc=4)" in msg
+    assert "failing open" in msg
+    assert "convergence_health.py" in msg, \
+        "the message must point the operator at the broken script"
+
+
+# =====================================================================
+# consumer pins: rc=1 / rc=2 reject behavior unchanged
+# =====================================================================
+
+def test_consumer_rc1_rc2_reject_pins(monkeypatch):
+    monkeypatch.setattr(
+        wbc, "_run_py",
+        lambda args, cwd=None: SimpleNamespace(returncode=1, stdout="", stderr=""))
+    ok, msg = wbc.check_convergence_health({"workspace": "/tmp/whatever-ws"})
+    assert ok is False
+    assert "STALLED" in msg
+
+    monkeypatch.setattr(
+        wbc, "_run_py",
+        lambda args, cwd=None: SimpleNamespace(returncode=2, stdout="", stderr=""))
+    ok, msg = wbc.check_convergence_health({"workspace": "/tmp/whatever-ws"})
+    assert ok is False
+    assert "SPINNING" in msg
+
+
+# =====================================================================
+# protocol pin: exit codes 0/1/2/3 unchanged, 4 is new and distinct
+# =====================================================================
+
+def test_exit_code_constants_protocol():
+    assert (ch.EXIT_HEALTHY, ch.EXIT_STALLED, ch.EXIT_SPINNING,
+            ch.EXIT_NO_DATA) == (0, 1, 2, 3)
+    assert ch.EXIT_CRASHED == 4
+    assert ch.EXIT_CRASHED not in (ch.EXIT_HEALTHY, ch.EXIT_STALLED,
+                                   ch.EXIT_SPINNING, ch.EXIT_NO_DATA)
+
+
+def test_rc_pins_healthy_stalled_spinning_no_data(tmp_path):
+    # HEALTHY: converging
+    ws = tmp_path / "h"
+    ws.mkdir()
+    _write_ledger(ws, [_snap(0, 4, ["C-1", "C-2"]),
+                       _snap(1, 3, ["C-1"]),
+                       _snap(2, 1, [])])
+    assert _run(ws).returncode == 0
+
+    # STALLED: flatline 6 (old-format rows — also re-pins #2 fallback)
+    ws = tmp_path / "s"
+    ws.mkdir()
+    _write_ledger(ws, [_snap(i, 2, ["C-1"]) for i in range(6)])
+    assert _run(ws).returncode == 1
+
+    # SPINNING: facts grow while open_count holds
+    ws = tmp_path / "sp"
+    ws.mkdir()
+    _write_ledger(ws, [_snap(i, 2, ["C-1"], facts_total=10 + i) for i in range(8)])
+    assert _run(ws).returncode == 2
+
+    # NO_DATA: no ledger — explicit early path stays outside the guard
+    ws = tmp_path / "n"
+    ws.mkdir()
+    r = _run(ws)
+    assert r.returncode == 3
+    assert "no .convergence_ledger.jsonl" in (r.stderr + r.stdout)


### PR DESCRIPTION
## Summary

A crashed convergence_health no longer masquerades as STALLED (#3).

- New exit code `EXIT_CRASHED = 4` (next free; the 0/1/2/3 protocol is
  untouched). `main()` wraps only the assess/print section — argparse and the
  exit-3 no-ledger path stay outside — and on unexpected exception prints a
  one-line flushed stderr diagnostic and exits 4. Docstring exit-code table
  extended.
- Consumer `hooks/worker_budget_core.check_convergence_health`: rc==4 →
  fail-open (mirrors the module's existing posture for subprocess/resolve
  failures) with a VISIBLE reason string — "convergence health check crashed
  (rc=4) — failing open; investigate scripts/convergence_health.py" — echoed
  to stderr so the message survives the pre_check aggregation loop (which
  ignores msg on ok=True).
- Masquerade demonstrated live pre-fix: corrupt ledger row (valid JSON,
  string open_count) → TypeError → rc=1 → dispatch blocked as "STALLED".

Stacked on #2 (fix/2-stalled-deadlock) — merge that first.

Closes #3

Milestone: v0.1.5 (milestone #1)

## Anti-orphan gate (REQUIRED)

- Added code: EXIT_CRASHED + guard in scripts/convergence_health.py, rc==4
  branch in hooks/worker_budget_core.py, 6 tests
  (tests/test_convergence_health_crash_3.py).
- Code moved/deleted: none; exit protocol 0/1/2/3 semantics unchanged and
  pinned.

## Test plan

- [x] RED first: 4 failed (corrupt→4, assess-crash→4, consumer message,
      constant); masquerade repro pre-fix showed rc=1
- [x] GREEN: 6/6; corrupt fixture end-to-end now rc=4 with diagnostic
- [x] Full suite: 35 failed = exactly the known pre-existing dev set
      (31 decide anchors / 2 event-stream / 2 resume) — zero delta
- [x] ruff clean; targeted gate set 113 passed; deploy manifest regenerated
      (#783)
