### PR TITLE
fix: priority_ratio consumes mission value/difficulty feeds — VoI loop closes (#9)

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -603,7 +603,7 @@ files:
   - src: scripts/priority_ratio.py
     dest: .claude/scripts/priority_ratio.py
     kind: scaffold
-    sha256: 1fb21dd7a9dfa0153faf6eb280b80f3ab188568f7b788af6d0f82ab231bbde8c
+    sha256: d3c078bdde46d57fa43778c85a592381a57dc45c791135780100c6fd292e806a
   - src: scripts/progress_report.py
     dest: .claude/scripts/progress_report.py
     kind: scaffold

--- a/scripts/priority_ratio.py
+++ b/scripts/priority_ratio.py
@@ -33,6 +33,28 @@ discriminator groups) and results (writing facts); ranking is zero-LLM.
   replaces hand-edited ranking inputs / SendMessage verdict hacks);
   see SKILL.md "Value ordering".
 
+#9 dynamic data hookup (feeds that already exist on dev; score assembly
+  structure UNCHANGED — this is wiring, not redesign):
+  L(a) additionally carries the mission-learning signal the #823-P3 ledger
+    read already touches: headroom (1 − v_norm) × live slope gate
+    (d_slope_norm > 0, per-settlement-round rate, #10) × open-PQ linkage
+    (positive mission_gap). No ledger / flat accrual / converged mission →
+    0 contribution (graph leverage unchanged); rising V_m on an open PQ →
+    positive L (the exploration loop demonstrably pays).
+  D(a) scales by sample difficulty from evidence/difficulty.json (or the
+    task_spec ``difficulty:`` key — #15's two mount faces): multiplier
+    1 + 0.5·score, or the tier enum when no numeric score; clamped to the
+    D ceiling 1.0. Absent/unusable/foreign-schema → legacy D (absence is
+    never scored as difficulty, mirroring #15's gap rule).
+  N(a) counts method repetition from rows the #496 strategy-log read path
+    ALREADY returns (dispatch rows per claim, minus the rows its own
+    failure channel already counts — one signal, one channel, no double
+    counting). No new data plumbing; no dispatch history → byte-identical
+    pre-#9 novelty.
+  Every term records its feed state (Action.feeds: neutral reason when a
+  feed is absent, feed values when live). Fail-open everywhere: a corrupt
+  feed degrades to neutral, never to a crash or a faked signal.
+
 Usage:
   python priority_ratio.py <workspace> [--json]
 """
@@ -59,11 +81,20 @@ import yaml
 
 from status_defs import TERMINAL, IN_PROGRESS_STATUSES, SUSPENDED
 from kunglao_log import iter_jsonl  # noqa: E402  (#863 Family K single source)
+import tuition_curve  # noqa: E402  (#9: v_norm/d_slope helpers, single source)
 
 WEIGHTS = {"L": 0.45, "D": 0.30, "N": 0.25}
 TIER_COST = {1: 1.0, 2: 3.0, 3: 10.0}
 NOVELTY_BASE = 3  # 3 terminal facts in a category → N=0 (saturated)
 CAPABILITY_BONUS = 1.5  # #823 A3: multiplier for claims holding a validated capability card
+
+# #9 D-term difficulty hookup: the #15 calibrated score lifts the legacy
+# discriminator by up to +50% (a discriminating action is worth more on a
+# resistant sample); the tier enum is the fallback surface (score absent).
+DIFFICULTY_D_BOOST = 0.5
+DIFFICULTY_TIER_MULT = {"easy": 1.0, "medium": 1.15, "hard": 1.3, "max": 1.5}
+DIFFICULTY_SCHEMA = "difficulty-calibration/"
+DIFFICULTY_JSON = "evidence/difficulty.json"
 
 # #496: the strategy dispatch log (single writer: hooks/dispatch_gate.py on
 # its PASS path; the interface is deliberately optional — no marker, no row).
@@ -97,6 +128,18 @@ class EvidenceView:
     # unattempted→w); mission_active only with positive gaps.
     mission_gap: dict[str, float] = field(default_factory=dict)
     mission_active: bool = False
+    # #9 (always-on, appended — all default-None/empty → pre-#9 neutral):
+    # dynamic mission-value signals for the L term, from the SAME ledger
+    # read as mission_gap (#8 settlement face, #10 normalization).
+    mission_v_norm: float | None = None
+    mission_d_slope_norm: float | None = None
+    # #9 D term: #15 difficulty verdict (score continuous, tier enum).
+    difficulty_score: float | None = None
+    difficulty_tier: str | None = None
+    # #9 N term: non-failed dispatch rows per claim — the redundancy proxy
+    # rides the #496 strategy-log read path (no separate novelty ledger on
+    # dev); failure rows stay exclusively in strategy_failures.
+    claim_dispatch_repeats: dict[str, int] = field(default_factory=dict)
 
     @classmethod
     def from_workspace(cls, ws: Path) -> "EvidenceView":
@@ -148,31 +191,50 @@ class EvidenceView:
                 except (yaml.YAMLError, OSError):
                     pass  # fail-open: broken register must not break ranking
         caps, obstacles, covers = _scan_failure_artifacts(ws)
-        claim_strategy, strategy_failures = _load_strategy_view(ws, covers)
+        claim_strategy, strategy_failures, dispatch_repeats = \
+            _load_strategy_view(ws, covers)
         classes, overrides = load_value_weights(ws)
         prior_p = _resolve_prior_p(ws)
         mission_gap: dict[str, float] = {}
         mission_active = False
+        mission_v_norm: float | None = None
+        mission_d_slope_norm: float | None = None
         # #823-P3 (always-on since #51): mission gap weights from the欠账表
-        # (fail-open).
+        # (fail-open). #9: the same read now also yields the L-term value
+        # dynamics (v_norm / d_slope_norm, #10 single-source helpers).
         try:
             led_path = ws / "runs" / "mission_ledger.yaml"
             if led_path.exists():
                 led = yaml.safe_load(
                     led_path.read_text(encoding="utf-8")) or {}
-                beta = float(led.get("mission", {}).get("beta", 0.3))
-                for p in led.get("mission", {}).get("pqs", []):
+                mission = led.get("mission", {})
+                beta = float(mission.get("beta", 0.3))
+                pqs = mission.get("pqs", [])
+                for p in pqs:
                     w = float(p.get("weight", 1.0))
                     st = p.get("state")
                     mission_gap[str(p.get("id"))] = (
                         0.0 if st == "answered" else
                         (1.0 - beta) * w if st == "blocked" else w)
                 mission_active = any(v > 0 for v in mission_gap.values())
+                # #9: ledger PRESENT → the signals are defined even with an
+                # empty history (0.0/0.0 = no demonstrated accrual, a flat
+                # state — NOT the absent-feed state).
+                total_w = sum(float(p.get("weight", 1.0)) for p in pqs)
+                norm = tuition_curve._norm_series(mission.get("history"),
+                                                  total_w)
+                mission_v_norm = norm[-1] if norm else 0.0
+                mission_d_slope_norm = tuition_curve._slope(
+                    norm[-tuition_curve._WINDOW:]) if norm else 0.0
         except Exception:  # noqa: BLE001 — fail-open
             mission_gap, mission_active = {}, False
+            mission_v_norm, mission_d_slope_norm = None, None
+        difficulty_score, difficulty_tier = _load_difficulty_verdict(ws)
         return cls(frozenset(terminal_claims), verified, {}, lines,
                    caps, obstacles, strategy_failures, claim_strategy,
-                   classes, overrides, prior_p, mission_gap, mission_active)
+                   classes, overrides, prior_p, mission_gap, mission_active,
+                   mission_v_norm, mission_d_slope_norm,
+                   difficulty_score, difficulty_tier, dispatch_repeats)
 
 
 @dataclass(frozen=True)
@@ -191,8 +253,13 @@ class Action:
     cost: float
     weight: float = 1.0  # #759 H2 value multiplier (appended field — the pre-#759 construction shape is positionally compatible)
     gap_bucket: int = 0  # #823-P3: 1 = answers an open-PQ gap (leads the sort)
+    # #9: term → feed state ("feed live: <values>" / "feed absent: <reason>")
+    feeds: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
+        # feeds (#9) stay object-level diagnostics, NOT a json face key:
+        # consumers compare full to_dict() payloads across workspaces where
+        # feed STATES legitimately differ while scores do not.
         return {"claim_id": self.claim_id, "action": self.action,
                 "score": round(self.score, 3), "skill": self.skill,
                 "weight": round(self.weight, 3)}
@@ -355,8 +422,9 @@ def _scan_failure_artifacts(ws: Path) -> tuple[tuple[tuple[str, str], ...],
     return tuple(caps), tuple(obstacles), covers
 
 
-def _load_strategy_view(ws: Path, covers: dict[str, int]) -> tuple[dict[str, str], dict[str, int]]:
-    """Derive (claim_strategy, strategy_failures) from runs/strategy-log.jsonl.
+def _load_strategy_view(ws: Path, covers: dict[str, int]) -> tuple[dict[str, str], dict[str, int], dict[str, int]]:
+    """Derive (claim_strategy, strategy_failures, dispatch_repeats) from
+    runs/strategy-log.jsonl.
 
     claim_strategy: claim id -> strategy of its LATEST dispatch row.
     strategy_failures: strategy -> count of dispatch rows whose claim later
@@ -364,16 +432,23 @@ def _load_strategy_view(ws: Path, covers: dict[str, int]) -> tuple[dict[str, str
     taken at dispatch time (attempts semantics make timestamps redundant: a
     post-dispatch failure always re-records the analysis with a higher
     covers). Rows without a snapshot cannot be judged and are ignored for
-    failure counting. Missing/corrupt log -> ({}, {}) — opt-in interface."""
+    failure counting. Missing/corrupt log -> ({}, {}, {}) — opt-in interface.
+    #9: dispatch_repeats (claim -> row count) is the N-term method
+    repetition proxy — SAME rows, zero new plumbing, and rows already
+    counted as #496 failures are NOT re-counted (one signal, one channel:
+    failure repetition lives in strategy_failures; repeats owns redundancy
+    WITHOUT resolution).
+    """
     log = ws / Path(STRATEGY_LOG)
     if not log.is_file():
-        return {}, {}
+        return {}, {}, {}
     try:
         rows = log.read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError:
-        return {}, {}
+        return {}, {}, {}
     claim_strategy: dict[str, str] = {}
     failures: dict[str, int] = {}
+    repeats: dict[str, int] = {}
     for e in iter_jsonl(rows):
         if not isinstance(e, dict) or e.get("event") != "dispatch":
             continue
@@ -385,10 +460,12 @@ def _load_strategy_view(ws: Path, covers: dict[str, int]) -> tuple[dict[str, str
         try:
             snapshot = int(e.get("attempts_at_snapshot"))
         except (TypeError, ValueError):
-            continue
-        if covers.get(claim, 0) > snapshot:
+            snapshot = None
+        if snapshot is not None and covers.get(claim, 0) > snapshot:
             failures[strategy] = failures.get(strategy, 0) + 1
-    return claim_strategy, failures
+            continue  # failure repetition is the #496 channel's — not #9's
+        repeats[claim] = repeats.get(claim, 0) + 1  # #9: redundancy, no resolution
+    return claim_strategy, failures, repeats
 
 
 # #496: tool-family vocabulary for the capability card. A token maps a
@@ -601,6 +678,95 @@ def _resolve_prior_p(ws: Path) -> float:
         return 1.0
 
 
+def _difficulty_doc_from_spec(ws: Path) -> dict | None:
+    """#15's second mount face: the ``difficulty:`` key in task_spec.yaml."""
+    try:
+        sp = ws / "task_spec.yaml"
+        if not sp.exists():
+            return None
+        doc = (yaml.safe_load(sp.read_text(encoding="utf-8")) or {}).get(
+            "difficulty")
+    except (OSError, yaml.YAMLError):
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
+def _load_difficulty_verdict(ws: Path) -> tuple[float | None, str | None]:
+    """#9 D feed: (score∈[0,1], tier) from evidence/difficulty.json, falling
+    back to the task_spec ``difficulty:`` key (#15's two mount faces).
+
+    Fail-open: absent / unparsable / foreign-schema docs yield (None, None)
+    — a doc that is not the #15 verdict is NOT signal (absence is never
+    scored as difficulty, mirroring the #15 gap rule). The single-doc parse
+    delegates to kunglao_log.iter_jsonl (#863 Family K: this file carries
+    zero local json parse sites)."""
+    doc: object = None
+    try:
+        dp = ws / Path(DIFFICULTY_JSON)
+        if dp.exists():
+            text = dp.read_text(encoding="utf-8")
+            doc = next(iter_jsonl([text]), None)
+    except OSError:
+        doc = None
+    if not isinstance(doc, dict) or not str(
+            doc.get("schema", "")).startswith(DIFFICULTY_SCHEMA):
+        doc = _difficulty_doc_from_spec(ws)
+    if not isinstance(doc, dict) or not str(
+            doc.get("schema", "")).startswith(DIFFICULTY_SCHEMA):
+        return None, None
+    raw_score = doc.get("score")
+    score: float | None = None
+    if isinstance(raw_score, (int, float)) and not isinstance(raw_score, bool):
+        score = max(0.0, min(1.0, float(raw_score)))
+    tier = str(doc.get("tier") or "").strip().lower()
+    return score, (tier if tier in DIFFICULTY_TIER_MULT else None)
+
+
+def _difficulty_multiplier(evidence: EvidenceView) -> tuple[float, str]:
+    """#9 D hookup: difficulty verdict → mechanical multiplier on the legacy
+    discriminator (1 + 0.5·score, or the tier enum when no numeric score);
+    callers clamp D to its 1.0 ceiling. Returns (multiplier, feed state)."""
+    if evidence.difficulty_score is not None:
+        mult = 1.0 + DIFFICULTY_D_BOOST * evidence.difficulty_score
+        return (mult,
+                f"difficulty feed live: score={evidence.difficulty_score} "
+                f"tier={evidence.difficulty_tier} mult=×{round(mult, 3)}")
+    if evidence.difficulty_tier is not None:
+        mult = DIFFICULTY_TIER_MULT[evidence.difficulty_tier]
+        return (mult,
+                f"difficulty feed live: tier={evidence.difficulty_tier} "
+                f"(no numeric score) mult=×{mult}")
+    return (1.0,
+            "difficulty feed absent or unusable (no evidence/difficulty.json, "
+            "no task_spec difficulty) — legacy D")
+
+
+def _mission_leverage_factor(evidence: EvidenceView) -> tuple[float, str]:
+    """#9 L hookup: the mission-learning factor in [0,1] from the ledger the
+    #823-P3 read already touches.
+
+      factor = headroom (1 − v_norm) × live gate (d_slope_norm > 0)
+
+    Headroom closes the loop: a converged mission (v_norm→1) has no mission
+    learning left to pay for. The live gate keeps the signal honest: without
+    demonstrated per-round accrual (#10 d_slope_norm, per settlement round)
+    the L term contributes nothing — flat ≠ paying. Returns (factor, feed
+    state); ledger absent/unusable → (0.0, absent reason)."""
+    v, s = evidence.mission_v_norm, evidence.mission_d_slope_norm
+    if v is None or s is None:
+        return (0.0,
+                "mission feed absent or unusable (no runs/mission_ledger.yaml)"
+                " — graph leverage only")
+    if s <= 0:
+        return (0.0,
+                f"mission feed present but flat: v_norm={v} "
+                f"d_slope_norm={s} — no demonstrated accrual, mission L=0")
+    headroom = max(0.0, min(1.0, 1.0 - v))
+    return (headroom,
+            f"mission feed live: v_norm={v} d_slope_norm={s} "
+            f"headroom={round(headroom, 3)}")
+
+
 def priority_ratio(claims: list[dict], deps: dict, evidence: EvidenceView) -> list[Action]:
     """VoI proxy / cost ranking (purely mechanical, zero LLM).
 
@@ -647,17 +813,43 @@ def priority_ratio(claims: list[dict], deps: dict, evidence: EvidenceView) -> li
         lev_raw[cid] = sum(1 for d in rev_deps.get(cid, []) if d in open_ids)
     max_lev = max(lev_raw.values(), default=0)
 
+    # #9 feed states (claim-independent): mission factor gates the L term,
+    # the difficulty multiplier scales the D term.
+    m_factor, m_state = _mission_leverage_factor(evidence)
+    d_mult, d_state = _difficulty_multiplier(evidence)
+
     actions: list[Action] = []
     for c in candidates:
         cid = c["id"]
         action_cat = classify_action(c)
-        L = (lev_raw[cid] / max_lev) if max_lev else 0.0
-        D = _discriminator(c, active_groups)
+        # #9: graph leverage (unchanged) + mission-learning factor on the
+        # open-PQ linkage; clamp keeps L in [0,1]. No mission linkage → the
+        # mission factor contributes nothing to THIS claim.
+        L_graph = (lev_raw[cid] / max_lev) if max_lev else 0.0
+        pq = str(c.get("answers_question") or "").strip()
+        linkage = 1.0 if (pq and evidence.mission_gap.get(pq, 0.0) > 0.0) \
+            else 0.0
+        L = min(1.0, L_graph + m_factor * linkage)
+        l_state = m_state
+        if m_factor > 0.0 and linkage == 0.0:
+            l_state += "; claim not mission-linked (no open-PQ gap)"
+        # #9: difficulty lifts the legacy discriminator, clamped to the
+        # ceiling 1.0 (easy/no-feed mult is 1.0 → byte-identical legacy D).
+        D = min(1.0, _discriminator(c, active_groups) * d_mult)
         # #496: same-strategy historical failures join the novelty count
         # (opt-in — claims with no [strategy] dispatch history keep N intact)
         strat = evidence.claim_strategy.get(cid)
         s_fails = evidence.strategy_failures.get(strat, 0) if strat else 0
-        N = _novelty(action_cat, fact_counts, s_fails)
+        # #9: method repetition — dispatch rows per claim, riding the same
+        # #496 strategy-log read (no separate novelty ledger exists on dev;
+        # nothing new invented — empty rows → repeats 0 → pre-#9 N intact).
+        repeats = evidence.claim_dispatch_repeats.get(cid, 0)
+        N = _novelty(action_cat, fact_counts, s_fails + repeats)
+        n_state = (f"dispatch rows for claim={repeats} (strategy-log)"
+                   if repeats
+                   else "no dispatch history (runs/strategy-log.jsonl) — "
+                        "repetition proxy inert")
+        feeds = {"L": l_state, "D": d_state, "N": n_state}
         cost = action_cost(c)
         numerator = WEIGHTS["L"] * L + WEIGHTS["D"] * D + WEIGHTS["N"] * N
         # #759 H2: the user's structured worth ruling multiplies the final
@@ -675,17 +867,15 @@ def priority_ratio(claims: list[dict], deps: dict, evidence: EvidenceView) -> li
             bonus = CAPABILITY_BONUS
         # #823-P3: gap-hit bucket — claims answering an OPEN PQ gap lead the
         # ranking (缺口命中 > tier > VoI). No ledger data → bucket stays 0.
-        gap_bucket = 0
-        if evidence.mission_active:
-            pq = str(c.get("answers_question") or "").strip()
-            if pq and evidence.mission_gap.get(pq, 0.0) > 0.0:
-                gap_bucket = 1
+        # (#9: the same pq/linkage pair computed above for the L term.)
+        gap_bucket = 1 if (evidence.mission_active and linkage == 1.0) else 0
         score = round(numerator / cost_eff * weight * bonus, 3)
         actions.append(Action(
             claim_id=cid, action=action_cat, score=score, skill=None,
             tier=action_tier(c), attempts=int(c.get("promotion_attempts", 0)),
-            leverage=round(L, 3), discriminator=D, novelty=round(N, 3), cost=cost,
-            weight=weight, gap_bucket=gap_bucket,
+            leverage=round(L, 3), discriminator=round(D, 6),
+            novelty=round(N, 3), cost=cost,
+            weight=weight, gap_bucket=gap_bucket, feeds=feeds,
         ))
     # score tie within ε → lower cost wins (mechanical ruling, no LLM); then stable by claim_id.
     # #823-P3 (always-on since #51): gap-bucket leads; uniform buckets reduce

--- a/tests/test_priority_data_hookup_9.py
+++ b/tests/test_priority_data_hookup_9.py
@@ -1,0 +1,388 @@
+# -*- coding: utf-8 -*-
+"""tests/test_priority_data_hookup_9.py — #9 priority_ratio consumes the
+dynamic feeds that already exist on dev (mission_ledger / tuition V_m
+dynamics, difficulty_calibration, strategy-log dispatch rows).
+
+Issue #9: after #51 (L/D/N always-on), #8 (mission_ledger settlement) and
+#10 (v_norm / d_slope_norm), the SCORE still reads none of it — the L/D/N
+terms stay on their static graph/register inputs and the VoI exploration
+loop never closes (a converged mission ranks exactly like a fresh one).
+
+Pre-change behavior (pinned by the neutral-path tests below, citing the
+module docstring of priority_ratio.py on dev bd6dbdf):
+  L(a) = leverage: |downstream OPEN claims| normalized (claim_deps reverse
+         edges) — a claim with no dependents scored L=0.0 even when the
+         mission ledger showed live V_m accrual on the PQ it answers;
+  D(a) = discriminator: live competitor_group=1.0 / answers_question=0.5 /
+         else=0.2 — difficulty evidence was never read;
+  N(a) = 1 - min(1, (terminal facts in category + same-strategy failures)
+         / NOVELTY_BASE) — dispatch-row repetition was not counted.
+
+This suite pins: feeds flow in, missing feeds stay NEUTRAL with an explicit
+reason, and the score assembly formula is unchanged (structure preservation
+— data hookup, not algorithm redesign).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import priority_ratio as pr  # noqa: E402
+
+
+DIFF_DOC = {
+    "schema": "difficulty-calibration/1",
+    "tier": "max",
+    "score": 0.812,
+    "dominant_factor": "packer_present",
+    "factors": {}, "families": {},
+    "coverage": {"die": True, "apkid": True},
+    "thresholds": {"medium": 0.15, "hard": 0.4, "max": 0.65},
+    "notes": [],
+}
+
+
+def _claim(cid, status="OPEN", answers_question=None, competitor_group=None,
+           statement=""):
+    c = {"id": cid, "status": status, "evidence_tier_attempted": 0,
+         "promotion_attempts": 0, "statement": statement or cid}
+    if answers_question is not None:
+        c["answers_question"] = answers_question
+    if competitor_group is not None:
+        c["competitor_group"] = competitor_group
+    return c
+
+
+def _mk_ws(tmp_path, name="ws", claims=(), pqs=None, with_difficulty=False):
+    """Minimal workspace: register + PQ spec (+ optional difficulty mount)."""
+    ws = tmp_path / name
+    ws.mkdir()
+    (ws / "claim-register.yaml").write_text(
+        yaml.safe_dump({"claims": list(claims)}, allow_unicode=True),
+        encoding="utf-8")
+    (ws / "task_spec.yaml").write_text(
+        yaml.safe_dump({"primary_questions": pqs or {}}, allow_unicode=True),
+        encoding="utf-8")
+    if with_difficulty:
+        ev = ws / "evidence"
+        ev.mkdir()
+        (ev / "difficulty.json").write_text(json.dumps(DIFF_DOC), encoding="utf-8")
+    return ws
+
+
+def _seed_ledger(ws, settled: bool, rounds: int = 2):
+    """mission_ledger at init; when settled, PROVEN C-0 answers PQ-1 between
+    two value_m() calls → V_m history rises 0 -> 0.5 (2 PQs, Σw=2)."""
+    import mission_ledger as ml
+    ml.init(ws)
+    ml.value_m(ws)
+    if settled:
+        ml.update(ws)
+    for _ in range(rounds - 1):
+        ml.value_m(ws)
+
+
+# ---------- L <- mission value dynamics ----------
+
+def test_rising_vm_makes_leverage_positive(tmp_path):
+    """RED on dev: a claim answering an OPEN PQ in a ledger with RISING V_m
+    history scored L=0.0 (no claim_deps edges). After the hookup the L term
+    carries the mission-learning signal: headroom (1 - v_norm) x live slope
+    x open-PQ linkage > 0."""
+    claims = [_claim("C-0", status="PROVEN", answers_question="PQ-1"),
+              _claim("C-1", answers_question="PQ-2")]
+    ws = _mk_ws(tmp_path, claims=claims,
+                pqs={"PQ-1": "which family?", "PQ-2": "which c2?"})
+    _seed_ledger(ws, settled=True)
+    ev = pr.EvidenceView.from_workspace(ws)
+    assert ev.mission_v_norm == 0.5, "fixture sanity: one of two PQs settled"
+    assert ev.mission_d_slope_norm > 0, "fixture sanity: V_m rising"
+    out = pr.priority_ratio(claims, {"depends_on": {}}, ev)
+    by = {a.claim_id: a for a in out}
+    assert by["C-1"].leverage > 0.0, (
+        "rising V_m + open-PQ linkage must lift the L term above the "
+        "pre-change graph-only 0.0")
+    # structure preserved: the Action still carries the combined L and the
+    # score formula identity holds over the FINAL per-term values (cost_eff
+    # = cost / prior — the #823 feed-side term from_workspace resolves)
+    a = by["C-1"]
+    cost_eff = a.cost / max(ev.prior_p_complete, 0.05)
+    assert a.score == round(
+        (0.45 * a.leverage + 0.30 * a.discriminator + 0.25 * a.novelty)
+        / cost_eff, 3)
+    assert "mission" in (a.feeds or {}).get("L", "")
+
+
+def test_converged_mission_closes_L(tmp_path):
+    """VoI loop closure: v_norm=1 (all PQs answered) -> headroom 0 -> the
+    mission contribution to L collapses to 0 even while slope was live."""
+    claims = [_claim("C-0", status="PROVEN", answers_question="PQ-1"),
+              _claim("C-1", status="PROVEN", answers_question="PQ-2"),
+              _claim("C-2", answers_question="PQ-2")]
+    ws = _mk_ws(tmp_path, claims=claims,
+                pqs={"PQ-1": "which family?", "PQ-2": "which c2?"})
+    import mission_ledger as ml
+    ml.init(ws)
+    ml.value_m(ws)
+    ml.update(ws)  # both PQs answered
+    ml.value_m(ws)
+    ev = pr.EvidenceView.from_workspace(ws)
+    out = pr.priority_ratio(claims, {"depends_on": {}}, ev)
+    by = {a.claim_id: a for a in out}
+    assert ev.mission_v_norm == 1.0
+    assert by["C-2"].leverage == 0.0, "converged mission must not re-inflate L"
+
+
+def test_flat_vm_keeps_L_neutral(tmp_path):
+    """Ledger present but zero accrual (flat history) -> no demonstrated
+    learning -> the mission contribution stays 0 (and the reason says so)."""
+    claims = [_claim("C-0", status="PROVEN", answers_question="PQ-1"),
+              _claim("C-1", answers_question="PQ-2")]
+    ws = _mk_ws(tmp_path, claims=claims,
+                pqs={"PQ-1": "which family?", "PQ-2": "which c2?"})
+    import mission_ledger as ml
+    ml.init(ws)
+    ml.value_m(ws)
+    ml.value_m(ws)  # flat: two zero points
+    ev = pr.EvidenceView.from_workspace(ws)
+    out = pr.priority_ratio(claims, {"depends_on": {}}, ev)
+    a = out[0]
+    assert a.leverage == 0.0
+    assert "flat" in (a.feeds or {}).get("L", "")
+
+
+# ---------- D <- difficulty evidence ----------
+
+def test_difficulty_max_reflects_in_discriminator(tmp_path):
+    """RED on dev: difficulty.json tier=max left D at the legacy 0.2 floor.
+    After the hookup the calibrated score lifts D mechanically (x
+    1 + 0.5*score), clamped to the D ceiling 1.0."""
+    claims = [_claim("C-1", statement="generic recon")]
+    ws = _mk_ws(tmp_path, claims=claims, with_difficulty=True)
+    ev = pr.EvidenceView.from_workspace(ws)
+    assert ev.difficulty_tier == "max" and ev.difficulty_score == 0.812
+    out = pr.priority_ratio(claims, {"depends_on": {}}, ev)
+    a = out[0]
+    assert a.discriminator > 0.2, "tier=max must lift D above the legacy base"
+    assert round(a.discriminator, 6) == round(0.2 * (1 + 0.5 * 0.812), 6)
+    assert "difficulty" in (a.feeds or {}).get("D", "")
+
+
+def test_difficulty_tier_only_doc_fallback(tmp_path):
+    """A difficulty doc with a tier but no numeric score still maps (tier
+    enum surface: easy 1.0 / medium 1.15 / hard 1.3 / max 1.5)."""
+    claims = [_claim("C-1")]
+    ws = _mk_ws(tmp_path, claims=claims)
+    ev_dir = ws / "evidence"
+    ev_dir.mkdir()
+    doc = dict(DIFF_DOC)
+    doc.pop("score")
+    (ev_dir / "difficulty.json").write_text(json.dumps(doc), encoding="utf-8")
+    ev = pr.EvidenceView.from_workspace(ws)
+    out = pr.priority_ratio(claims, {"depends_on": {}}, ev)
+    assert round(out[0].discriminator, 6) == round(0.2 * 1.5, 6)
+
+
+def test_difficulty_via_task_spec_mount(tmp_path):
+    """#15's second face: the ``difficulty:`` key mounted in task_spec.yaml
+    feeds D when evidence/difficulty.json is absent."""
+    claims = [_claim("C-1")]
+    ws = _mk_ws(tmp_path, claims=claims)
+    (ws / "task_spec.yaml").write_text(
+        yaml.safe_dump({"primary_questions": {},
+                        "difficulty": DIFF_DOC}, allow_unicode=True),
+        encoding="utf-8")
+    ev = pr.EvidenceView.from_workspace(ws)
+    out = pr.priority_ratio(claims, {"depends_on": {}}, ev)
+    assert out[0].discriminator > 0.2
+
+
+# ---------- N <- dispatch-row repetition (existing strategy-log feed) ----------
+
+def test_dispatch_repetition_damps_novelty(tmp_path):
+    """RED on dev: repeated same-strategy dispatch rows for a claim left N
+    at 1.0. After the hookup the rows the strategy-log ALREADY carries
+    (#496 read path, no new plumbing) count as method repetition."""
+    claims = [_claim("C-1", statement="generic recon")]
+    ws = _mk_ws(tmp_path, claims=claims)
+    runs = ws / "runs"
+    runs.mkdir()
+    rows = [{"event": "dispatch", "strategy": "static", "claim": "C-1",
+             "attempts_at_snapshot": 0},
+            {"event": "dispatch", "strategy": "static", "claim": "C-1",
+             "attempts_at_snapshot": 1}]
+    (runs / "strategy-log.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    ev = pr.EvidenceView.from_workspace(ws)
+    out = pr.priority_ratio(claims, {"depends_on": {}}, ev)
+    a = out[0]
+    assert ev.claim_dispatch_repeats == {"C-1": 2}
+    assert a.novelty == round(1.0 - min(1.0, 2 / pr.NOVELTY_BASE), 3), (
+        "two dispatch rows for the claim must damp N by 2/NOVELTY_BASE")
+    fresh = pr.EvidenceView()
+    assert pr.priority_ratio(claims, {"depends_on": {}}, fresh)[0].novelty == 1.0
+
+
+def test_failed_rows_not_double_counted_in_novelty(tmp_path):
+    """One signal, one channel: dispatch rows already counted by the #496
+    failure channel (covers > snapshot) are NOT re-counted as #9 repeats —
+    N keeps the pinned 2-failures arithmetic (1/3, not 0)."""
+    claims = [_claim("C-1", statement="generic recon")]
+    ws = _mk_ws(tmp_path, claims=claims)
+    runs = ws / "runs"
+    runs.mkdir()
+    rows = [{"event": "dispatch", "strategy": "static", "claim": "C-1",
+             "attempts_at_snapshot": 0},
+            {"event": "dispatch", "strategy": "static", "claim": "C-1",
+             "attempts_at_snapshot": 1}]
+    (runs / "strategy-log.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    analyses = ws / "analyses"
+    analyses.mkdir()
+    # covers_attempt=2 > both snapshots -> both rows are #496 failures
+    (analyses / "failure-C-1.yaml").write_text(
+        yaml.safe_dump({"claim": "C-1", "covers_attempt": 2,
+                        "validated_capability": "", "identified_obstacle": ""}),
+        encoding="utf-8")
+    ev = pr.EvidenceView.from_workspace(ws)
+    assert ev.strategy_failures == {"static": 2}
+    assert ev.claim_dispatch_repeats == {}, "failed rows are not #9 repeats"
+    a = pr.priority_ratio(claims, {"depends_on": {}}, ev)[0]
+    assert a.novelty == round(1.0 - min(1.0, 2 / pr.NOVELTY_BASE), 3)
+
+
+# ---------- neutral fallbacks / regression ----------
+
+def test_no_feeds_terms_neutral_and_score_unchanged():
+    """No ledger, no difficulty, no dispatch rows -> every term takes the
+    documented pre-change value, the formula identity holds byte-identical,
+    and each term records an explicit neutral reason."""
+    claims = [_claim("HUB"), _claim("L-1"), _claim("L-2")]
+    deps = {"depends_on": {"L-1": ["HUB"], "L-2": ["HUB"]}}
+    ev = pr.EvidenceView()  # direct construction == no feeds anywhere
+    out = pr.priority_ratio(claims, deps, ev)
+    by = {a.claim_id: a for a in out}
+    hub = by["HUB"]
+    assert hub.leverage == 1.0, "graph-only leverage unchanged"
+    assert hub.discriminator == 0.2 and hub.novelty == 1.0
+    assert hub.score == round(
+        (0.45 * 1.0 + 0.30 * 0.2 + 0.25 * 1.0) / hub.cost, 3)
+    feeds = hub.feeds or {}
+    assert "graph leverage only" in feeds.get("L", "")
+    assert "difficulty feed absent" in feeds.get("D", "")
+    assert "dispatch" in feeds.get("N", "")
+    # feeds are object-level diagnostics — the --json face (to_dict) keeps
+    # its pre-#9 key set (full-payload equality across workspaces, qtable p3)
+    assert set(hub.to_dict()) == {"claim_id", "action", "score", "skill",
+                                  "weight"}
+
+
+def test_neutral_reasons_on_bare_workspace(tmp_path):
+    """from_workspace over a workspace with none of the feeds -> neutral
+    terms + reasons (and the pre-change score, regression-pinned)."""
+    claims = [_claim("C-1", statement="generic recon")]
+    ws = _mk_ws(tmp_path, claims=claims)
+    ev = pr.EvidenceView.from_workspace(ws)
+    assert ev.mission_v_norm is None and ev.mission_d_slope_norm is None
+    assert ev.difficulty_tier is None and ev.difficulty_score is None
+    out = pr.priority_ratio(claims, {"depends_on": {}}, ev)
+    a = out[0]
+    # pre-change values, byte-identical: claim has no answers_question here
+    assert (a.leverage, a.discriminator, a.novelty) == (0.0, 0.2, 1.0)
+    cost_eff = a.cost / max(ev.prior_p_complete, 0.05)  # #823 prior feed
+    assert a.score == round((0.30 * 0.2 + 0.25 * 1.0) / cost_eff, 3)
+    feeds = a.feeds or {}
+    assert "absent" in feeds.get("L", "") and "absent" in feeds.get("D", "")
+
+
+def test_no_ledger_no_crash(tmp_path):
+    """No runs/ dir at all -> from_workspace must not raise and the ranking
+    must stay fully neutral (fail-open discipline)."""
+    ws = tmp_path / "bare"
+    ws.mkdir()
+    (ws / "claim-register.yaml").write_text(
+        yaml.safe_dump({"claims": [_claim("C-1")]}, allow_unicode=True),
+        encoding="utf-8")
+    ev = pr.EvidenceView.from_workspace(ws)
+    out = pr.priority_ratio([_claim("C-1")], {"depends_on": {}}, ev)
+    assert len(out) == 1
+    assert ev.mission_active is False
+    assert ev.mission_v_norm is None
+
+
+def test_corrupt_feeds_fail_open(tmp_path):
+    """Garbage difficulty.json + corrupt ledger yaml -> neutral, not crash,
+    not faked signal."""
+    claims = [_claim("C-1")]
+    ws = _mk_ws(tmp_path, claims=claims, pqs={"PQ-1": "q"})
+    (ws / "runs").mkdir()
+    (ws / "runs" / "mission_ledger.yaml").write_text(
+        "{not: [valid: yaml", encoding="utf-8")
+    evd = ws / "evidence"
+    evd.mkdir()
+    (evd / "difficulty.json").write_text("<<<garbage>>>", encoding="utf-8")
+    ev = pr.EvidenceView.from_workspace(ws)
+    out = pr.priority_ratio(claims, {"depends_on": {}}, ev)
+    a = out[0]
+    assert (a.leverage, a.discriminator, a.novelty) == (0.0, 0.2, 1.0)
+
+
+def test_wrong_schema_difficulty_ignored(tmp_path):
+    """A difficulty file that is not the #15 schema is NOT signal (never
+    scored as difficulty) -> D stays legacy."""
+    claims = [_claim("C-1")]
+    ws = _mk_ws(tmp_path, claims=claims)
+    evd = ws / "evidence"
+    evd.mkdir()
+    (evd / "difficulty.json").write_text(
+        json.dumps({"tier": "max", "score": 0.9}), encoding="utf-8")
+    ev = pr.EvidenceView.from_workspace(ws)
+    out = pr.priority_ratio(claims, {"depends_on": {}}, ev)
+    assert out[0].discriminator == 0.2
+
+
+# ---------- score differentiation (the issue's actual complaint) ----------
+
+def test_converging_vs_flat_workspaces_different_top_scores(tmp_path):
+    """Two synthetic workspaces identical except for ledger dynamics: the
+    converging one (rising V_m) must outrank the flat one — the score stops
+    being flat across mission states."""
+    claims = [_claim("C-0", status="PROVEN", answers_question="PQ-1"),
+              _claim("C-1", answers_question="PQ-2", statement="generic recon")]
+    pqs = {"PQ-1": "which family?", "PQ-2": "which c2?"}
+    ws_conv = _mk_ws(tmp_path, name="conv", claims=claims, pqs=pqs)
+    ws_flat = _mk_ws(tmp_path, name="flat", claims=claims, pqs=pqs)
+    _seed_ledger(ws_conv, settled=True)
+    import mission_ledger as ml
+    ml.init(ws_flat)
+    ml.value_m(ws_flat)
+    ml.value_m(ws_flat)
+    ev_conv = pr.EvidenceView.from_workspace(ws_conv)
+    ev_flat = pr.EvidenceView.from_workspace(ws_flat)
+    top_conv = pr.priority_ratio(claims, {"depends_on": {}}, ev_conv)[0]
+    top_flat = pr.priority_ratio(claims, {"depends_on": {}}, ev_flat)[0]
+    assert top_conv.claim_id == top_flat.claim_id == "C-1"
+    assert top_conv.score > top_flat.score, (
+        "converging mission must outrank a flat one — the VoI score must "
+        "differentiate on ledger dynamics")
+
+
+def test_difficulty_lifts_rank_between_identical_workspaces(tmp_path):
+    """Same workspace except difficulty mount -> the max-difficulty one ranks
+    its claim higher (D channel differentiates)."""
+    claims = [_claim("C-1", statement="generic recon")]
+    pqs = {"PQ-1": "q"}
+    ws_plain = _mk_ws(tmp_path, name="plain", claims=claims, pqs=pqs)
+    ws_hard = _mk_ws(tmp_path, name="hard", claims=claims, pqs=pqs,
+                     with_difficulty=True)
+    ev_p = pr.EvidenceView.from_workspace(ws_plain)
+    ev_h = pr.EvidenceView.from_workspace(ws_hard)
+    s_p = pr.priority_ratio(claims, {"depends_on": {}}, ev_p)[0].score
+    s_h = pr.priority_ratio(claims, {"depends_on": {}}, ev_h)[0].score
+    assert s_h > s_p


### PR DESCRIPTION
## Summary

priority_ratio now consumes the mission value/difficulty feeds — the VoI
exploration loop closes (#9). Score structure unchanged (same formula
weights); this is data hookup, not redesign.

| Term | Feed | Fallback |
|---|---|---|
| L | mission headroom (1−v_norm) × live gate (d_slope_norm>0) × open-PQ linkage; v_norm/slope via tuition_curve single source | no ledger / flat history / converged → factor 0, leverage unchanged |
| D | evidence/difficulty.json → task_spec `difficulty:` fallback (#15's two mount faces); multiplier 1+0.5·score, tier enum fallback | absent/foreign schema → legacy D (0.2/0.5/1.0) |
| N | non-failed dispatch rows per claim via the #496 strategy-log read (channel separation: failures stay #496's) | no dispatch history → byte-identical pre-#9 N |

Diagnostics: `Action.feeds` records per-term feed state ("live: ..." /
"absent: reason") object-level only. End-to-end CLI: feeds visible in
ranking (L=0.5 mission-live; D=0.703 on tier=max); kunglao-decide dispatch
path unbroken.

Closes #9

Milestone: v0.1.5 (milestone #1)

## Anti-orphan gate (REQUIRED)

- Added code: `_mission_leverage_factor`, `_load_difficulty_verdict`,
  `_difficulty_multiplier`, `_load_strategy_view` third return, feeds
  channel, 15 tests (tests/test_priority_data_hookup_9.py).
- Code moved/deleted: none. Score formula weights and assembly unchanged.

## Test plan

- [x] RED first: 12/14 new tests failed pre-change (2 fail-open regression
      guards green on both sides)
- [x] Three real interaction regressions found and fixed (N/#496 channel
      separation, Family K delegation, feeds leakage into to_dict)
- [x] Final full suite: 5573 passed / 10 skipped / 0 failed
- [x] ruff clean; deploy --write + --verify OK (377 entries)
