### PR TITLE
fix: V_m [0,1] normalization + per-round value density (#10)

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -535,7 +535,7 @@ files:
   - src: scripts/mission_ledger.py
     dest: .claude/scripts/mission_ledger.py
     kind: scaffold
-    sha256: a2cee4d85551010f0a4888e798742729ed21e4c3ab26f242cd1b0de67e57c0eb
+    sha256: 89fa24ee9f81bd628df9cbd6147cbcaf6191d25819f6adc51a35559475d073b8
   - src: scripts/mission_stall.py
     dest: .claude/scripts/mission_stall.py
     kind: scaffold
@@ -711,7 +711,7 @@ files:
   - src: scripts/statusline_snapshot.py
     dest: .claude/scripts/statusline_snapshot.py
     kind: scaffold
-    sha256: ae92ac2efeaf2e0b3a98bbac64f9de432aec8a18def926f27fedd55e34d03345
+    sha256: 811bdcc221f2117e3ada35c71f9b3ca4b4428a444ea8525d8b888c74fba16b86
   - src: scripts/strategy_metrics.py
     dest: .claude/scripts/strategy_metrics.py
     kind: scaffold
@@ -775,7 +775,7 @@ files:
   - src: scripts/tuition_curve.py
     dest: .claude/scripts/tuition_curve.py
     kind: scaffold
-    sha256: 18e029aff07a6a360e1e543c5e289023ece7cb2ca82edea509b2dcc40bd4d4da
+    sha256: 55691fb07f5aab12d8e37e7577994f825dafe71cc3e4f8bed3b785f50b883a9a
   - src: scripts/tuition_refit.py
     dest: .claude/scripts/tuition_refit.py
     kind: scaffold

--- a/scripts/mission_ledger.py
+++ b/scripts/mission_ledger.py
@@ -154,14 +154,26 @@ def mark_blocked(ws, pq_id: str, blocker: str, wake: str) -> dict:
 
 
 def value_m(ws) -> dict:
-    """V_m + A_t。history 只由此函数追加（增量结算即时入账）。"""
+    """V_m + A_t。history 只由此函数追加（增量结算即时入账）。
+
+    #10 归一化（additive，raw 字段原样保留）：
+      - v_norm = v_m / Σweight ∈ [0,1]（欠账表条目自带 weight，缺省 1.0；
+        未加权工作区 Σweight == len(pqs)；Σweight <= 0 → 0.0，不除零）。
+      - a_t_norm = v_norm 的每轮增量（上一 history 点的 v_norm 为基线；
+        legacy 点缺 v_norm 时按 prev_v_m/Σweight 推导）。
+    单位语义：密度按结算轮计——一次 value_m() 调用 = 一条 history 点 =
+    一轮；全程无 wall-clock 参与（墙钟 ETA 由 rho_checkpoint.eta_min /
+    statusline tick 面单独承载，不与 V_m 混用）。
+    """
     led = load(ws)
     beta = float(led.get("mission", {}).get("beta", BETA))
     pqs = led.get("mission", {}).get("pqs", [])
     v_m = 0.0
+    total_w = 0.0
     per_pq = {}
     for p in pqs:
         w = float(p.get("weight", 1.0))
+        total_w += w
         cov = float(p.get("coverage", 0.0))
         st = p.get("state")
         contrib = w * cov if st == "answered" else (
@@ -169,10 +181,17 @@ def value_m(ws) -> dict:
         v_m += contrib
         per_pq[str(p.get("id"))] = {"state": st,
                                     "contrib": round(contrib, 6)}
+    v_norm = max(0.0, min(1.0, v_m / total_w)) if total_w > 0 else 0.0
     hist = led.get("mission", {}).get("history") or []
     prev = float(hist[-1].get("v_m", 0.0)) if hist else 0.0
+    if hist and "v_norm" in hist[-1]:
+        prev_norm = float(hist[-1]["v_norm"])
+    else:
+        prev_norm = (prev / total_w) if total_w > 0 else 0.0
     a_t = v_m - prev
-    hist.append({"ts": _utc_now(), "v_m": round(v_m, 6)})
+    a_t_norm = v_norm - prev_norm
+    hist.append({"ts": _utc_now(), "v_m": round(v_m, 6),
+                 "v_norm": round(v_norm, 6)})
     led["mission"]["history"] = hist
     _save(ws, led)
     n_answered = sum(1 for p in pqs if p.get("state") == "answered")
@@ -180,6 +199,8 @@ def value_m(ws) -> dict:
     n_unattempted = sum(1 for p in pqs if p.get("state") == "unattempted"
                         )
     return {"v_m": round(v_m, 6), "prev_v_m": prev, "a_t": round(a_t, 6),
+            "v_norm": round(v_norm, 6), "a_t_norm": round(a_t_norm, 6),
+            "total_weight": round(total_w, 6),
             "per_pq": per_pq, "answered": n_answered,
             "blocked": n_blocked, "unattempted": n_unattempted}
 
@@ -195,6 +216,9 @@ def emit_snapshot(ws, epoch: int | None = None, arm: str | None = None,
             "v_m": val["v_m"], "prev_v_m": val["prev_v_m"],
             "a_t": val["a_t"], "answered": val["answered"],
             "blocked": val["blocked"], "unattempted": val["unattempted"],
+            # #10 additive: normalized value + per-round normalized delta
+            "v_norm": val["v_norm"], "a_t_norm": val["a_t_norm"],
+            "total_weight": val["total_weight"],
         }, ensure_ascii=False)
         kunglao_log.emit(ws, "mission_ledger", "mission_snapshot",
                          detail=detail, arm=arm, epoch=epoch,

--- a/scripts/statusline_snapshot.py
+++ b/scripts/statusline_snapshot.py
@@ -417,10 +417,18 @@ def _claims_state(ws: Path) -> tuple[int, int]:
 
 
 def _mission_state(ws: Path) -> dict:
-    """mission_ledger.yaml -> PQ coverage + V_m/d_slope/eta + elapsed ticks."""
-    from tuition_curve import _slope
+    """mission_ledger.yaml -> PQ coverage + V_m/d_slope/eta + elapsed ticks.
+
+    #10: v_norm / d_slope_norm ride alongside the raw fields — normalized
+    value in [0,1] (v_m / total PQ weight) and the per-settlement-round
+    rate on the normalized history (one history point == one round; no
+    wall-clock in the density). eta_ticks extrapolates from the normalized
+    series (same numbers under stable weights; scale-free after repin).
+    """
+    from tuition_curve import _norm_series, _slope
     out = {"answered": 0, "blocked": 0, "unattempted": 0, "total": 0,
-           "coverage": 0.0, "v_m": 0.0, "d_slope": 0.0, "eta_ticks": None,
+           "coverage": 0.0, "v_m": 0.0, "v_norm": 0.0,
+           "d_slope": 0.0, "d_slope_norm": 0.0, "eta_ticks": None,
            "elapsed_ticks": 0, "started_ts": None}
     try:
         led = yaml.safe_load((ws / "runs" / "mission_ledger.yaml")
@@ -429,6 +437,8 @@ def _mission_state(ws: Path) -> dict:
         hist = led.get("mission", {}).get("history") or []
         vm_hist = [float(h.get("v_m", 0.0)) for h in hist
                    if isinstance(h, dict) and "v_m" in h]
+        total_w = sum(float(p.get("weight", 1.0)) for p in pqs)
+        norm = _norm_series(hist, total_w)
         out["answered"] = sum(1 for p in pqs if p.get("state") == "answered")
         out["blocked"] = sum(1 for p in pqs if p.get("state") == "blocked")
         out["unattempted"] = sum(1 for p in pqs
@@ -440,9 +450,12 @@ def _mission_state(ws: Path) -> dict:
             out["v_m"] = round(vm_hist[-1], 6)
             slope = _slope(vm_hist[-5:])
             out["d_slope"] = round(slope, 6)
-            total_w = sum(float(p.get("weight", 1.0)) for p in pqs)
-            out["eta_ticks"] = (round((total_w - vm_hist[-1]) / slope, 2)
-                                if slope > 0 else None)
+            if norm:
+                out["v_norm"] = round(norm[-1], 6)
+                norm_slope = _slope(norm[-5:])
+                out["d_slope_norm"] = round(norm_slope, 6)
+                out["eta_ticks"] = (round((1.0 - norm[-1]) / norm_slope, 2)
+                                    if norm_slope > 0 else None)
             out["elapsed_ticks"] = len(vm_hist)
             first_ts = hist[0].get("ts") if isinstance(hist[0], dict) else None
             out["started_ts"] = first_ts
@@ -644,7 +657,9 @@ def build_snapshot(ws: Path, now: datetime.datetime | None = None) -> dict:
         "probe_detail": probe_detail,
         "pq": pq,
         "v_m": pq["v_m"],
+        "v_norm": pq["v_norm"],
         "d_slope": pq["d_slope"],
+        "d_slope_norm": pq["d_slope_norm"],
         "eta_ticks": pq["eta_ticks"],
         "eta_fade_cells": _eta_fade_cells(pq["d_slope"]),
         "elapsed": elapsed,

--- a/scripts/tuition_curve.py
+++ b/scripts/tuition_curve.py
@@ -137,8 +137,32 @@ def _slope(ys):
     return (n * siy - si * sy) / den
 
 
+def _norm_series(hist, total_w):
+    """#10 history -> normalized V_m series (per settlement round).
+
+    每条带 v_m 的 history 点换算到 [0,1]：新点直接取 v_norm；legacy 点
+    （只有 v_m）按当前 Σweight 推导（best-effort：repin 改权重后旧点为
+    近似）。无 v_m 的行（repin 留痕）不入样。Σweight <= 0 → 全 0 序列。
+    """
+    out = []
+    for h in (hist or []):
+        if not isinstance(h, dict) or "v_m" not in h:
+            continue
+        if "v_norm" in h:
+            out.append(float(h["v_norm"]))
+        else:
+            out.append(float(h["v_m"]) / total_w if total_w > 0 else 0.0)
+    return out
+
+
 def cockpit_summary(ws):
-    """V/D/ETA 一阶信号（消费 mission_ledger + tuition），结构化 dict。"""
+    """V/D/ETA 一阶信号（消费 mission_ledger + tuition），结构化 dict。
+
+    #10 单位语义：d_slope / d_slope_norm 均为每结算轮速率（一条 history
+    点 = 一轮，无 wall-clock 参与）；d_slope_norm 在归一化序列上取斜率，
+    eta_checkpoints 由归一化序列外推（权重稳定时数值与旧口径一致，
+    repin 变权后 scale-free）。raw v / d_slope 原样保留（additive）。
+    """
     import mission_ledger
     led = mission_ledger.load(ws)
     mission = led.get("mission", {})
@@ -146,12 +170,16 @@ def cockpit_summary(ws):
     total_w = sum(float(p.get("weight", 1.0)) for p in pqs)
     hist = [float(h.get("v_m", 0.0))
             for h in (mission.get("history") or [])]
+    norm = _norm_series(mission.get("history"), total_w)
     v = hist[-1] if hist else 0.0
+    v_norm = norm[-1] if norm else 0.0
     slope = _slope(hist[-_WINDOW:])
-    eta = ((total_w - v) / slope) if slope > 0 else None
+    slope_norm = _slope(norm[-_WINDOW:])
+    eta = ((1.0 - v_norm) / slope_norm) if slope_norm > 0 else None
     recs = missions_from_ledger(ws)
     cs_cost = cost_state(ws)
-    out = {"v": v, "d_slope": round(slope, 6),
+    out = {"v": v, "v_norm": round(v_norm, 6),
+           "d_slope": round(slope, 6), "d_slope_norm": round(slope_norm, 6),
            "eta_checkpoints": eta, "total_weight": total_w,
            "answered": sum(1 for p in pqs if p.get("state") == "answered"),
            "blocked": sum(1 for p in pqs if p.get("state") == "blocked"),

--- a/tests/test_ghidra_async.py
+++ b/tests/test_ghidra_async.py
@@ -101,7 +101,7 @@ def wait_state(jobs_dir, job_id, states, timeout=15.0, grace=0.2):
     raise AssertionError(f"job {job_id} never reached {states}; last={last}")
 
 
-def poll_status(jobs_dir, job_id, grace=0.2, timeout=15.0):
+def poll_status(jobs_dir, job_id, grace=5.0, timeout=15.0):
     """Return the status --json dict once it reports a terminal state."""
     deadline = time.monotonic() + timeout
     last = None

--- a/tests/test_vm_normalization_10.py
+++ b/tests/test_vm_normalization_10.py
@@ -1,0 +1,278 @@
+# -*- coding: utf-8 -*-
+"""tests/test_vm_normalization_10.py — #10 V_m [0,1] normalization + per-round value density.
+
+Two semantic defects fixed additively:
+
+1. Normalization: value_m() gains ``v_norm`` = v_m / total PQ weight
+   (guarded: no/zero weights -> 0.0) + ``a_t_norm`` = per-round delta of
+   v_norm. Raw ``v_m``/``a_t``/``per_pq`` keys byte-identical (additive
+   migration; issue #10 suggested-fix #1).
+2. Unit: density is per SETTLEMENT ROUND (one value_m() call appends one
+   history point == one round). ``d_slope_norm`` (cockpit + statusline) is
+   the dimensionless per-round rate on the normalized history — invariant
+   to wall-clock spacing of history timestamps. No wall-clock velocity is
+   introduced (rho_checkpoint.eta_min / statusline tick cadence already
+   own wall-clock; issue #10 suggested-fix #4).
+
+Denominator = sum of PQ weights (ledger carries ``weight``, default 1.0;
+unweighted workspaces -> len(pqs)). Precedent: rho_verifier._mission_level,
+cockpit_summary.total_weight, statusline total_w — all already sum weights.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import mission_ledger as ml  # noqa: E402
+import tuition_curve  # noqa: E402
+import statusline_snapshot as sls  # noqa: E402
+
+
+def _mk_ws(tmp_path, pqs, claims, spec_extra=None):
+    ws = tmp_path / "ws"
+    (ws / "runs").mkdir(parents=True)
+    spec = {"primary_questions": pqs}
+    if spec_extra:
+        spec.update(spec_extra)
+    (ws / "task_spec.yaml").write_text(
+        yaml.safe_dump(spec, allow_unicode=True), encoding="utf-8")
+    (ws / "claim-register.yaml").write_text(
+        yaml.safe_dump({"claims": claims}, allow_unicode=True), encoding="utf-8")
+    return ws
+
+
+def _claim(cid, status="PROVEN", answers=None):
+    c = {"id": cid, "status": status}
+    if answers is not None:
+        c["answers_question"] = answers
+    return c
+
+
+def _write_led(ws, pqs, hist):
+    """Direct ledger write (hand-seeded shape, mirrors live schema)."""
+    (ws / "runs" / "mission_ledger.yaml").write_text(
+        yaml.safe_dump({"mission": {"pqs": pqs, "beta": 0.3,
+                                    "history": hist, "feature_used": True}},
+                       allow_unicode=True), encoding="utf-8")
+
+
+def _pq(pid, state="unattempted", cov=0.0, weight=1.0):
+    return {"id": pid, "question": pid, "state": state, "coverage": cov,
+            "answered_by": [], "blocker": None, "wake": None,
+            "weight": weight}
+
+
+def _iso(base, offset_s):
+    return (base + timedelta(seconds=offset_s)).isoformat()
+
+
+# ---------- 1. v_norm present, in [0,1], == raw / total weight ----------
+
+def test_v_norm_present_in_unit_range_equals_raw_over_total_weight(tmp_path):
+    ws = _mk_ws(tmp_path, [{"id": "q1"}, {"id": "q2"}],
+                [_claim("C-1", answers="q1")])
+    ml.init(ws, None)
+    ml.update(ws)
+    v = ml.value_m(ws)
+    assert "v_norm" in v
+    assert 0.0 <= v["v_norm"] <= 1.0
+    assert v["v_m"] == 1.0
+    assert v["v_norm"] == pytest.approx(1.0 / 2.0)  # raw / max(pqs) unweighted
+
+
+def test_v_norm_respects_pq_weights(tmp_path):
+    ws = _mk_ws(tmp_path, [], [])
+    _write_led(ws, [_pq("q1", "answered", 1.0, weight=3.0),
+                    _pq("q2", weight=1.0)], [])
+    v = ml.value_m(ws)
+    assert v["v_m"] == 3.0
+    assert v["v_norm"] == pytest.approx(3.0 / 4.0)  # weighted denominator
+
+
+def test_v_norm_empty_no_pq_ledger_zero_no_div_by_zero(tmp_path):
+    ws = _mk_ws(tmp_path, [], [])
+    ml.init(ws, None)
+    v = ml.value_m(ws)
+    assert v["v_norm"] == 0.0  # no PQs -> 0.0, never ZeroDivisionError
+
+
+def test_v_norm_zero_weight_ledger_zero_no_div_by_zero(tmp_path):
+    ws = _mk_ws(tmp_path, [], [])
+    _write_led(ws, [_pq("q1", "answered", 1.0, weight=0.0)], [])
+    v = ml.value_m(ws)
+    assert v["v_norm"] == 0.0  # total weight 0 -> guarded, not divided
+
+
+def test_v_norm_all_answered_is_one(tmp_path):
+    ws = _mk_ws(tmp_path, [{"id": "q1"}, {"id": "q2"}, {"id": "q3"}],
+                [_claim("C-1", answers="q1"), _claim("C-2", answers="q2"),
+                 _claim("C-3", answers="q3")])
+    ml.init(ws, None)
+    ml.update(ws)
+    v = ml.value_m(ws)
+    assert v["v_m"] == 3.0
+    assert v["v_norm"] == 1.0
+
+
+# ---------- 2. a_t_norm: per-round delta of v_norm ----------
+
+def test_a_t_norm_is_per_round_delta_of_v_norm(tmp_path):
+    ws = _mk_ws(tmp_path, [{"id": "q1"}, {"id": "q2"}], [])
+    ml.init(ws, None)
+    v1 = ml.value_m(ws)
+    assert v1["a_t_norm"] == 0.0
+    (Path(ws) / "claim-register.yaml").write_text(
+        yaml.safe_dump({"claims": [_claim("C-1", answers="q1")]},
+                       allow_unicode=True), encoding="utf-8")
+    ml.update(ws)
+    v2 = ml.value_m(ws)
+    assert v2["a_t"] == 1.0            # raw per-round delta unchanged
+    assert v2["a_t_norm"] == pytest.approx(0.5)  # 1.0 / total weight 2.0
+    v3 = ml.value_m(ws)
+    assert v3["a_t_norm"] == 0.0       # flat round -> 0
+
+
+# ---------- 3. history entries carry v_norm (additive) ----------
+
+def test_history_entries_carry_v_norm_additive(tmp_path):
+    ws = _mk_ws(tmp_path, [{"id": "q1"}, {"id": "q2"}],
+                [_claim("C-1", answers="q1")])
+    ml.init(ws, None)
+    ml.value_m(ws)
+    ml.update(ws)
+    ml.value_m(ws)
+    hist = ml.load(ws)["mission"]["history"]
+    assert all("v_m" in h for h in hist)          # raw key intact
+    assert all("v_norm" in h for h in hist)       # new normalized key
+    assert hist[-1]["v_m"] == 1.0 and hist[-1]["v_norm"] == pytest.approx(0.5)
+
+
+# ---------- 4. density is per-round, wall-clock irrelevant ----------
+
+def _density_ws(tmp_path, base, gap_s):
+    ws = tmp_path / f"ws_gap{gap_s}"
+    (ws / "runs").mkdir(parents=True)
+    # 4 PQs weight 1 -> total_w 4.0; history v_m [0, 1, 2] == v_norm [0, .25, .5]
+    _write_led(ws, [_pq(f"q{i}") for i in range(4)],
+               [{"ts": _iso(base, i * gap_s), "v_m": float(v),
+                 "v_norm": v / 4.0}
+                for i, v in enumerate([0.0, 1.0, 2.0])])
+    return ws
+
+
+def test_density_per_round_wall_clock_spacing_irrelevant(tmp_path):
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    fast = tuition_curve.cockpit_summary(_density_ws(tmp_path, base, 1))
+    slow = tuition_curve.cockpit_summary(_density_ws(tmp_path, base, 3600))
+    assert "d_slope_norm" in fast
+    # same value deltas, wildly different wall-clock spacing -> same density
+    assert fast["d_slope_norm"] == pytest.approx(slow["d_slope_norm"])
+    assert fast["d_slope_norm"] == pytest.approx(0.25)  # per settlement round
+
+
+def test_d_slope_norm_is_raw_slope_over_total_weight(tmp_path):
+    ws = _density_ws(tmp_path, datetime(2026, 1, 1, tzinfo=timezone.utc), 60)
+    cs = tuition_curve.cockpit_summary(ws)
+    assert cs["d_slope"] == pytest.approx(1.0)            # raw unchanged
+    assert cs["d_slope_norm"] == pytest.approx(cs["d_slope"] / 4.0)
+
+
+def test_d_slope_norm_derives_norm_for_legacy_history(tmp_path):
+    """Legacy history entries carry only v_m -> v_norm derived via total_w."""
+    ws = tmp_path / "ws_legacy"
+    (ws / "runs").mkdir(parents=True)
+    _write_led(ws, [_pq(f"q{i}") for i in range(4)],
+               [{"ts": "t0", "v_m": 0.0}, {"ts": "t1", "v_m": 2.0}])
+    cs = tuition_curve.cockpit_summary(ws)
+    assert cs["v_norm"] == pytest.approx(0.5)
+    assert cs["d_slope_norm"] == pytest.approx(0.5)
+
+
+def test_eta_checkpoints_scale_free_from_normalized_series(tmp_path):
+    """eta = remaining normalized value / normalized slope (same numbers
+    under stable weights; scale-free under repin weight changes)."""
+    ws = _density_ws(tmp_path, datetime(2026, 1, 1, tzinfo=timezone.utc), 60)
+    cs = tuition_curve.cockpit_summary(ws)
+    assert cs["v_norm"] == pytest.approx(0.5)
+    assert cs["eta_checkpoints"] == pytest.approx((1.0 - 0.5) / 0.25)
+
+
+# ---------- 5. consumer migration: cockpit + statusline ----------
+
+def test_cockpit_surfaces_v_norm_raw_v_unchanged(tmp_path):
+    ws = _density_ws(tmp_path, datetime(2026, 1, 1, tzinfo=timezone.utc), 60)
+    cs = tuition_curve.cockpit_summary(ws)
+    assert cs["v"] == 2.0                    # raw display value unchanged
+    assert cs["v_norm"] == pytest.approx(0.5)  # normalized alongside
+    assert cs["total_weight"] == 4.0
+
+
+def test_statusline_surfaces_v_norm(tmp_path):
+    ws = tmp_path / "ws_sl"
+    (ws / "runs").mkdir(parents=True)
+    _write_led(ws, [_pq(f"q{i}") for i in range(4)],
+               [{"ts": "t0", "v_m": 1.0, "v_norm": 0.25}])
+    pq = sls._mission_state(ws)
+    assert pq["v_m"] == 1.0                  # raw kept
+    assert pq["v_norm"] == pytest.approx(0.25)
+    assert "d_slope_norm" in pq
+    snap = sls.build_snapshot(ws)
+    assert snap["v_norm"] == pytest.approx(0.25)
+
+
+# ---------- 6. regression: raw v_m byte-identical (additive) ----------
+
+def test_raw_output_keys_and_values_unchanged(tmp_path):
+    ws = _mk_ws(tmp_path, [{"id": "q1"}, {"id": "q2"}],
+                [_claim("C-1", answers="q1")])
+    ml.init(ws, None)
+    ml.update(ws)
+    v = ml.value_m(ws)
+    # exact raw projection — byte-identical to the pre-#10 contract
+    assert {k: v[k] for k in ("v_m", "prev_v_m", "a_t", "per_pq",
+                              "answered", "blocked", "unattempted")} == {
+        "v_m": 1.0, "prev_v_m": 0.0, "a_t": 1.0,
+        "per_pq": {"q1": {"state": "answered", "contrib": 1.0},
+                   "q2": {"state": "unattempted", "contrib": 0.0}},
+        "answered": 1, "blocked": 0, "unattempted": 1}
+
+
+def test_raw_blocked_contribution_unchanged(tmp_path):
+    ws = _mk_ws(tmp_path, [], [])
+    _write_led(ws, [_pq("q1", "blocked", 0.0), _pq("q2")], [])
+    v = ml.value_m(ws)
+    assert v["v_m"] == pytest.approx(0.3)    # beta * w, raw untouched
+    assert v["v_norm"] == pytest.approx(0.3 / 2.0)
+
+
+def test_raw_anti_stupid_zero_delta_unchanged(tmp_path):
+    ws = _mk_ws(tmp_path, [{"id": "q1"}], [_claim("C-1")])  # no answers_question
+    ml.init(ws, None)
+    ml.update(ws)
+    v = ml.value_m(ws)
+    assert v["v_m"] == 0.0 and v["a_t"] == 0.0 and v["v_norm"] == 0.0
+
+
+def test_emit_snapshot_detail_carries_v_norm_additive(tmp_path):
+    ws = _mk_ws(tmp_path, [{"id": "q1"}], [_claim("C-1", answers="q1")])
+    ml.init(ws, None)
+    ml.update(ws)
+    ml.emit_snapshot(ws, epoch=1, arm="N")
+    rows = []
+    for p in sorted((Path(ws) / "runs" / "logs").glob("kunglao-*.jsonl")):
+        rows += [json.loads(line)
+                 for line in p.read_text(encoding="utf-8").splitlines()
+                 if line.strip()]
+    snap = [r for r in rows if r["action"] == "mission_snapshot"]
+    detail = json.loads(snap[0]["detail"])
+    assert detail["v_m"] == 1.0 and detail["a_t"] == 1.0   # raw intact
+    assert detail["v_norm"] == 1.0                          # additive
+    assert detail["total_weight"] == 1.0


### PR DESCRIPTION
## Summary

V_m gets a [0,1] normalization and an explicit round-based unit (#10):

- **`v_norm` = V_m / sum(PQ weights)** — denominator is the ledger's own
  total weight (default 1.0 per PQ, so unweighted degrades to len(pqs));
  in-tree precedent (rho_verifier._mission_level, cockpit total_weight,
  statusline total_w) already sums weights. Clamp + zero-weight guard
  (total_w <= 0 → 0.0). Raw fields unchanged — additive keys only.
- **Unit: per settlement round, named.** No `/min` field exists on the
  current tree (the issue's `V=3.00/min` evidence is not reproducible —
  density surfaces were already round-based); the fix makes the unit
  explicit: `d_slope_norm` / `a_t_norm` are normalized value per settlement
  round (one value_m() call == one round). Wall-clock stays owned by
  rho_checkpoint.eta_min / statusline tick cadence — no duplicate clock.
- **Consumers migrated (inventory-verified)**: cockpit (v_norm,
  d_slope_norm, scale-free eta), statusline (additive; raw d_slope
  threshold D_SLOPE_NOMINAL stays valid — unit unchanged), mission_stall
  (flatness is normalization-invariant — no change), backtrack_loop raw
  display (by design), emit_snapshot (additive).

Closes #10

Milestone: v0.1.5 (milestone #1)

## Anti-orphan gate (REQUIRED)

- Added code: normalization in mission_ledger.value_m + consumer fields,
  17 tests (tests/test_vm_normalization_10.py).
- Code moved/deleted: none. Raw v_m byte-identical for same input
  (contract-pinned); frozen-snapshot updates: zero needed.

## Test plan

- [x] RED first: 16 failed / 1 passed (raw-contract guard green by design)
- [x] GREEN: 17/17; adjacent suites 131 passed
- [x] Full suite (env -u KUNGLAO_VALUE_ALGO): 5339 passed / 2 failed —
      both were mid-run manifest-regeneration races, re-run green (18/18)
- [x] ruff clean; deploy --verify OK (374 entries, 3 shas refreshed)
