### PR TITLE
feat: Android toolchain lighting — semantic keyword aliases + rationale suggestions, zero enforcement (#54)

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -67,7 +67,7 @@ files:
   - src: hooks/worker_budget_gates.py
     dest: .claude/hooks/worker_budget_gates.py
     kind: hook
-    sha256: 9cde96f841b840bc45642a9ed9a2c8fb0efb5a637b7b41d55c802a85f58906b9
+    sha256: 391a30ee4896b81f877fda13dfd2379c3f5405ea50856f38158be83caf564c91
   - src: hooks/worker_budget_sinks.py
     dest: .claude/hooks/worker_budget_sinks.py
     kind: hook
@@ -695,7 +695,7 @@ files:
   - src: scripts/route_capability.py
     dest: .claude/scripts/route_capability.py
     kind: scaffold
-    sha256: dc7c3e01b230766f75bf28b65ce78f697f1f82c3933f8f8a2bec9f072e960931
+    sha256: 01de8322607122e8a78428286e36c7556b72eb963b57f7776f2806da9aa74ac5
   - src: scripts/run_test_matrix.py
     dest: .claude/scripts/run_test_matrix.py
     kind: scaffold

--- a/hooks/worker_budget_gates.py
+++ b/hooks/worker_budget_gates.py
@@ -866,6 +866,34 @@ _TOOLFIRST_STOPWORDS = frozenset(
     {'static', 'pipeline', 'pipelines', 'aux', 'auxiliary',
      'annotate', 'decode'})
 
+# ---------- issue #54: android toolchain lighting aliases (keyword DATA) ------
+# LIGHTING ONLY (#54 owner ruling: 不能强制 — we cannot force tool choice).
+# The android capability halves in tools/_INDEX.yaml ("android:java-source",
+# "android:packer-fingerprint", ...) are compound registry ids that literal
+# dispatch prose never matches, so an android dispatch CITING its tool could
+# never reach mode='matched' (the #46 self-attestation lock shape, android
+# edition) and verify_tool_catalog could not resolve the citation. Each alias
+# below maps to the registered android tool the dispatch means.
+#
+# The gate's REJECT semantics are UNTOUCHED: a keyword hit still behaves
+# exactly like 'crypto' does today (same missing_marker face, same opt-out) —
+# no new REJECT mode, no new required marker. An android-flavored dispatch
+# that names no alias (e.g. the #54 repro "分析这个APK的登录加密逻辑" itself)
+# still passes silently (no_match).
+#
+# Discipline (_TOOLFIRST_STOPWORDS spirit): DISTINCTIVE terms only — provider
+# names derived from the registry's own `provider:` field (jadx/baksmali/
+# apkid/gitnexus/dexdc) plus CJK android-RE compounds. Generic prose ("app",
+# "apk", "java", "加密", "tls", "okhttp", "frida") stays OUT of the trigger
+# set — those false-positive normal dispatches; the ambiguous-but-likely
+# terms are route-side lighting only (scripts/route_capability.py #54 table).
+_ANDROID_KEYWORD_ALIASES: dict[str, tuple[str, ...]] = {
+    # tools/_INDEX.yaml capability tag -> extra keywords for that tool family
+    'android:java-source': ('反编译', 'java源码', 'java 源码'),
+    'android:bytecode-truth': ('smali',),
+    'android:packer-fingerprint': ('加固', '脱壳', '加壳'),
+}
+
 # One-off diagnostic exemption: CJK phrases are substring-matched (no word
 # concept to bound), ASCII phrases are word-bounded so 'one-off' inside a
 # longer word cannot trigger, and BOTH are negation-aware — "not a one-off
@@ -892,6 +920,13 @@ def _load_tool_index_keywords(skill_root: Path) -> dict[str, str]:
     {'crypto': 'crypto-tool', 'decode': 'crypto-tool'}. Multiple tools sharing
     a keyword keep the first-registered tool (informational only; the gate
     only needs ONE candidate name to cite in its REJECT message).
+
+    #54 android lighting: entries whose capability is an android:* tag also
+    contribute their `provider` name plus the distinctive aliases in
+    _ANDROID_KEYWORD_ALIASES — same first-registered-wins rule, so registry
+    order decides e.g. 反编译 -> jadx-decompile (the high-quality
+    android:java-source provider) over dexdc-decompile. Coverage only: the
+    gate's REJECT semantics are unchanged.
     """
     index_path = skill_root / 'tools' / '_INDEX.yaml'
     if not index_path.exists():
@@ -915,6 +950,15 @@ def _load_tool_index_keywords(skill_root: Path) -> dict[str, str]:
         for kw in (domain.strip().lower(), op.strip().lower()):
             if kw and kw not in out:
                 out[kw] = name
+        # #54 android lighting aliases (data table above; coverage only)
+        cap_l = capability.strip().lower()
+        if cap_l.startswith('android:'):
+            provider = str(entry.get('provider') or '').strip().lower()
+            if provider and provider not in out:
+                out[provider] = name
+            for alias in _ANDROID_KEYWORD_ALIASES.get(cap_l, ()):
+                if alias and alias not in out:
+                    out[alias] = name
     return out
 
 

--- a/scripts/route_capability.py
+++ b/scripts/route_capability.py
@@ -47,6 +47,8 @@ with no registered tool stay as capability queries. agent_type = recommended
 specialist agent (issue #310) from the mechanical trigger table parsed out of
 the `triggers:` frontmatter of agents/*.md — claim task domain x sample
 features; None when no specialist fits (kunglao-worker allowed).
+`capability_suggestions` (#692 WP6 deobf prior; #54 android toolchain
+lighting) is a NON-BINDING prior list — it never alters the route.
 
 Exit codes: 0 ok / 2 usage / 3 missing inputs.
 
@@ -94,6 +96,116 @@ CLAIM_KEYWORDS = {
     "go": ("languages:go", 0.8),
 }
 DYNAMIC_INTENT = ("vm", "run", "execute", "detonate")
+
+# ---- issue #54: android toolchain lighting (suggestion rows, non-binding) ----
+# Owner ruling (#54): 不能强制 — we cannot force tool choice. These aliases
+# NEVER fire a capability rule (CLAIM_KEYWORDS / feature rules above own the
+# route): they only attach prior-shaped {capability, rationale} entries (the
+# #692 WP6 deobf-prior shape) to the route output, naming the registered
+# android tool a dispatch likely means and WHY. The chain, confidence and
+# fired-rule rationale are never altered — the agent may ignore every
+# suggestion (ZERO new REJECT paths).
+#
+# Matching: ASCII aliases are word-bounded on the lowered text (same
+# discipline as the tool-first gate's ASCII boundary), CJK aliases substring-
+# match (no word-boundary concept). Rationale = one plain line: the concrete
+# tools/_INDEX.yaml tool + why it applies.
+#
+# Strong aliases light on their own. Weak aliases need a strong android
+# anchor in the same text — "tls"/"签名" alone are PE TLS-table/Authenticode
+# prose, but "tls" next to "apk" is android certificate pinning. Generic
+# single words ("app", "java", "加密") are deliberately absent.
+_ANDROID_SUGGESTION_ROWS: tuple[tuple[str, bool, str, str], ...] = (
+    # (alias, strong, capability, one-line WHY)
+    ("apk", True, "android:packer-fingerprint",
+     "APK 样本 → apkid-prescan 先识别加固器/编译器，可省去盲扫"),
+    ("apk安装包", True, "android:packer-fingerprint",
+     "APK 安装包样本 → apkid-prescan 先识别加固器/编译器，可省去盲扫"),
+    ("android app", True, "android:packer-fingerprint",
+     "APK 样本 → apkid-prescan 先识别加固器/编译器，可省去盲扫"),
+    ("加固", True, "android:packer-fingerprint",
+     "加固/壳特征 → apkid-prescan 指纹在先，先认壳再定反编译路线"),
+    ("加壳", True, "android:packer-fingerprint",
+     "加壳特征 → apkid-prescan 指纹在先，先认壳再定反编译路线"),
+    ("脱壳", True, "android:packer-fingerprint",
+     "脱壳前 → apkid-prescan 先认壳，避免盲脱"),
+    ("packer", True, "android:packer-fingerprint",
+     "packer marker → apkid-prescan 先识别加固器/编译器"),
+    ("so库", False, "android:packer-fingerprint",
+     "native/so 路线前 → apkid-prescan 先看整体加固/混淆指纹"),
+    ("native层", False, "android:packer-fingerprint",
+     "native/so 路线前 → apkid-prescan 先看整体加固/混淆指纹"),
+    (".so", False, "android:packer-fingerprint",
+     "native/so 路线前 → apkid-prescan 先看整体加固/混淆指纹"),
+    ("unpack", False, "android:packer-fingerprint",
+     "apk 解包目标 → apkid-prescan 先识别加固器，再定脱壳/反编译路线"),
+    ("jadx", True, "android:java-source",
+     "DEX 目标 → jadx-decompile 出 Java 源码树（apk_mem_gate 过闸）；"
+     "内存超限时 dexdc-decompile 兜底"),
+    ("反编译", True, "android:java-source",
+     "DEX 目标 → jadx-decompile 出 Java 源码树（apk_mem_gate 过闸）；"
+     "内存超限时 dexdc-decompile 兜底"),
+    ("dex", True, "android:java-source",
+     "DEX 目标 → jadx-decompile 出 Java 源码树（apk_mem_gate 过闸）；"
+     "内存超限时 dexdc-decompile 兜底"),
+    ("java-source", True, "android:java-source",
+     "DEX 目标 → jadx-decompile 出 Java 源码树（apk_mem_gate 过闸）；"
+     "内存超限时 dexdc-decompile 兜底"),
+    ("java源码", True, "android:java-source",
+     "java 源码恢复 → jadx-decompile 出源码树（apk_mem_gate 过闸）；"
+     "内存超限时 dexdc-decompile 兜底"),
+    ("java 源码", True, "android:java-source",
+     "java 源码恢复 → jadx-decompile 出源码树（apk_mem_gate 过闸）；"
+     "内存超限时 dexdc-decompile 兜底"),
+    ("smali", True, "android:bytecode-truth",
+     "字节码 1:1 truth → baksmali-xref 产 smali_index.json（类/方法/xref）"),
+    ("baksmali", True, "android:bytecode-truth",
+     "字节码 1:1 truth → baksmali-xref 产 smali_index.json（类/方法/xref）"),
+    ("字节码", True, "android:bytecode-truth",
+     "字节码 1:1 truth → baksmali-xref 产 smali_index.json（类/方法/xref）"),
+    ("登录加密", False, "android:java-source",
+     "APK + 加密目标 → apkid-prescan 先识别加固器（可省去盲扫），再 "
+     "jadx-decompile 源码 + gitnexus-query 溯加密调用链"),
+    ("加密逻辑", False, "android:java-source",
+     "APK + 加密目标 → apkid-prescan 先识别加固器（可省去盲扫），再 "
+     "jadx-decompile 源码 + gitnexus-query 溯加密调用链"),
+    ("java加密", False, "android:java-source",
+     "java 层加密目标 → jadx-decompile 源码 + gitnexus-query 溯加密调用链"),
+    ("通信加密", False, "android:java-source",
+     "通信加密目标 → jadx-decompile 源码 + gitnexus-query 溯请求封装/加密点"),
+    ("login encryption", False, "android:java-source",
+     "APK + login-encryption target → apkid-prescan first (skip blind "
+     "sweeps), then jadx-decompile + gitnexus-query for the crypto chain"),
+    ("okhttp", False, "android:java-source",
+     "网络库特征 → jadx-decompile 后 gitnexus-query 定位请求封装与证书校验"),
+    ("network library", False, "android:java-source",
+     "网络库特征 → jadx-decompile 后 gitnexus-query 定位请求封装与证书校验"),
+    ("抓包", False, "android:java-source",
+     "抓包目标 → jadx-decompile 后 gitnexus-query 定位请求封装与证书校验"),
+    ("签名", False, "android:java-source",
+     "签名校验逻辑 → jadx-decompile 源码树里直接搜签名判断，避免盲扫"),
+    ("签名校验", False, "android:java-source",
+     "签名校验逻辑 → jadx-decompile 源码树里直接搜签名判断，避免盲扫"),
+    ("certificate", False, "android:java-source",
+     "certificate/pinning target on an android sample → jadx-decompile "
+     "source + gitnexus-query for the check chain"),
+    ("tls", False, "android:java-source",
+     "TLS/证书校验目标 → jadx-decompile 源码树里搜 pinning/TrustManager"),
+    ("ssl pinning", False, "android:java-source",
+     "TLS/证书校验目标 → jadx-decompile 源码树里搜 pinning/TrustManager"),
+    ("证书校验", False, "android:java-source",
+     "TLS/证书校验目标 → jadx-decompile 源码树里搜 pinning/TrustManager"),
+    ("frida", False, "android:java-source",
+     "hook 点定位 → jadx-decompile 的类名/方法名是 frida/xposed 脚本的直接来源"),
+    ("xposed", False, "android:java-source",
+     "hook 点定位 → jadx-decompile 的类名/方法名是 frida/xposed 脚本的直接来源"),
+    ("调用链", False, "android:semantic-query",
+     "调用链/数据流问题 → 源码树 lazy-index 后用 gitnexus-query（Graph RAG）"),
+    ("call chain", False, "android:semantic-query",
+     "调用链/数据流问题 → 源码树 lazy-index 后用 gitnexus-query（Graph RAG）"),
+    ("数据流", False, "android:semantic-query",
+     "调用链/数据流问题 → 源码树 lazy-index 后用 gitnexus-query（Graph RAG）"),
+)
 
 DEFAULT_INDEX = Path(__file__).resolve().parent.parent / "tools" / "_INDEX.yaml"
 DEFAULT_TOOL_SEARCH = Path(__file__).resolve().parent.parent / "tools" / \
@@ -547,6 +659,47 @@ def claim_hits(text: str) -> list[tuple[str, float, str]]:
     return _dedupe(hits)
 
 
+def _alias_in_text(alias: str, lowered_text: str) -> bool:
+    """ASCII aliases word-bound on the lowered text; CJK aliases substring-
+    match (Python \\b treats CJK as word chars, so \\b is meaningless there —
+    same reason the tool-first gate uses an ASCII-only boundary)."""
+    if alias.isascii():
+        return re.search(
+            rf"(?<![a-z0-9_]){re.escape(alias)}(?![a-z0-9_])",
+            lowered_text) is not None
+    return alias in lowered_text
+
+
+def android_suggestions(claim_text: str, tools: list[dict]) -> list[dict]:
+    """issue #54: non-binding android toolchain lighting for the route output.
+
+    Owner ruling (#54): 不能强制 — suggestion ONLY, zero enforcement. The
+    returned entries are the #692 WP6 deobf-prior shape (exactly
+    {capability, rationale}; the rationale names the concrete registered
+    android tool + why). They never fire a capability rule and never touch
+    chain/confidence; [] for non-android dispatches (zero noise).
+    """
+    text = (claim_text or "").lower()
+    if not text:
+        return []
+    anchor = False
+    fired: list[tuple[str, str]] = []
+    for alias, strong, cap, why in _ANDROID_SUGGESTION_ROWS:
+        if _alias_in_text(alias, text):
+            anchor = anchor or strong
+            fired.append((cap, why))
+    if not anchor:
+        return []  # only weak/ambiguous aliases: not confidently android
+    out: list[dict] = []
+    seen: set[str] = set()
+    for cap, why in fired:
+        if cap in seen:  # first fired alias's rationale wins per capability
+            continue
+        seen.add(cap)
+        out.append({"capability": cap, "rationale": why})
+    return out
+
+
 def _fallback() -> dict:
     """No rule fired: deterministic tool-search subprocess, confidence 0.4."""
     rationale = ["no feature/claim rule fired",
@@ -596,6 +749,22 @@ def _deobf_prior(state: dict) -> list[dict]:
     ]
 
 
+def _attach_lighting(result: dict, claim_text: str, tools: list[dict],
+                     ws) -> None:
+    """Attach `capability_suggestions` — non-binding lighting only (#54
+    android aliases + #692 WP6 deobf prior, android first). Additive: never
+    touches chain/confidence/fired-rule rationale, and adds NO key when
+    nothing fires (pre-#54 output shape preserved)."""
+    suggestions = android_suggestions(claim_text, tools)
+    if ws is not None:
+        have = {s["capability"] for s in suggestions}
+        for s in _deobf_prior(load_workspace_state(ws)):
+            if s["capability"] not in have:
+                suggestions.append(s)
+    if suggestions:
+        result["capability_suggestions"] = suggestions
+
+
 def route(features: dict, claim_text: str, index_path: Path,
           agents_dir: Path | None = None,
           ws: Path | None = None) -> dict:
@@ -604,7 +773,9 @@ def route(features: dict, claim_text: str, index_path: Path,
 
     #692 WP6: `ws` (optional — all pre-#692 callers omit it) adds the
     deobf composition prior (capability_suggestions) from apkid evidence.
-    A prior only: chain/confidence are never altered by suggestions."""
+    #54: android toolchain lighting joins the same suggestion list for
+    android-flavored dispatches (no workspace needed). A prior only:
+    chain/confidence are never altered by suggestions."""
     tools = load_index(index_path)
     fhits = feature_hits(features or {})
     chits = claim_hits(claim_text)
@@ -615,10 +786,7 @@ def route(features: dict, claim_text: str, index_path: Path,
         result = _fallback()
         result["agent_type"] = agent_type
         result["agent_rationale"] = agent_rationale
-        if ws is not None:
-            suggestions = _deobf_prior(load_workspace_state(ws))
-            if suggestions:
-                result["capability_suggestions"] = suggestions
+        _attach_lighting(result, claim_text, tools, ws)
         return result
 
     corroborations = len({c for c, _, _ in fhits} & {c for c, _, _ in chits})
@@ -651,10 +819,7 @@ def route(features: dict, claim_text: str, index_path: Path,
               "rationale": rationale,
               "agent_type": agent_type,
               "agent_rationale": agent_rationale}
-    if ws is not None:
-        suggestions = _deobf_prior(load_workspace_state(ws))
-        if suggestions:
-            result["capability_suggestions"] = suggestions
+    _attach_lighting(result, claim_text, tools, ws)
     return result
 
 
@@ -671,6 +836,10 @@ def format_text(result: dict) -> str:
     if result.get("agent_rationale"):
         lines.append("agent_rationale:")
         lines.extend(f"  - {r}" for r in result["agent_rationale"])
+    if result.get("capability_suggestions"):
+        lines.append("capability_suggestions (non-binding lighting):")
+        lines.extend(f"  - [{s['capability']}] {s['rationale']}"
+                     for s in result["capability_suggestions"])
     return "\n".join(lines)
 
 

--- a/tests/test_android_lighting_54.py
+++ b/tests/test_android_lighting_54.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""tests/test_android_lighting_54.py — issue #54 Android toolchain visibility.
+
+VERIFIED ROOT CAUSE (prior session):
+  - scripts/route_capability.py: keyword tables only trigger android tools on
+    literal "android"/"java-source"; the live dispatch "分析这个APK的登录加密逻辑"
+    (and its English variant) fell to the static:disasm fallback with
+    "no feature/claim rule fired" — android tools invisible.
+  - hooks/worker_budget_gates.py _load_tool_index_keywords derives gate
+    keywords from tools/_INDEX.yaml category + capability halves, so android
+    tools contribute compound halves ("android:java-source") that literal
+    prose never matches — a dispatch CITING jadx/baksmali can never reach
+    mode='matched' (the #46 self-attestation lock shape, android edition).
+
+OWNER RULING (#54 anchor): 不能强制 — we cannot force tool choice; LIGHTING
+ONLY. The agent may ignore every recommendation; there must be ZERO new
+REJECT paths. These tests pin exactly that:
+  - route(): android-flavored dispatches gain a non-binding
+    `capability_suggestions` entry (the SAME prior shape as the #692 WP6
+    deobf prior: exactly {capability, rationale}, rationale naming the
+    concrete registered android tool + the WHY); the recommendation
+    chain/confidence are identical with and without the lighting.
+  - gate: android alias keywords join the tool-first keyword map (provider
+    names + distinctive CJK android-RE compounds), while an android-flavored
+    dispatch WITHOUT a tool-catalog marker still passes silently (no_match) —
+    existing REJECT semantics untouched, only keyword coverage enriched.
+
+RED phase: no android alias tables exist — the route repro fires no android
+suggestion and the gate keyword map lacks the android aliases.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import route_capability as rc  # noqa: E402  (pytest pythonpath: scripts)
+import worker_budget_gates as wbg  # noqa: E402  (pytest pythonpath: hooks)
+
+REPO = Path(__file__).resolve().parents[1]
+ROUTE_CLI = REPO / "scripts" / "route_capability.py"
+
+# the live failing repros from the issue #54 report
+REPRO_ZH = "分析这个APK的登录加密逻辑"
+REPRO_EN = "analyze login encryption in this APK"
+
+# registered android toolchain providers (tools/_INDEX.yaml)
+ANDROID_TOOLS = ("jadx-decompile", "baksmali-xref", "apkid-prescan",
+                 "gitnexus-query", "dexdc-decompile")
+
+
+def _route(claim_text: str, features: dict | None = None) -> dict:
+    return rc.route(features or {}, claim_text, rc.DEFAULT_INDEX)
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(ROUTE_CLI), *args],
+        capture_output=True, text=True, timeout=60,
+        encoding="utf-8", errors="replace",
+    )
+
+
+# ---------------------------------------------------------------------------
+# RED: the live repros must light android tools in the route output
+# ---------------------------------------------------------------------------
+
+def test_repro_zh_route_carries_android_suggestions():
+    result = _route(REPRO_ZH)
+    sugs = result.get("capability_suggestions") or []
+    assert sugs, ("android-flavored dispatch must light android suggestions "
+                  "(#54 RED: 'no feature/claim rule fired' hid the toolchain)")
+    caps = {s["capability"] for s in sugs}
+    assert caps
+    assert all(c.startswith("android:") for c in caps), caps
+    # android TOOLS present in the result: the rationale names the concrete
+    # registered tool, and each capability resolves to registered tools
+    blob = json.dumps(result, ensure_ascii=False)
+    assert any(t in blob for t in ANDROID_TOOLS), blob
+    tools = rc.load_index(rc.DEFAULT_INDEX)
+    resolved = {t for s in sugs
+                for t in rc.resolve_capability(s["capability"], tools)}
+    assert resolved & set(ANDROID_TOOLS), resolved
+
+
+def test_repro_en_route_carries_android_suggestion():
+    sugs = _route(REPRO_EN).get("capability_suggestions") or []
+    assert sugs, "English variant must light android suggestions too (#54)"
+    assert any(s["capability"].startswith("android:") for s in sugs)
+
+
+def test_suggestion_shape_matches_deobf_prior_shape():
+    """Exactly {capability, rationale} — the #692 WP6 prior shape. The
+    exact-keys pin in test_deobf_composition must keep holding."""
+    for s in _route(REPRO_ZH).get("capability_suggestions") or []:
+        assert set(s) == {"capability", "rationale"}, (
+            f"suggestion must be prior-shaped, got keys {sorted(s)}")
+
+
+def test_suggestion_rationale_carries_the_why():
+    """Rationale-bearing lighting: one plain line naming WHY + the concrete
+    registered android tool (e.g. 'APK 样本 → apkid-prescan 先识别加固器')."""
+    for s in _route(REPRO_ZH).get("capability_suggestions") or []:
+        why = s["rationale"]
+        assert why and "\n" not in why, why
+        assert any(t in why for t in ANDROID_TOOLS), why
+
+
+# ---------------------------------------------------------------------------
+# zero-enforcement: lighting never touches the route
+# ---------------------------------------------------------------------------
+
+def test_lighting_never_touches_fallback_chain_or_confidence():
+    """Both dispatches fall back (no feature/claim rule) — the fallback route
+    must be IDENTICAL with and without android lighting; the lighting is
+    additive only (不能强制: the agent may ignore it)."""
+    neutral = _route("summarize the workspace state")
+    android = _route(REPRO_ZH)
+    assert android["recommendation"]["confidence"] == \
+        neutral["recommendation"]["confidence"] == 0.4
+    assert android["recommendation"]["chain"] == \
+        neutral["recommendation"]["chain"]
+    assert "fallback" in " ".join(android["rationale"])
+
+
+def test_confident_route_keeps_chain_with_lighting():
+    """A dispatch that fires a REAL rule ('unpack' → static:overlay) AND an
+    android alias keeps the exact rule-driven route; suggestions add nothing
+    to chain/confidence."""
+    baseline = _route("unpack it", {"machine": "AMD64"})
+    lit = _route("unpack this apk", {"machine": "AMD64"})
+    assert lit["recommendation"]["chain"] == baseline["recommendation"]["chain"]
+    assert lit["recommendation"]["confidence"] == \
+        baseline["recommendation"]["confidence"]
+    assert lit.get("capability_suggestions")
+
+
+def test_non_android_dispatch_has_no_suggestions():
+    assert not (_route("static overview of imports")
+                .get("capability_suggestions"))
+    assert not (_route("decode the string table", {"machine": "AMD64"})
+                .get("capability_suggestions"))
+    assert not (_route("").get("capability_suggestions"))
+
+
+# ---------------------------------------------------------------------------
+# CLI faces (stdout lighting): JSON + text
+# ---------------------------------------------------------------------------
+
+def test_route_cli_json_face_carries_suggestions():
+    r = _run_cli("--features", "{}", "--claim-text", REPRO_ZH, "--json")
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out.get("capability_suggestions"), out
+    blob = json.dumps(out, ensure_ascii=False)
+    assert any(t in blob for t in ANDROID_TOOLS)
+
+
+def test_route_cli_text_face_renders_lighting():
+    r = _run_cli("--features", "{}", "--claim-text", REPRO_ZH)
+    assert r.returncode == 0, r.stderr
+    assert "capability_suggestions" in r.stdout
+    assert any(t in r.stdout for t in ANDROID_TOOLS), r.stdout
+
+
+# ---------------------------------------------------------------------------
+# gate keyword derivation: android aliases join the tool-first keyword map
+# (lighting data — coverage, NOT new enforcement)
+# ---------------------------------------------------------------------------
+
+def test_android_aliases_in_gate_keyword_map():
+    kw = wbg._load_tool_index_keywords(wbg._SKILL_ROOT)
+    # provider names (derived from the registry's own provider: field)
+    assert kw.get("jadx") == "jadx-decompile"
+    assert kw.get("baksmali") == "baksmali-xref"
+    assert kw.get("apkid") == "apkid-prescan"
+    assert kw.get("gitnexus") == "gitnexus-query"
+    assert kw.get("dexdc") == "dexdc-decompile"
+    # distinctive CJK android-RE compounds
+    assert kw.get("反编译") == "jadx-decompile"
+    assert kw.get("加固") == "apkid-prescan"
+    assert kw.get("smali") == "baksmali-xref"
+    # pre-existing halves stay put (first-registered wins, unchanged)
+    assert kw.get("android") == "jadx-decompile"
+    assert kw.get("java-source") == "jadx-decompile"
+    assert kw.get("crypto") == "crypto-tool"
+    assert kw.get("ida") == "ida-decompile"
+
+
+def test_gate_map_keeps_generic_words_out():
+    """_TOOLFIRST_STOPWORDS discipline: generic prose never joins the gate
+    trigger set — ambiguous terms are route-side lighting ONLY."""
+    kw = wbg._load_tool_index_keywords(wbg._SKILL_ROOT)
+    for generic in ("app", "apk", "java", "加密", "登录", "tls", "okhttp",
+                    "frida", "xposed", "certificate", "network library",
+                    "login encryption"):
+        assert generic not in kw, generic
+
+
+def test_android_citing_dispatch_reaches_matched():
+    """The enrichment's purpose: a dispatch that RUNS a registered android
+    tool and CITES it has a compliant path — the #46 self-attestation lock
+    must not reappear for the android toolchain."""
+    ev = wbg._toolfirst_evaluate(
+        "use jadx for the java-source pass", "jadx-decompile")
+    assert ev["mode"] == "matched", ev
+    assert ev["tool"] == "jadx-decompile"
+    assert "jadx" in ev["keywords"]
+
+
+def test_verify_tool_catalog_resolves_android_citation(tmp_path):
+    """A done worker's `tool-catalog: jadx-decompile` must resolve (and a
+    fabricated name must not) — the #630 liveness proxy covers android."""
+    runs = tmp_path / "runs"
+    runs.mkdir()
+    (runs / "worker-status-android-ok.md").write_text(
+        "status: done\ntool-catalog: jadx-decompile\n", encoding="utf-8")
+    (runs / "worker-status-android-bad.md").write_text(
+        "status: done\ntool-catalog: totally-made-up-tool\n", encoding="utf-8")
+    violations = wbg.verify_tool_catalog(tmp_path)
+    assert len(violations) == 1
+    assert violations[0]["worker"] == "worker-status-android-bad"
+
+
+# ---------------------------------------------------------------------------
+# ZERO-enforcement red line (#54 owner ruling 不能强制) — pinned explicitly
+# ---------------------------------------------------------------------------
+
+def test_redline_android_dispatch_without_marker_still_passes():
+    """THE acceptance red line: an android-flavored dispatch WITHOUT a
+    tool-catalog marker still PASSES silently (no_match), exactly as today.
+    No new REJECT path may exist for android dispatches."""
+    ok, reason = wbg.check_tool_first(
+        {}, f"[T1 tools=grep] claim C-001 {REPRO_ZH}", "")
+    assert ok is True, f"ZERO new REJECT paths (#54): {reason}"
+    ev = wbg._toolfirst_evaluate(REPRO_ZH.lower(), None)
+    assert ev["mode"] == "no_match", ev
+
+
+def test_redline_english_variant_without_marker_still_passes():
+    ok, reason = wbg.check_tool_first(
+        {}, f"[T1 tools=grep] claim C-001 {REPRO_EN}", "")
+    assert ok is True, f"ZERO new REJECT paths (#54): {reason}"
+    ev = wbg._toolfirst_evaluate(REPRO_EN.lower(), None)
+    assert ev["mode"] == "no_match", ev
+
+
+def test_redline_existing_reject_semantics_unchanged():
+    """The pre-#54 faces fire exactly as before: keyword hit without marker
+    still rejects (existing semantics — only WHICH keywords are visible
+    changed), stopword discipline intact."""
+    ok, reason = wbg.check_tool_first({}, "decode the crypto layer", "")
+    assert ok is False
+    assert "tool-catalog" in reason
+    ok2, _msg = wbg.check_tool_first(
+        {}, "[T1 tools=grep] claim C-001 static overview of imports", "")
+    assert ok2, "stopword discipline must be unchanged"
+
+
+def test_redline_optout_still_honored_on_android_keyword_hit():
+    """The explicit `tool-catalog: none (reasoning: ...)` opt-out keeps
+    passing even when an android alias hit — the agent may always decline."""
+    ok, reason = wbg.check_tool_first(
+        {}, "反编译这个dex",
+        "tool-catalog: none (reasoning: sample is a stub, jadx adds nothing)")
+    assert ok is True, reason


### PR DESCRIPTION
## Summary

Android toolchain lighting (#54): semantic keyword aliases + rationale-bearing
suggestions — ZERO enforcement added (verified: gates file diff is 44
insertions, 0 deletions; enforcement vocabulary grep hits only comments).

- **route_capability.py**: 39 alias rows (16 strong / 23 weak) over the 4
  android capabilities — apk/加固/脱壳/smali/dex/jadx/反编译/签名校验/okhttp/
  frida/so库/native层/java加密/登录加密 + English equivalents. Weak aliases
  (tls/签名/hook-family) are anchor-gated so PE prose never false-lights.
  New `android_suggestions()` + text-face rendering block
  ("capability_suggestions (non-binding lighting)").
- **worker_budget_gates.py**: `_ANDROID_KEYWORD_ALIASES` data table +
  provider-name derivation in `_load_tool_index_keywords` (12 new distinctive
  keywords: 反编译/java源码/smali/加固/脱壳/加壳/jadx/baksmali/apkid/gitnexus/
  dexdc...); generic words (app/apk/java/加密) asserted absent to keep the
  #294 stopword discipline.
- **Rationale text** names the concrete tool + why ("APK 样本 → apkid-prescan
  先识别加固器，可省去盲扫"); suggestion shape stays `{capability, rationale}`
  (the #692 exact-keys pin holds).
- Live repro flipped: `route("分析这个APK的登录加密逻辑")` keeps the identical
  fallback chain but now lights `android:packer-fingerprint` +
  `android:java-source` on both JSON and text faces.

Closes #54

Milestone: v0.1.5 (milestone #1)

## Anti-orphan gate (REQUIRED)

- Added code: alias tables + suggestion emitters + 17 tests
  (tests/test_android_lighting_54.py).
- Code moved/deleted: none. `_toolfirst_evaluate`/`check_tool_first`
  byte-untouched; no new REJECT modes; both #54 repro dispatches without a
  marker still pass silently (pinned by test).

## Test plan

- [x] RED first: 7 failed pre-change (both live repros fired zero android)
- [x] GREEN: 17/17
- [x] Full suite: 5575 passed / 10 skipped / 0 failed
- [x] ruff clean; deploy --write + --verify OK (377 entries)
