### PR TITLE
fix: design-assumption failures — debug_flag task-spec demotion, --builtin-skills rename, hooks-scope notice (#25)

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -43,7 +43,7 @@ files:
   - src: hooks/session_start.py
     dest: .claude/hooks/session_start.py
     kind: hook
-    sha256: d7ac654d7538ab94b679580cd28f3ac3aacc8a86220acc430546614d42c04aae
+    sha256: 0db49a065d26e08690282324f1cb9c7ce00bf022da1d0d8608c6e730064384a9
   - src: hooks/state_anchor.py
     dest: .claude/hooks/state_anchor.py
     kind: hook
@@ -431,7 +431,7 @@ files:
   - src: scripts/kunglao-init.py
     dest: .claude/scripts/kunglao-init.py
     kind: scaffold
-    sha256: 2afeb5b2def8a5f23b2161f99367977532cf5ccb824ec1e4e1acd54e72223483
+    sha256: 9ddb68cc6ee11337d41819abac8d66bce180abce9fd5f06ea9594d306c9eedc9
   - src: scripts/kunglao-monitor.py
     dest: .claude/scripts/kunglao-monitor.py
     kind: scaffold
@@ -759,7 +759,7 @@ files:
   - src: scripts/toolchain.py
     dest: .claude/scripts/toolchain.py
     kind: scaffold
-    sha256: 27def01ce87060c7f5d8557ae708693443f0ef63f331cfe985e903c61fcb1f22
+    sha256: e84941a1eccc81c026944d8441206d024a8c8903d38f7698a8dba6cd36237380
   - src: scripts/toolchain_install.py
     dest: .claude/scripts/toolchain_install.py
     kind: scaffold

--- a/hooks/session_start.py
+++ b/hooks/session_start.py
@@ -29,11 +29,20 @@ def session_start(workspace: Path) -> int:
     """SessionStart handler: arm completion_gate and refresh TTL.
 
     #533 F-C5: SessionStart re-arms enforcement hooks on session restart.
+    #25 D4: hooks-only-in-workspace is a silent assumption failure — when
+    this entry runs WITHOUT a kunglao workspace (user-level registration,
+    a half-initialized dir, or a path passed by hand), the gates will not
+    fire, so say so loudly instead of quietly skipping: one line, hooks
+    NOT active + the activation hint.
     """
     try:
         ws = workspace / ".kunglao"
         if not ws.exists():
-            print(f"[session_start] no .kunglao dir at {ws} — skipped")
+            print(f"[session_start] kunglao hooks are NOT active in this "
+                  f"session — no kunglao workspace at {workspace} "
+                  f"(hooks are workspace-scoped: they deploy to and fire "
+                  f"only inside <ws>/.claude/settings.json). To activate: "
+                  f"cd into the workspace and run /kunglao-agent:init")
             return 0
 
         # F-S1: ensure completion_gate is always armed

--- a/scripts/kunglao-init.py
+++ b/scripts/kunglao-init.py
@@ -613,10 +613,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
                         help="skip hook deployment entirely (the ONLY "
                              "legal hooks skip; default deploys "
                              "<ws>/.claude/settings.json + self-check)")
-    parser.add_argument("--skills", metavar="A,B", default=None,
-                        help="deploy auxiliary skills (comma-separated "
-                             "names under skills/) to <ws>/.claude/skills/ — "
-                             "pure opt-in, nothing installed without the flag")
+    parser.add_argument("--builtin-skills", metavar="A,B", default=None,
+                        help="deploy kunglao's BUILT-IN auxiliary skills "
+                             "(comma-separated names under skills/) to "
+                             "<ws>/.claude/skills/ — pure opt-in, nothing "
+                             "installed without the flag; NOT for "
+                             "globally-installed skills (#25 D2)")
     parser.add_argument("--assume-yes", action="store_true",
                         help="consent to every ask-then-install prompt "
                              "(CI/headless; non-interactive stdin declines by default)")
@@ -2064,22 +2066,26 @@ def _deploy_agents(ws: Path) -> list[dict]:
 
 
 def _deploy_skills(ws: Path, skills: list[str] | None) -> dict:
-    """#478 L4: pure opt-in skill deployment (`--skills a,b`).
+    """#478 L4: pure opt-in skill deployment (`--builtin-skills a,b`).
 
     Copies <repo>/skills/<name>/ -> <ws>/.claude/skills/<name>/ recursively.
     No flag -> nothing installed. Unknown name -> ValueError (caller maps
     to RC_ERROR with the valid-names list — fail fast on typo'd flags).
+    #25 D2: renamed to the builtin spelling — the bare skills name read as
+    "deploy any skills" and collided with the global-skill semantic; this
+    flag accepts kunglao-BUILT-IN names only (no compat alias, owner
+    ruling 2026-09-01).
     Returns the manifest component entry.
     """
     dst_root = ws / ".claude" / "skills"
     if not skills:
         return {"name": "skills", "path": ".claude/skills/",
-                "status": "none", "detail": "opt-in (--skills a,b)"}
+                "status": "none", "detail": "opt-in (--builtin-skills a,b)"}
     valid = sorted(d.name for d in SKILLS_SRC.iterdir() if d.is_dir())
     unknown = [s for s in skills if s not in valid]
     if unknown:
         raise ValueError(
-            f"unknown --skills name(s): {', '.join(unknown)} "
+            f"unknown --builtin-skills name(s): {', '.join(unknown)} "
             f"(available: {', '.join(valid)})")
     for name in skills:
         src = SKILLS_SRC / name
@@ -3033,8 +3039,8 @@ def main(argv: list[str] | None = None) -> int:
             print(f"kunglao-init: ERROR --resolve {args.resolve}: {exc}",
                   file=sys.stderr)
             return RC_ERROR
-    skills = ([s.strip() for s in args.skills.split(",") if s.strip()]
-              if args.skills else None)
+    skills = ([s.strip() for s in args.builtin_skills.split(",") if s.strip()]
+              if args.builtin_skills else None)
     return run(Path(args.workspace) if args.workspace else None,
                force=args.force, hooks_json=args.hooks_json,
                profile_root=args.profile_root, project_type=args.type,

--- a/scripts/toolchain.py
+++ b/scripts/toolchain.py
@@ -1101,12 +1101,21 @@ class Requirements:
     needs_vm: the windows/linux VM channel (vmr-shell + frida-to-VM) is
         required. True is the conservative default — the pre-#449 status
         quo — whenever task_spec does not explicitly say otherwise.
+    needs_debug_flag: the android JDWP device flag (ro.debuggable=1) is
+        required. True is the conservative default (#304 F3 enforcement).
+        #25 D1: ro.debuggable=1 is unreachable on Android 12+ user builds
+        (SELinux property_service lock) while frida/android_server run fine
+        via Magisk su without it — a task that does not need the flag must
+        be able to say so (constraints.dynamic_re=forbidden, or an explicit
+        constraints.debug_flag: false); the debug_flag check then downgrades
+        FAIL -> WARN instead of blocking an init that can never pass.
     basis: why (task_spec field citation, or the conservative default) —
         rides into the downgraded check details so a WARN is never mystery
         noise.
     """
 
     needs_vm: bool = True
+    needs_debug_flag: bool = True
     basis: str = "task_spec absent/unreadable — conservative default (VM HARD)"
 
 
@@ -1122,6 +1131,13 @@ def requirements_from_task_spec(task_spec: dict | None) -> Requirements:
     needed. Anything else (absent, empty, non-mapping, garbage, "allowed")
     stays conservative: needs_vm=True, pre-#449 behavior.
 
+    #25 D1 debug_flag: constraints.dynamic_re == "forbidden" implies no
+    JDWP dynamics (static-only), and constraints.debug_flag: false is the
+    explicit user-build opt-out (ro.debuggable=1 unreachable on Android 12+
+    user builds; the dynamic plan runs via Magisk su without it). Only the
+    exact YAML boolean false demotes — a string "false" or any other value
+    stays conservative, the same rule dynamic_re applies to its vocabulary.
+
     primary_questions carry no env-relevant explicit field today (their
     `need:` enum says how to answer, not which environment to bring up);
     when one lands (#450+), it extends HERE, never at the checkers.
@@ -1134,13 +1150,22 @@ def requirements_from_task_spec(task_spec: dict | None) -> Requirements:
     constraints = task_spec.get("constraints")
     if not isinstance(constraints, dict):
         return DEFAULT_REQUIREMENTS
+    needs_vm = True
+    needs_debug_flag = True
+    basis = DEFAULT_REQUIREMENTS.basis
     dynamic_re = str(constraints.get("dynamic_re", "")).strip().lower()
     if dynamic_re == "forbidden":
-        return Requirements(
-            needs_vm=False,
-            basis="task_spec constraints.dynamic_re=forbidden (static-only)",
-        )
-    return DEFAULT_REQUIREMENTS
+        needs_vm = False
+        needs_debug_flag = False  # static-only: no JDWP dynamics either (#25 D1)
+        basis = "task_spec constraints.dynamic_re=forbidden (static-only)"
+    if constraints.get("debug_flag") is False:
+        needs_debug_flag = False
+        basis = ("task_spec constraints.debug_flag=false "
+                 "(user build: JDWP flag not required)")
+    if needs_vm and needs_debug_flag:
+        return DEFAULT_REQUIREMENTS
+    return Requirements(needs_vm=needs_vm,
+                        needs_debug_flag=needs_debug_flag, basis=basis)
 
 
 def load_task_spec(ws: Path) -> dict | None:
@@ -1638,11 +1663,14 @@ def _check_android(report: ToolchainReport, ws: Path,
                    reqs: Requirements = DEFAULT_REQUIREMENTS) -> None:
     """Android toolchain checks (APK/DEX/SO).
 
-    #449: `reqs` is accepted for checker-signature uniformity but does not
-    relax anything — android's dynamic contract is the ADB channel
-    (device-side services), not the VMware/VBox VM channel (#455;
-    NEVER_CHECKS). Needs-first android relaxation is follow-up scope, not
-    #449 evidence."""
+    #449: `reqs` is accepted for checker-signature uniformity — android's
+    VM-face has nothing to relax (its dynamic contract is the ADB channel,
+    device-side services, not the VMware/VBox VM channel (#455;
+    NEVER_CHECKS)). #25 D1 wires the ONE android relaxation that exists:
+    the debug_flag gate downgrades FAIL -> WARN when the task does not
+    need the JDWP flag (reqs.needs_debug_flag False — static-only, or the
+    explicit constraints.debug_flag=false opt-out); the basis rides into
+    the detail. The default path is byte-identical to the pre-#25 gate."""
     # T0: venv + aapt/aapt2 (or unzip substitute)
     aapt_found = None
     for tool in ("aapt", "aapt2"):
@@ -1754,11 +1782,23 @@ def _check_android(report: ToolchainReport, ws: Path,
     # T2: debug flag (HARD, enforced — #304 F3): verified by reading back
     # ro.debuggable == 1. "Must be set" is a user design requirement, so an
     # unset flag FAILs init instead of silently warning.
+    # #25 D1: ro.debuggable=1 is unreachable on Android 12+ user builds
+    # (SELinux property_service lock) while frida/android_server run fine
+    # via Magisk su — when the task does not need the flag
+    # (reqs.needs_debug_flag False), a miss downgrades FAIL -> WARN with
+    # the task_spec basis in the detail (reported, never silently skipped;
+    # the #449 VM-downgrade contract). The default path stays byte-identical.
+    flag_optional = not reqs.needs_debug_flag
     if not adb_ok:
+        detail = "Cannot check debug flag — ADB unavailable"
+        if flag_optional:
+            detail += f" — not required by task_spec ({reqs.basis})"
         report.items.append(CheckResult(
-            name="debug_flag", status=Status.FAIL, tier=Tier.HARD,
-            detail="Cannot check debug flag — ADB unavailable",
-            root_cause="ADB",
+            name="debug_flag",
+            status=Status.WARN if flag_optional else Status.FAIL,
+            tier=Tier.WARN if flag_optional else Tier.HARD,
+            detail=detail,
+            root_cause=None if flag_optional else "ADB",
         ))
     else:
         assert adb  # noqa: S101 — adb is set when adb_ok is True
@@ -1772,11 +1812,19 @@ def _check_android(report: ToolchainReport, ws: Path,
                 probe=ProbeTier.CAPABILITY,
             ))
         else:
+            detail = (f"debug flag not set (ro.debuggable="
+                      f"{debuggable or 'unreadable'}; {err or out[:60]})")
+            if flag_optional:
+                detail += f" — not required by task_spec ({reqs.basis})"
+            else:
+                detail += " — required for Android dynamic analysis"
             report.items.append(CheckResult(
-                name="debug_flag", status=Status.FAIL, tier=Tier.HARD,
-                detail=f"debug flag not set (ro.debuggable={debuggable or 'unreadable'}; "
-                       f"{err or out[:60]}) — required for Android dynamic analysis",
-                root_cause="debug_flag", probe=ProbeTier.CAPABILITY,
+                name="debug_flag",
+                status=Status.WARN if flag_optional else Status.FAIL,
+                tier=Tier.WARN if flag_optional else Tier.HARD,
+                detail=detail,
+                root_cause=None if flag_optional else "debug_flag",
+                probe=ProbeTier.CAPABILITY,
             ))
 
     # T2: frida-server (renamed + custom port, convention 1337) — HARD, enforced

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -62,9 +62,16 @@ analysis; a workspace that is not initialized is refused work.
    subagents to `<ws>/.claude/agents/`, records the MCP supply state in
    `env-manifest.yaml` (missing registrations become MANUAL entries with
    their register command — init never runs `claude mcp add` itself), and
-   writes the deployment ledger. `--skills a,b` opts into auxiliary skill
-   deployment. Activation (which hooks FIRE) stays a separate
-   orchestrator act:
+   writes the deployment ledger. Deployment is WORKSPACE-SCOPED (#25 D4):
+   the hooks live in `<ws>/.claude/settings.json` and fire only for
+   sessions opened inside `<ws>` — a Claude session started elsewhere
+   (another project, the repo checkout, home) loads none of them, so
+   kunglao's gates are silently absent there; `hooks/session_start.py`
+   prints an explicit NOT-active notice when it runs without a kunglao
+   workspace. `--builtin-skills a,b` opts into auxiliary skill
+   deployment (kunglao's BUILT-IN bundled skills only — globally-installed
+   skills are a different, future surface). Activation (which hooks FIRE)
+   stays a separate orchestrator act:
    `python <SKILL_DIR>/scripts/hook_activation.py <workspace> --wire-up`
    remains the canonical re-registration/repair entry .
 
@@ -76,7 +83,8 @@ The workspace path is a positional argument (omitted -> pending decision).
 default — an undecided type pends, exit 8). `--target NAME` names the
 analysis target under `bins/`; containers additionally resolve
 `target_object`. `--no-hooks` skips hook deployment (the only legal skip);
-`--skills a,b` deploys named auxiliary skills (opt-in, default none).
+`--builtin-skills a,b` deploys named built-in auxiliary skills (opt-in,
+default none; kunglao-bundled names only, #25 D2).
 
 ## No arguments
 

--- a/tests/test_builtin_skills_flag_25.py
+++ b/tests/test_builtin_skills_flag_25.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""Issue #25 D2 — the init skill-deployment flag naming clash.
+
+`--skills` reads as "deploy these skills into my workspace", but it only
+accepts kunglao-INTERNAL bundled names (skills/<name> under the package).
+Issue evidence (2026-08-23): `--skills malware-analysis-claude-skills,
+re-baseline-looper` — both valid globally-installed skills — failed with
+"unknown --skills name(s): ... (available: analysis, help, init,
+kunglao-agent, resume)". The name collides with its intuitive semantic.
+
+Owner no-backcompat ruling (2026-09-01): rename directly, no compat alias.
+New name: `--builtin-skills` — the flag deploys kunglao's BUILT-IN
+auxiliary skills; plural matches the comma-list arity (`A,B`). The global/
+workspace-skill semantic is a different, future feature — it must not
+inherit this name.
+
+TDD RED phase: written BEFORE the rename (2026-09-04).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from _factories import seed_bins
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+SKILL_INIT = ROOT / "skills" / "init" / "SKILL.md"
+
+FLAG_NAME = "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"
+RC_OK = 0
+RC_ERROR = 1
+
+# Built here so this file's own source never carries the retired literal.
+OLD_FLAG = "--" + "skills"
+NEW_FLAG = "--builtin-skills"
+
+
+# ---------- rename hygiene: the retired name is gone everywhere ----------
+
+def test_old_flag_name_has_zero_references():
+    """No compat alias: the old name must grep ZERO on its live surfaces
+    (scripts/, the init SKILL.md, tests/). openspec/archive/ is historical
+    record and deliberately out of scope."""
+    scan = list((ROOT / "scripts").glob("*.py"))
+    scan.append(SKILL_INIT)
+    scan.extend(p for p in (ROOT / "tests").glob("*.py")
+                if p.name != Path(__file__).name)
+    hits = [str(p) for p in scan
+            if OLD_FLAG in p.read_text(encoding="utf-8")]
+    assert not hits, f"retired {OLD_FLAG} still referenced in: {hits}"
+
+
+def test_new_flag_name_declared_on_cli_and_docs():
+    """The new name exists on the argparse surface AND is documented where
+    init describes skill deployment."""
+    init_src = (SCRIPTS / "kunglao-init.py").read_text(encoding="utf-8")
+    assert NEW_FLAG in init_src, "kunglao-init.py must declare --builtin-skills"
+    doc = SKILL_INIT.read_text(encoding="utf-8")
+    assert NEW_FLAG in doc, "skills/init/SKILL.md must document --builtin-skills"
+
+
+# ---------- e2e: the renamed flag keeps the #478 L4 contract ----------
+
+def _mk_ws(tmp_path: Path, name: str = "ws") -> Path:
+    ws = tmp_path / name
+    seed_bins(ws, payload=b"MZ\x90\x00" + b"\x00" * 64)
+    (ws / "runs").mkdir()
+    return ws
+
+
+def _run_init(ws: Path, extra: list[str] | None = None) -> subprocess.CompletedProcess:
+    """Hermetic CLI run (same shape as test_init_deploy_env._run_init)."""
+    argv = [sys.executable, str(SCRIPTS / "kunglao-init.py"), str(ws),
+            *(extra or [])]
+    argv += ["--type", "windows", "--skip-toolchain",
+             "--host-exec-protection", "enabled",
+             "--profile-root", str(ws.parent / "profile-root")]
+    env = {k: v for k, v in os.environ.items()
+           if k not in (FLAG_NAME, "GHIDRA_HOME", "KUNGLAO_VM_HOST")}
+    env["PATH"] = str(ws.parent / "empty-bin")
+    (ws.parent / "empty-bin").mkdir(exist_ok=True)
+    env["PYTHONIOENCODING"] = "utf-8"
+    env[FLAG_NAME] = "0"
+    env["KUNGLAO_CLAUDE_JSON"] = str(ws.parent / "fake-claude.json")
+    if not (ws.parent / "fake-claude.json").exists():
+        (ws.parent / "fake-claude.json").write_text("{}", encoding="utf-8")
+    return subprocess.run(argv, capture_output=True, text=True, timeout=120,
+                          env=env, errors="replace")
+
+
+def test_builtin_skills_flag_deploys_named_dir(tmp_path):
+    ws = _mk_ws(tmp_path)
+    r = _run_init(ws, [NEW_FLAG, "analysis"])
+    assert r.returncode == RC_OK, (
+        f"{NEW_FLAG} analysis must deploy: {r.stdout}{r.stderr}")
+    dst = ws / ".claude" / "skills" / "analysis"
+    assert dst.is_dir(), "skills/analysis not deployed"
+    assert (dst / "SKILL.md").exists(), "deployed skill lost SKILL.md"
+
+
+def test_builtin_skills_unknown_name_fails_fast(tmp_path):
+    ws = _mk_ws(tmp_path)
+    r = _run_init(ws, [NEW_FLAG, "definitely-not-a-skill"])
+    assert r.returncode == RC_ERROR, (
+        f"unknown {NEW_FLAG} name must fail RC_ERROR=1: {r.stdout}{r.stderr}")
+    combined = r.stdout + r.stderr
+    assert "definitely-not-a-skill" in combined
+    assert NEW_FLAG in combined, "error must name the NEW flag, not the old one"
+
+
+def test_builtin_skills_no_flag_deploys_nothing(tmp_path):
+    ws = _mk_ws(tmp_path)
+    r = _run_init(ws)
+    assert r.returncode == RC_OK, r.stderr
+    skills_dir = ws / ".claude" / "skills"
+    assert not skills_dir.exists() or not any(skills_dir.iterdir()), (
+        f"no {NEW_FLAG} flag must install nothing")

--- a/tests/test_debug_flag_task_spec_25.py
+++ b/tests/test_debug_flag_task_spec_25.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+"""Issue #25 D1 — the debug_flag (ro.debuggable) gate is unreachable in real
+environments.
+
+Android 12+ user builds lock ro.debuggable (SELinux property_service: setprop
+rejected, `adb root` refused on production builds, verity nondisablable) —
+yet the android gate treats debug_flag as HARD-enforced (#304 F3), so ANY
+android init without a physically rooted/debuggable device is blocked even
+when the dynamic plan (frida / android_server via Magisk su) does not need
+the flag at all. A gate that cannot pass in the most common environment is
+the "design assumption silently fails" class the postmortem names.
+
+Fix = WIRE the existing seam, not remove: `_check_android` already receives
+the #449 Requirements (task_spec-derived) but ignored them. Now:
+  * Requirements grows needs_debug_flag (conservative default True);
+  * requirements_from_task_spec derives it — constraints.dynamic_re ==
+    "forbidden" (static-only => no JDWP dynamics) or an explicit
+    constraints.debug_flag: false (user-build opt-out) both demote;
+  * the debug_flag check downgrades FAIL -> WARN citing the basis in the
+    detail (reported, never silently skipped — the #449 VM-downgrade
+    contract). Absent/garbage task_spec keeps HARD, byte-identical.
+
+TDD RED phase: written BEFORE the implementation (2026-09-04).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+import toolchain as tc  # pytest.ini pythonpath = . hooks scripts tools
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+
+
+# ---------- unit: requirements_from_task_spec derivation ----------
+
+def test_requirements_debug_flag_explicit_optout():
+    """constraints.debug_flag: false -> needs_debug_flag False, VM untouched."""
+    reqs = tc.requirements_from_task_spec({"constraints": {"debug_flag": False}})
+    assert reqs.needs_debug_flag is False, reqs
+    assert reqs.needs_vm is True, "debug_flag opt-out alone must not touch VM"
+    assert "debug_flag" in reqs.basis, reqs
+
+
+def test_requirements_static_only_implies_no_debug_flag():
+    """dynamic_re=forbidden (static-only) needs no VM channel AND no JDWP flag."""
+    reqs = tc.requirements_from_task_spec(
+        {"constraints": {"dynamic_re": "forbidden"}})
+    assert reqs.needs_debug_flag is False, reqs
+    assert reqs.needs_vm is False, reqs
+
+
+def test_requirements_debug_flag_conservative_family():
+    """Absent/garbage/non-boolean-false debug_flag keeps conservative HARD."""
+    for spec in (None, {}, {"constraints": {}},
+                 {"constraints": {"debug_flag": True}},
+                 {"constraints": {"debug_flag": "false"}},  # string, not bool
+                 {"constraints": {"debug_flag": None}}):
+        reqs = tc.requirements_from_task_spec(spec)
+        assert reqs.needs_debug_flag is True, \
+            f"{spec!r} must stay conservative: {reqs}"
+
+
+def test_requirements_combined_static_only_plus_optout():
+    """Both signals present -> both channels relaxed in one Requirements."""
+    reqs = tc.requirements_from_task_spec(
+        {"constraints": {"dynamic_re": "forbidden", "debug_flag": False}})
+    assert reqs.needs_debug_flag is False, reqs
+    assert reqs.needs_vm is False, reqs
+
+
+def test_requirements_debug_flag_immutable():
+    reqs = tc.requirements_from_task_spec({"constraints": {"debug_flag": False}})
+    with pytest.raises(Exception):
+        reqs.needs_debug_flag = True  # type: ignore[misc]
+
+
+# ---------- e2e: the android gate via the CLI ----------
+
+@pytest.fixture
+def fake_bin(tmp_path: Path) -> Path:
+    """Empty fake-bin dir; tests write the platform adb wrapper into it."""
+    fb = tmp_path / "fake-bin"
+    fb.mkdir()
+    return fb
+
+
+def _write_adb(fake_bin: Path, *, debuggable: str, uid: str = "0") -> None:
+    """Minimal platform adb wrapper + stub (same shape as test_toolchain's):
+    answers devices / su id / getprop ro.debuggable / getprop sdk / forward."""
+    stub = fake_bin / "adb_stub.py"
+    stub.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "args = sys.argv[1:]\n"
+        "if 'devices' in args:\n"
+        "    print('List of devices attached')\n"
+        "    print('emulator-5554\\tdevice')\n"
+        "    sys.exit(0)\n"
+        "if 'shell' in args and 'su' in args and 'id' in args:\n"
+        f"    print('uid={uid}(root) gid=0(root)')\n"
+        "    sys.exit(0)\n"
+        "if 'shell' in args and 'getprop' in args:\n"
+        "    if 'ro.debuggable' in args:\n"
+        f"        print('{debuggable}')\n"
+        "    else:\n"
+        "        print('31')\n"
+        "    sys.exit(0)\n"
+        "if 'shell' in args and 'ls' in args:\n"
+        "    for a in args:\n"
+        "        if 'android_server' in a or 'frida' in a:\n"
+        "            print(a)\n"
+        "    sys.exit(0)\n"
+        "if 'forward' in args:\n"
+        "    sys.exit(0)\n"
+        "sys.exit(0)\n",
+        encoding="utf-8",
+    )
+    adb = fake_bin / "adb"
+    adb.write_text(
+        f"#!/bin/sh\nexec \"{sys.executable}\" \"{stub}\" \"$@\"\n",
+        encoding="utf-8",
+    )
+    adb.chmod(0o755)
+
+
+def _mk_ws(tmp_path: Path) -> Path:
+    ws = tmp_path / "ws"
+    (ws / "runs").mkdir(parents=True)
+    return ws
+
+
+def _pin_claude_json(ws: Path, monkeypatch) -> None:
+    """Hermetic MCP probe: never read the developer's real ~/.claude.json."""
+    fake = ws.parent / "fake-claude.json"
+    if not fake.exists():
+        fake.write_text(json.dumps({
+            "mcpServers": {name: {} for name in (
+                "ghidra", "sequential-thinking", "x64dbg", "gitnexus")},
+        }), encoding="utf-8")
+    monkeypatch.setenv("KUNGLAO_CLAUDE_JSON", str(fake))
+
+
+def _run_toolchain(ws: Path, extra: list[str]) -> subprocess.CompletedProcess:
+    argv = [sys.executable, str(SCRIPTS / "toolchain.py"), str(ws), *extra]
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("GHIDRA_HOME", "KUNGLAO_VM_HOST")}
+    env["PYTHONIOENCODING"] = "utf-8"
+    return subprocess.run(argv, capture_output=True, text=True, timeout=60,
+                          env=env, errors="replace")
+
+
+def _debug_flag_item(ws: Path) -> tuple[subprocess.CompletedProcess, dict]:
+    r = _run_toolchain(ws, ["--type", "android", "--json"])
+    data = json.loads(r.stdout)
+    df = next(c for c in data["checks"] if c["name"] == "debug_flag")
+    return r, df
+
+
+def test_android_debug_flag_warn_with_task_spec_optout(
+        tmp_path, fake_bin, monkeypatch):
+    """#25 D1 core: user build (ro.debuggable=0) + constraints.debug_flag
+    false -> the item is REPORTED (WARN) instead of blocking init (FAIL)."""
+    _write_adb(fake_bin, debuggable="0")
+    monkeypatch.setenv("PATH", str(fake_bin), prepend=os.pathsep)
+    ws = _mk_ws(tmp_path)
+    _pin_claude_json(ws, monkeypatch)
+    (ws / "task_spec.yaml").write_text(yaml.safe_dump(
+        {"constraints": {"debug_flag": False}}, sort_keys=False),
+        encoding="utf-8")
+    r, df = _debug_flag_item(ws)
+    assert df["status"] == "WARN", \
+        f"opted-out debug_flag must WARN, not block init: {df}"
+    assert df["tier"] == "WARN", df
+    assert "debug_flag" in df["detail"], "basis must ride into the detail"
+    assert "task_spec" in df["detail"], df
+
+
+def test_android_debug_flag_pass_untouched_when_optout_and_set(
+        tmp_path, fake_bin, monkeypatch):
+    """Opt-out only lifts the enforcement floor; a set flag still PASSes."""
+    _write_adb(fake_bin, debuggable="1")
+    monkeypatch.setenv("PATH", str(fake_bin), prepend=os.pathsep)
+    ws = _mk_ws(tmp_path)
+    _pin_claude_json(ws, monkeypatch)
+    (ws / "task_spec.yaml").write_text(yaml.safe_dump(
+        {"constraints": {"debug_flag": False}}, sort_keys=False),
+        encoding="utf-8")
+    r, df = _debug_flag_item(ws)
+    assert df["status"] == "PASS", df
+
+
+def test_android_debug_flag_stays_hard_without_task_spec(
+        tmp_path, fake_bin, monkeypatch):
+    """Conservative pin: absent task_spec keeps the pre-#25 HARD gate
+    (byte-identical; test_toolchain F3 owns the long-form contract)."""
+    _write_adb(fake_bin, debuggable="0")
+    monkeypatch.setenv("PATH", str(fake_bin), prepend=os.pathsep)
+    ws = _mk_ws(tmp_path)
+    _pin_claude_json(ws, monkeypatch)
+    r, df = _debug_flag_item(ws)
+    assert df["status"] == "FAIL", f"no task_spec must stay HARD: {df}"
+    assert df["tier"] == "HARD", df
+    assert r.returncode == 1, "HARD debug_flag FAIL must still exit 1"

--- a/tests/test_init_deploy_env.py
+++ b/tests/test_init_deploy_env.py
@@ -249,14 +249,14 @@ def test_l4_no_flag_deploys_nothing(tmp_path):
     assert r.returncode == RC_OK, r.stderr
     skills_dir = ws / ".claude" / "skills"
     assert not skills_dir.exists() or not any(skills_dir.iterdir()), (
-        "no --skills flag must install nothing")
+        "no --builtin-skills flag must install nothing")
 
 
 def test_l4_skills_flag_deploys_named_dir(tmp_path):
     ws = _mk_ws(tmp_path)
-    r = _run_init(ws, ["--skills", "analysis"])
+    r = _run_init(ws, ["--builtin-skills", "analysis"])
     assert r.returncode == RC_OK, (
-        f"--skills analysis must deploy: {r.stdout}{r.stderr}")
+        f"--builtin-skills analysis must deploy: {r.stdout}{r.stderr}")
     dst = ws / ".claude" / "skills" / "analysis"
     assert dst.is_dir(), "skills/analysis not deployed"
     assert (dst / "SKILL.md").exists(), "deployed skill lost SKILL.md"
@@ -264,9 +264,10 @@ def test_l4_skills_flag_deploys_named_dir(tmp_path):
 
 def test_l4_unknown_skill_fails_fast(tmp_path):
     ws = _mk_ws(tmp_path)
-    r = _run_init(ws, ["--skills", "definitely-not-a-skill"])
+    r = _run_init(ws, ["--builtin-skills", "definitely-not-a-skill"])
     assert r.returncode == RC_ERROR, (
-        f"unknown --skills name must fail RC_ERROR=1: {r.stdout}{r.stderr}")
+        f"unknown --builtin-skills name must fail RC_ERROR=1: "
+        f"{r.stdout}{r.stderr}")
     assert "definitely-not-a-skill" in (r.stdout + r.stderr)
 
 

--- a/tests/test_session_start_notice_25.py
+++ b/tests/test_session_start_notice_25.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Issue #25 D4 — hooks-only-in-workspace is a silent assumption failure.
+
+Kunglao hooks are deployed PROJECT-scoped (<ws>/.claude/settings.json,
+#258): a Claude session opened OUTSIDE the workspace never loads them, so
+the gates silently don't fire — while the user believes kunglao is active
+because it is "installed". Fix = documentation + detection (NOT new hook
+plumbing): hooks/session_start.py already had a workspace-resolution
+failure path (`.kunglao` missing) that printed a quiet internal skip line;
+it now emits a clear one-line notice that kunglao hooks are NOT active in
+this session plus the activation hint.
+
+Contract:
+  * non-workspace session (hook entry runs, no .kunglao) -> the notice,
+    exit 0 (non-fatal, same as before);
+  * workspace session (.kunglao present) -> NO notice; the normal
+    always_arm/renew output is unchanged.
+
+TDD RED phase: written BEFORE the notice exists (2026-09-04).
+"""
+from __future__ import annotations
+
+import session_start as ss  # pytest.ini pythonpath includes hooks/
+
+NOTICE_TOKEN = "kunglao hooks are NOT active"
+ACTIVATE_TOKEN = "/kunglao-agent:init"
+
+
+def test_non_workspace_session_emits_notice(tmp_path, capsys):
+    """No .kunglao -> one-line notice: hooks NOT active + how to activate."""
+    ws = tmp_path / "not-a-kunglao-ws"
+    ws.mkdir()
+    rc = ss.session_start(ws)
+    out = capsys.readouterr().out
+    assert rc == 0, "non-workspace session must stay non-fatal"
+    assert NOTICE_TOKEN in out, f"notice missing from output: {out!r}"
+    assert ACTIVATE_TOKEN in out, f"activation hint missing: {out!r}"
+    # one line — SessionStart output should stay a single context line
+    notice_lines = [ln for ln in out.splitlines() if NOTICE_TOKEN in ln]
+    assert len(notice_lines) == 1, f"expected exactly one notice line: {out!r}"
+
+
+def test_workspace_session_emits_no_notice(tmp_path, capsys):
+    """A real kunglao workspace keeps the normal arm/renew output — the
+    notice must never fire there."""
+    ws = tmp_path / "ws"
+    (ws / ".kunglao").mkdir(parents=True)
+    rc = ss.session_start(ws)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert NOTICE_TOKEN not in out, f"notice must not fire in-workspace: {out!r}"
+    assert "always_arm" in out, f"normal arm output missing: {out!r}"
+
+
+def test_notice_names_the_workspace_path(tmp_path, capsys):
+    """The notice points at the resolved path so a user can see WHERE the
+    workspace was expected."""
+    ws = tmp_path / "some-other-dir"
+    ws.mkdir()
+    ss.session_start(ws)
+    out = capsys.readouterr().out
+    assert str(ws) in out, f"notice must cite the checked path: {out!r}"


### PR DESCRIPTION
## Summary

Three silent design-assumption failures (#25), each fixed per its own
nature:

**1. debug_flag — WIRED, not removed.** No advertised-but-dead knob exists;
the real failure: the `ro.debuggable` toolchain check (#304 F3) was
HARD-enforced while `ro.debuggable=1` is unreachable on Android 12+ user
builds, blocking all android init. `_check_android` now honors the #449
`Requirements`: `needs_debug_flag` (default True, conservative) demotes
FAIL→WARN on `constraints.dynamic_re: forbidden` (static-only) or explicit
`constraints.debug_flag: false` (exact boolean; string "false" stays
conservative). Default path byte-identical.

**2. --skills → --builtin-skills.** The flag (deploy kunglao-bundled
skills) rejected valid globally-installed skills — naming clash with the
user's mental model. Renamed per the no-backcompat ruling (no alias):
argparse, args attr, docstrings, error strings, SKILL.md, tests. Old name
greps zero on live surfaces.

**3. hooks-only-in-workspace — DOC + DETECTION.** Hooks are project-scoped
(#258); sessions outside the workspace silently get nothing. session_start's
failure path now emits a clear notice ("kunglao hooks are NOT active in
this session… To activate: cd into the workspace and run
/kunglao-agent:init"), exit 0 unchanged; in-workspace behavior
byte-identical. SKILL.md documents the scoping model.

Closes #25

Milestone: v0.1.5 (milestone #1)

## Anti-orphan gate (REQUIRED)

- Added code: Requirements.needs_debug_flag + demotion logic, session_start
  notice, 3 test files. Rename across flag surface.
- Code moved/deleted: none; openspec archive untouched (historical record).

## Test plan

- [x] Per-concern RED→GREEN (5+4+1 tests; conservative-path pins: no
      task_spec → HARD FAIL unchanged; opt-out+flag → PASS)
- [x] Full suite (env -u KUNGLAO_VALUE_ALGO): 5340 passed / 41 skipped /
      0 failed
- [x] ruff clean (7 files); deploy --write + --verify OK (374)
