### PR TITLE
feat: sub-PQ progress granularity — weighted claim credit + difficulty damping (#14)

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -539,7 +539,7 @@ files:
   - src: scripts/mission_ledger.py
     dest: .claude/scripts/mission_ledger.py
     kind: scaffold
-    sha256: 89fa24ee9f81bd628df9cbd6147cbcaf6191d25819f6adc51a35559475d073b8
+    sha256: fb8e7ba15286f7e5f8b9156f7b622c8989d910776da61c4849b2b14304ec3374
   - src: scripts/mission_stall.py
     dest: .claude/scripts/mission_stall.py
     kind: scaffold
@@ -607,7 +607,7 @@ files:
   - src: scripts/progress_report.py
     dest: .claude/scripts/progress_report.py
     kind: scaffold
-    sha256: cb7e8b74c67a24afab4678e667fdad4077628a2450f7a786ebeb5bf31acbdceb
+    sha256: 0118d4712ff28d1cc8c9065ec8663698d2db2830746cb5baa6768871121ff45b
   - src: scripts/provenance_gate.py
     dest: .claude/scripts/provenance_gate.py
     kind: scaffold
@@ -783,7 +783,7 @@ files:
   - src: scripts/tuition_curve.py
     dest: .claude/scripts/tuition_curve.py
     kind: scaffold
-    sha256: 55691fb07f5aab12d8e37e7577994f825dafe71cc3e4f8bed3b785f50b883a9a
+    sha256: e7074d625c829a9e202f3ce7e3100da403157672ae9eae2c17f3bd3c11d3af1d
   - src: scripts/tuition_refit.py
     dest: .claude/scripts/tuition_refit.py
     kind: scaffold

--- a/scripts/mission_ledger.py
+++ b/scripts/mission_ledger.py
@@ -23,6 +23,25 @@ _TERMINAL_STAMPED = {"PROVEN"}
 
 
 from harness_common import utc_now_z as _utc_now  # #863 Family F: single source (was a local def)
+from harness_common import utc_now  # #14 IN_PROGRESS freshness clock (claim_expiry-aligned)
+from status_defs import PARTIAL_STATUSES as _PARTIAL_STATUSES  # #14 single source (#34)
+from status_defs import IN_PROGRESS_STATUSES as _IN_PROGRESS_STATUSES
+
+
+# ---- #14 sub-PQ progress granularity ---------------------------------------
+# Per-claim credit weights — POLICY constants (values are tunable, not law);
+# each carries its one-line rationale.
+CREDIT_TERMINAL = 1.0    # PROVEN/VERIFIED settled with stamped evidence — full credit.
+CREDIT_PARTIAL = 0.5     # PARTIALLY-VERIFIED: evidence, no independent verification — half.
+CREDIT_ACTIVE = 0.25     # IN_PROGRESS with recent activity: work in flight — quarter.
+CREDIT_OPEN = 0.0        # OPEN / untouched in-flight: no movement — credit nothing.
+ACTIVE_FRESH_HOURS = 24  # "recent" = claim_expiry stale window; past it, in-flight work is dead.
+DAMP_HARD = 0.75         # hard tier: damp 25% — an open PQ on hard hides real remaining work.
+DAMP_MAX = 0.5           # max tier: strongest damping — max open PQs overstate the most.
+DAMP_NONE = 1.0          # easy/medium/unknown/missing: no damping (absence ≠ difficulty, #15).
+# settlement-family terminals; others stay 0.0 (PROVEN-only settlement, #69).
+_CREDIT_FULL = frozenset({"PROVEN", "VERIFIED"})
+_BAR_WIDTH = 10          # progress_report --progress bar cells per PQ row.
 
 
 def _parse_pqs(task_spec: dict) -> list[dict]:
@@ -153,7 +172,128 @@ def mark_blocked(ws, pq_id: str, blocker: str, wake: str) -> dict:
     return led
 
 
-def value_m(ws) -> dict:
+def _claim_last_activity(claim: dict):
+    """Single source: claim_expiry.last_activity_for (same field order); lazy
+    import keeps mission_ledger importable without the telemetry chain."""
+    from claim_expiry import last_activity_for
+    return last_activity_for(claim or {})
+
+
+def claim_credit(claim: dict, now=None) -> float:
+    """#14 per-claim credit ladder (pure; constants above carry the rationale).
+
+    PROVEN/VERIFIED → 1.0; PARTIALLY-VERIFIED family → 0.5; IN_PROGRESS with
+    recent (or unknown-age) worker activity → 0.25; everything else → 0.0.
+    Unknown activity counts as fresh (claim_expiry precedent: unknown age is
+    never staleness); other terminal statuses credit 0.0 because settlement
+    authority is PROVEN-only (PR #69) — understates rather than overstates.
+    """
+    st = ((claim or {}).get("status") or "").upper()
+    if st in _CREDIT_FULL:
+        return CREDIT_TERMINAL
+    if st in _PARTIAL_STATUSES:
+        return CREDIT_PARTIAL
+    if st in _IN_PROGRESS_STATUSES:
+        last = _claim_last_activity(claim)
+        if last is None:
+            return CREDIT_ACTIVE
+        ref = now or utc_now()
+        age_h = (ref - last).total_seconds() / 3600.0
+        if age_h <= ACTIVE_FRESH_HOURS:
+            return CREDIT_ACTIVE
+    return CREDIT_OPEN
+
+
+def _damping_for(tier: str | None) -> float:
+    """#14 difficulty damping: only hard/max damp; missing/unknown → none."""
+    return {"hard": DAMP_HARD, "max": DAMP_MAX}.get(
+        (tier or "").lower(), DAMP_NONE)
+
+
+def pq_progress(pq: dict, claims: list, now=None,
+                tier: str | None = None) -> dict:
+    """#14 sub-PQ progress (pure, no IO).
+
+    progress = max(1.0 if answered else 0.0, credit / max(1, claim_count)
+    × damping). Settlement (state answered, PR #69) stays authoritative at
+    exactly 1.0 and is never damped; unresolved PQs earn fractional credit
+    from their linked claims (answers_question == pq id) — edge claims with
+    no link stay out (the #823 anti-stupid rule, extended). Damping applies
+    ONLY to the unresolved fraction on hard/max tiers so remaining work is
+    understated, not overstated; missing difficulty → undamped.
+    """
+    answered = pq.get("state") == "answered"
+    linked = [c for c in (claims or [])
+              if str(c.get("answers_question") or "") == str(pq.get("id"))]
+    credit = sum(claim_credit(c, now) for c in linked)
+    frac = credit / max(1, len(linked))
+    damping = DAMP_NONE if answered else _damping_for(tier)
+    progress = min(max(1.0 if answered else 0.0, frac * damping), 1.0)
+    return {"progress": round(progress, 6), "credit": round(credit, 6),
+            "claim_count": len(linked), "damping": damping,
+            "damped": damping != DAMP_NONE}
+
+
+def read_difficulty_tier(ws) -> str | None:
+    """Difficulty tier for #14 damping: evidence/difficulty.json first, then
+    the ``difficulty:`` key difficulty_calibration.mount() copies into
+    task_spec.yaml (#16 open-loop contract, both mounts canonical). Missing,
+    unreadable, or non-mapping → None (no damping; absence is never scored
+    as difficulty — #15 gap rule)."""
+    ws = Path(ws)
+    doc = None
+    p = ws / "evidence" / "difficulty.json"
+    if p.exists():
+        try:
+            doc = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            doc = None
+    if not isinstance(doc, dict):
+        try:
+            spec = (yaml.safe_load(
+                (ws / "task_spec.yaml").read_text(encoding="utf-8")) or {})
+        except (OSError, yaml.YAMLError):
+            return None
+        doc = spec.get("difficulty") if isinstance(spec, dict) else None
+    tier = doc.get("tier") if isinstance(doc, dict) else None
+    return str(tier) if tier else None
+
+
+def progress_face(ws, now=None) -> dict:
+    """#14 read-only progress face (no history append, no ledger write).
+
+    {"progress_fraction": Σw·progress/Σw ∈ [0,1] (Σw<=0 → 0.0),
+     "per_pq": [{id, state, progress, credit, claim_count, damping,
+                 damped, weight}]}. Never raises on a missing claim register
+    or difficulty evidence — those degrade to zero-credit / undamped.
+    """
+    led = load(ws)
+    pqs = led.get("mission", {}).get("pqs", [])
+    reg = Path(ws) / "claim-register.yaml"
+    claims = []
+    if reg.exists():
+        try:
+            claims = ((yaml.safe_load(reg.read_text(encoding="utf-8"))
+                       or {}).get("claims")) or []
+        except yaml.YAMLError:
+            claims = []
+    tier = read_difficulty_tier(ws)
+    rows = []
+    total_w = 0.0
+    weighted = 0.0
+    for p in pqs:
+        w = float(p.get("weight", 1.0))
+        row = pq_progress(p, claims, now=now, tier=tier)
+        rows.append(dict(id=p.get("id"), state=p.get("state"),
+                         weight=w, **row))
+        total_w += w
+        weighted += w * row["progress"]
+    return {"progress_fraction":
+            round(weighted / total_w, 6) if total_w > 0 else 0.0,
+            "per_pq": rows}
+
+
+def value_m(ws, now=None) -> dict:
     """V_m + A_t。history 只由此函数追加（增量结算即时入账）。
 
     #10 归一化（additive，raw 字段原样保留）：
@@ -164,12 +304,30 @@ def value_m(ws) -> dict:
     单位语义：密度按结算轮计——一次 value_m() 调用 = 一条 history 点 =
     一轮；全程无 wall-clock 参与（墙钟 ETA 由 rho_checkpoint.eta_min /
     statusline tick 面单独承载，不与 V_m 混用）。
+    #14 sub-PQ 进度（additive，raw 字段原样保留）：新增顶层
+    progress_fraction（Σw·progress/Σw）与 per_pq_progress 列表
+    （每行 id/state/weight/progress/credit/claim_count/damping/damped）。
+    per_pq 行保持 #10 原样投影（byte-identical 守卫在
+    test_vm_normalization_10）——进度绝不写进 raw 面；V_m/A_t 数学原样
+    不动——欠账结算仍是唯一权威；``now`` 仅参与 IN_PROGRESS 新鲜度
+    分类，不入 V_m 单位。
     """
     led = load(ws)
     beta = float(led.get("mission", {}).get("beta", BETA))
     pqs = led.get("mission", {}).get("pqs", [])
+    tier = read_difficulty_tier(ws)
+    reg = Path(ws) / "claim-register.yaml"
+    claims = []
+    if reg.exists():
+        try:
+            claims = ((yaml.safe_load(reg.read_text(encoding="utf-8"))
+                       or {}).get("claims")) or []
+        except yaml.YAMLError:
+            claims = []
     v_m = 0.0
     total_w = 0.0
+    weighted_progress = 0.0
+    pq_rows = []
     per_pq = {}
     for p in pqs:
         w = float(p.get("weight", 1.0))
@@ -179,8 +337,13 @@ def value_m(ws) -> dict:
         contrib = w * cov if st == "answered" else (
             beta * w if st == "blocked" else 0.0)
         v_m += contrib
+        row = pq_progress(p, claims, now=now, tier=tier)
+        weighted_progress += w * row["progress"]
+        pq_rows.append(dict(id=p.get("id"), state=st, weight=w, **row))
         per_pq[str(p.get("id"))] = {"state": st,
                                     "contrib": round(contrib, 6)}
+    progress_fraction = (round(weighted_progress / total_w, 6)
+                         if total_w > 0 else 0.0)
     v_norm = max(0.0, min(1.0, v_m / total_w)) if total_w > 0 else 0.0
     hist = led.get("mission", {}).get("history") or []
     prev = float(hist[-1].get("v_m", 0.0)) if hist else 0.0
@@ -201,6 +364,8 @@ def value_m(ws) -> dict:
     return {"v_m": round(v_m, 6), "prev_v_m": prev, "a_t": round(a_t, 6),
             "v_norm": round(v_norm, 6), "a_t_norm": round(a_t_norm, 6),
             "total_weight": round(total_w, 6),
+            "progress_fraction": progress_fraction,
+            "per_pq_progress": pq_rows,
             "per_pq": per_pq, "answered": n_answered,
             "blocked": n_blocked, "unattempted": n_unattempted}
 
@@ -219,6 +384,8 @@ def emit_snapshot(ws, epoch: int | None = None, arm: str | None = None,
             # #10 additive: normalized value + per-round normalized delta
             "v_norm": val["v_norm"], "a_t_norm": val["a_t_norm"],
             "total_weight": val["total_weight"],
+            # #14 additive: sub-PQ progress aggregate (see value_m)
+            "progress_fraction": val["progress_fraction"],
         }, ensure_ascii=False)
         kunglao_log.emit(ws, "mission_ledger", "mission_snapshot",
                          detail=detail, arm=arm, epoch=epoch,

--- a/scripts/progress_report.py
+++ b/scripts/progress_report.py
@@ -17,6 +17,7 @@ Output is a markdown block suitable for both human eyes AND CI log capture.
 
 Usage:
   python progress_report.py <workspace>
+  python progress_report.py <workspace> --progress   # issue #14 sub-PQ bars
 """
 from __future__ import annotations
 
@@ -94,6 +95,35 @@ def _count_anomaly_notes(workspace: Path) -> int:
         return 0
 
 
+def progress_face_text(workspace: Path) -> str:
+    """#14 sub-PQ progress face: one bar per PQ from mission_ledger's
+    weighted-credit + difficulty-damped model. Read-only; a workspace with
+    no mission ledger (init never run) prints a hint and renders nothing —
+    it must not crash (empty-workspace contract)."""
+    led_rel = workspace / "runs" / "mission_ledger.yaml"
+    if not led_rel.exists():
+        return ("## Mission progress: ledger not initialized "
+                "(runs/mission_ledger.yaml missing — run mission_ledger.init)")
+    import mission_ledger
+    face = mission_ledger.progress_face(workspace)
+    lines = [f"## Mission progress: {face['progress_fraction'] * 100:.0f}% "
+             f"(sub-PQ credit, difficulty-damped)"]
+    for row in face["per_pq"]:
+        filled = round(float(row["progress"]) * mission_ledger._BAR_WIDTH)
+        bar = "#" * filled + "-" * (mission_ledger._BAR_WIDTH - filled)
+        flags = []
+        if row.get("damped"):
+            flags.append(f"damp x{row['damping']:g}")
+        if row.get("state") == "answered":
+            flags.append("answered")
+        lines.append(
+            f"  [{bar}] {float(row['progress']) * 100:5.1f}%  "
+            f"{row['id']}  claims={row['claim_count']} "
+            f"credit={row['credit']:g}"
+            + (f"  ({', '.join(flags)})" if flags else ""))
+    return "\n".join(lines)
+
+
 def report(workspace: Path) -> int:
     reg = _load_yaml(workspace / "claim-register.yaml")
     claims = (reg or {}).get("claims", []) or []
@@ -160,7 +190,14 @@ def report(workspace: Path) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description="kunglao-agent progress report")
     parser.add_argument("workspace", help="workspace root")
+    parser.add_argument("--progress", action="store_true",
+                        help="#14 sub-PQ mission progress: per-PQ bars with "
+                             "claim counts and damping flags (mission_ledger "
+                             "weighted credit + difficulty damping)")
     args = parser.parse_args()
+    if args.progress:
+        print(progress_face_text(Path(args.workspace)))
+        return 0
     return report(Path(args.workspace))
 
 

--- a/scripts/tuition_curve.py
+++ b/scripts/tuition_curve.py
@@ -197,4 +197,12 @@ def cockpit_summary(ws):
         out["backtrack"] = cockpit_backtrack(ws)
     except Exception:  # noqa: BLE001 — cockpit sampling never raises
         pass
+    # #14: sub-PQ progress face (per-PQ credit + difficulty damping).
+    # Additive + fail-open: ledger-less or malformed workspaces ship no key
+    # rather than breaking the V/D/ETA surface.
+    try:
+        import mission_ledger as _ml
+        out["progress"] = _ml.progress_face(ws)
+    except Exception:  # noqa: BLE001 — cockpit sampling never raises
+        pass
     return out

--- a/tests/test_progress_granularity_14.py
+++ b/tests/test_progress_granularity_14.py
@@ -1,0 +1,356 @@
+# -*- coding: utf-8 -*-
+"""tests/test_progress_granularity_14.py — #14 sub-PQ progress granularity.
+
+One-vote-per-PQ progress overstates convergence: a PQ with one PROVEN of five
+claims counts the same as a fully settled PQ, and open hypotheses / partial
+facts inside an unresolved PQ move nothing until terminal. #14 replaces the
+single vote with a weighted function of the PQ's claims' states (per-claim
+credit), damps fractional credit on hard/max-difficulty samples (remaining
+work is understated, never overstated), and lands the result ADDITIVELY —
+raw coverage / v_m / v_norm fields and the #823 settlement math are untouched.
+
+RED contract (every case below must fail before the GREEN implementation):
+  1. PQ with 1 PROVEN of 3 claims → 0 < progress < 1 (pre-change: 0).
+  2. answered PQ → progress exactly 1.0 regardless of shape (settlement
+     authoritative, PR #69).
+  3. PARTIALLY-VERIFIED contributes its 0.5 weight (PARTIAL of 2 → 0.25).
+  4. IN_PROGRESS with recent activity → 0.25; stale in-flight → 0.0.
+  5. max-difficulty open PQ < same-shape easy PQ; missing difficulty.json →
+     undamped (equal to easy).
+  6. additive: value_m raw fields, per_pq state/contrib, on-disk coverage,
+     and the #823 anti-stupid edge-claim invariant all unchanged.
+  7. cockpit_summary carries progress_fraction additively.
+  8. CLI face (--progress) renders per-PQ bars; empty workspace → no crash.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import mission_ledger as ml  # noqa: E402
+
+SCRIPTS = ROOT / "scripts"
+
+# Fixed clock: freshness tests must not depend on wall time. Only the
+# IN_PROGRESS recency classification consumes this — V_m units stay
+# wall-clock-free (#10).
+NOW = datetime(2026, 9, 5, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _claim(cid, status="OPEN", answers=None, last_activity_at=None):
+    c = {"id": cid, "status": status}
+    if answers is not None:
+        c["answers_question"] = answers
+    if last_activity_at is not None:
+        c["last_activity_at"] = last_activity_at
+    return c
+
+
+def _mk_ws(tmp_path, pqs, claims, tier=None, name="ws", spec_extra=None):
+    ws = tmp_path / name
+    (ws / "runs").mkdir(parents=True)
+    spec = {"primary_questions": pqs}
+    if spec_extra:
+        spec.update(spec_extra)
+    (ws / "task_spec.yaml").write_text(
+        yaml.safe_dump(spec, allow_unicode=True), encoding="utf-8")
+    (ws / "claim-register.yaml").write_text(
+        yaml.safe_dump({"claims": claims}, allow_unicode=True), encoding="utf-8")
+    if tier is not None:
+        ev = ws / "evidence"
+        ev.mkdir()
+        (ev / "difficulty.json").write_text(
+            json.dumps({"schema": "difficulty-calibration/1", "tier": tier}),
+            encoding="utf-8")
+    return ws
+
+
+def _prog(ws, pq_id, now=NOW):
+    v = ml.value_m(ws, now=now)
+    return next(r for r in v["per_pq_progress"] if r["id"] == pq_id)
+
+
+# ---------------------------------------------------------------------------
+# 1-4: per-claim credit model
+# ---------------------------------------------------------------------------
+
+
+class TestPerClaimCredit:
+    def test_proven_one_of_three_fractional(self, tmp_path):
+        """1 PROVEN of 3 linked claims → strictly between 0 and 1 (was 0)."""
+        ws = _mk_ws(tmp_path, [{"id": "q1"}],
+                    [_claim("C-1", "PROVEN", "q1"),
+                     _claim("C-2", "OPEN", "q1"),
+                     _claim("C-3", "OPEN", "q1")])
+        ml.init(ws, None)
+        p = _prog(ws, "q1")
+        assert 0.0 < p["progress"] < 1.0
+        assert abs(p["progress"] - 1 / 3) < 1e-6
+        assert p["claim_count"] == 3
+        assert abs(p["credit"] - 1.0) < 1e-9
+
+    def test_answered_pq_exactly_one(self, tmp_path):
+        """Settlement (PR #69) is authoritative: answered stays exactly 1.0."""
+        ws = _mk_ws(tmp_path, [{"id": "q1"}],
+                    [_claim("C-1", "PROVEN", "q1"),
+                     _claim("C-2", "OPEN", "q1")])
+        ml.init(ws, None)
+        ml.update(ws)
+        assert _prog(ws, "q1")["progress"] == 1.0
+
+    def test_partial_credit_half(self, tmp_path):
+        """PARTIALLY-VERIFIED carries the 0.5 weight: 1 of 2 → 0.25."""
+        ws = _mk_ws(tmp_path, [{"id": "q1"}],
+                    [_claim("C-1", "PARTIALLY-VERIFIED", "q1"),
+                     _claim("C-2", "OPEN", "q1")])
+        ml.init(ws, None)
+        p = _prog(ws, "q1")
+        assert abs(p["credit"] - 0.5) < 1e-9
+        assert abs(p["progress"] - 0.25) < 1e-9
+
+    def test_in_progress_fresh_quarter(self, tmp_path):
+        """IN_PROGRESS touched within the fresh window earns 0.25."""
+        ws = _mk_ws(tmp_path, [{"id": "q1"}],
+                    [_claim("C-1", "IN_PROGRESS", "q1",
+                            last_activity_at="2026-09-05T11:00:00Z")])
+        ml.init(ws, None)
+        p = _prog(ws, "q1")
+        assert abs(p["credit"] - 0.25) < 1e-9
+        assert abs(p["progress"] - 0.25) < 1e-9
+
+    def test_in_progress_stale_zero(self, tmp_path):
+        """IN_PROGRESS untouched beyond the window is presumed dead → 0.0."""
+        ws = _mk_ws(tmp_path, [{"id": "q1"}],
+                    [_claim("C-1", "IN_PROGRESS", "q1",
+                            last_activity_at="2026-08-30T00:00:00Z")])
+        ml.init(ws, None)
+        assert _prog(ws, "q1")["credit"] == 0.0
+
+    def test_in_progress_no_timestamps_counts_as_fresh(self, tmp_path):
+        """No activity fields = not provably stale (claim_expiry precedent:
+        unknown age is treated fresh, not stale)."""
+        ws = _mk_ws(tmp_path, [{"id": "q1"}],
+                    [_claim("C-1", "IN_PROGRESS", "q1")])
+        ml.init(ws, None)
+        assert abs(_prog(ws, "q1")["credit"] - 0.25) < 1e-9
+
+    def test_open_credit_zero(self, tmp_path):
+        ws = _mk_ws(tmp_path, [{"id": "q1"}],
+                    [_claim("C-1", "OPEN", "q1")])
+        ml.init(ws, None)
+        assert _prog(ws, "q1")["progress"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 5: difficulty-aware damping
+# ---------------------------------------------------------------------------
+
+
+class TestDifficultyDamping:
+    def _shape(self):
+        return [_claim("C-1", "PARTIALLY-VERIFIED", "q1"),
+                _claim("C-2", "OPEN", "q1")]
+
+    def test_max_damped_below_easy_and_missing_undamped(self, tmp_path):
+        easy = _mk_ws(tmp_path, [{"id": "q1"}], self._shape(),
+                      tier=None, name="easy")
+        mx = _mk_ws(tmp_path, [{"id": "q1"}], self._shape(),
+                    tier="max", name="mx")
+        ml.init(easy, None)
+        ml.init(mx, None)
+        pe, pm = _prog(easy, "q1"), _prog(mx, "q1")
+        assert abs(pe["progress"] - 0.25) < 1e-9  # missing difficulty → undamped
+        assert pe["damped"] is False
+        assert pm["progress"] < pe["progress"]  # the "overstated progress" fix
+        assert pm["damped"] is True
+
+    def test_hard_and_max_exact_factors(self, tmp_path):
+        hard = _mk_ws(tmp_path, [{"id": "q1"}], self._shape(),
+                      tier="hard", name="hard")
+        mx = _mk_ws(tmp_path, [{"id": "q1"}], self._shape(),
+                    tier="max", name="mx")
+        ml.init(hard, None)
+        ml.init(mx, None)
+        assert abs(_prog(hard, "q1")["progress"] - 0.25 * 0.75) < 1e-9
+        assert abs(_prog(mx, "q1")["progress"] - 0.25 * 0.5) < 1e-9
+
+    def test_damping_never_touches_answered(self, tmp_path):
+        ws = _mk_ws(tmp_path, [{"id": "q1"}],
+                    [_claim("C-1", "PROVEN", "q1")], tier="max")
+        ml.init(ws, None)
+        ml.update(ws)
+        p = _prog(ws, "q1")
+        assert p["progress"] == 1.0
+        assert p["damped"] is False
+
+    def test_task_spec_difficulty_key_fallback(self, tmp_path):
+        """difficulty_calibration.mount() also copies the tier into
+        task_spec.yaml (#16 open-loop contract) — that mount must damp too."""
+        ws = _mk_ws(tmp_path, [{"id": "q1"}], self._shape(), tier=None,
+                    name="spec", spec_extra={"difficulty": {"tier": "max"}})
+        ml.init(ws, None)
+        p = _prog(ws, "q1")
+        assert p["damped"] is True
+        assert abs(p["progress"] - 0.25 * 0.5) < 1e-9
+
+    def test_unknown_tier_undamped(self, tmp_path):
+        ws = _mk_ws(tmp_path, [{"id": "q1"}], self._shape(), name="u")
+        (ws / "evidence").mkdir()
+        (ws / "evidence" / "difficulty.json").write_text(
+            json.dumps({"tier": "warp"}), encoding="utf-8")
+        ml.init(ws, None)
+        assert abs(_prog(ws, "q1")["progress"] - 0.25) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# 6: additive surface — raw fields untouched
+# ---------------------------------------------------------------------------
+
+
+class TestAdditiveSurface:
+    def test_value_m_raw_fields_intact(self, tmp_path):
+        ws = _mk_ws(tmp_path, [{"id": "q1"}, {"id": "q2"}],
+                    [_claim("C-1", "PROVEN", "q1")])
+        ml.init(ws, None)
+        ml.update(ws)
+        v = ml.value_m(ws, now=NOW)
+        for k in ("v_m", "prev_v_m", "a_t", "v_norm", "a_t_norm",
+                  "total_weight", "per_pq", "answered", "blocked",
+                  "unattempted"):
+            assert k in v, k
+        assert v["v_m"] == 1.0  # exact #823 formula: answered w=1 cov=1
+        assert v["answered"] == 1 and v["blocked"] == 0
+        # per_pq rows keep the #10 raw projection EXACTLY — progress lives
+        # in per_pq_progress, never written into the pinned surface
+        # (same byte-identical guard test_vm_normalization_10 enforces).
+        assert v["per_pq"] == {"q1": {"state": "answered", "contrib": 1.0},
+                               "q2": {"state": "unattempted", "contrib": 0.0}}
+
+    def test_ledger_coverage_fields_unchanged(self, tmp_path):
+        """Fractional credit is computed, never written back into coverage."""
+        ws = _mk_ws(tmp_path, [{"id": "q1"}],
+                    [_claim("C-1", "PROVEN", "q1"),
+                     _claim("C-2", "OPEN", "q1"),
+                     _claim("C-3", "OPEN", "q1")])
+        ml.init(ws, None)
+        ml.value_m(ws, now=NOW)
+        pq = ml.load(ws)["mission"]["pqs"][0]
+        assert pq["coverage"] == 0.0
+        assert pq["state"] == "unattempted"
+
+    def test_anti_stupid_edge_claims_zero_progress(self, tmp_path):
+        """#823 invariant extended to the new face: edge claims all PROVEN
+        with zero PQ links move progress_fraction strictly 0."""
+        ws = _mk_ws(tmp_path, [{"id": "q1"}, {"id": "q2"}],
+                    [_claim("C-e1", "PROVEN"), _claim("C-e2", "VERIFIED")])
+        ml.init(ws, None)
+        v = ml.value_m(ws, now=NOW)
+        assert v["progress_fraction"] == 0.0
+        assert all(r["credit"] == 0.0 for r in v["per_pq_progress"])
+
+    def test_progress_fraction_aggregate(self, tmp_path):
+        ws = _mk_ws(tmp_path, [{"id": "q1"}, {"id": "q2"}],
+                    [_claim("C-1", "PROVEN", "q1"),
+                     _claim("C-2", "PARTIALLY-VERIFIED", "q2"),
+                     _claim("C-3", "OPEN", "q2")])
+        ml.init(ws, None)
+        ml.update(ws)
+        v = ml.value_m(ws, now=NOW)
+        assert abs(v["progress_fraction"] - (1.0 + 0.25) / 2) < 1e-9
+
+    def test_progress_fraction_weighted(self, tmp_path):
+        ws = _mk_ws(tmp_path, [{"id": "q1"}, {"id": "q2"}],
+                    [_claim("C-1", "PROVEN", "q1"),
+                     _claim("C-2", "PARTIALLY-VERIFIED", "q2"),
+                     _claim("C-3", "OPEN", "q2")])
+        ml.init(ws, None)
+        # weights live on ledger entries (repin-style), not task_spec (#10)
+        led = ml.load(ws)
+        led["mission"]["pqs"][0]["weight"] = 2.0
+        ml._save(ws, led)
+        ml.update(ws)
+        v = ml.value_m(ws, now=NOW)
+        assert abs(v["progress_fraction"] - (2 * 1.0 + 1 * 0.25) / 3) < 1e-9
+
+    def test_emit_snapshot_carries_progress_fraction(self, tmp_path):
+        ws = _mk_ws(tmp_path, [{"id": "q1"}],
+                    [_claim("C-1", "PROVEN", "q1")])
+        ml.init(ws, None)
+        ml.update(ws)
+        ml.emit_snapshot(ws, epoch=1, arm="N")
+        rows = []
+        for p in sorted((Path(ws) / "runs" / "logs").glob("kunglao-*.jsonl")):
+            rows += [json.loads(line)
+                     for line in p.read_text(encoding="utf-8").splitlines()
+                     if line.strip()]
+        detail = json.loads(
+            [r for r in rows if r["action"] == "mission_snapshot"][0]["detail"])
+        assert "progress_fraction" in detail
+
+
+# ---------------------------------------------------------------------------
+# 7: cockpit additive surface
+# ---------------------------------------------------------------------------
+
+
+class TestCockpitSurface:
+    def test_cockpit_progress_fraction_additive(self, tmp_path):
+        import tuition_curve as tc
+        ws = _mk_ws(tmp_path, [{"id": "q1"}, {"id": "q2"}],
+                    [_claim("C-1", "PROVEN", "q1"),
+                     _claim("C-2", "PARTIALLY-VERIFIED", "q2"),
+                     _claim("C-3", "OPEN", "q2")])
+        (ws / "runs" / "logs").mkdir(parents=True)
+        ml.init(ws, None)
+        ml.update(ws)
+        ml.value_m(ws, now=NOW)
+        cs = tc.cockpit_summary(ws)
+        for k in ("v", "v_norm", "d_slope", "d_slope_norm", "eta_checkpoints",
+                  "total_weight", "answered", "blocked", "unattempted",
+                  "cost", "burn", "tuition"):
+            assert k in cs, k
+        assert abs(cs["progress"]["progress_fraction"] - 0.625) < 1e-9
+        ids = [row["id"] for row in cs["progress"]["per_pq"]]
+        assert ids == ["q1", "q2"]
+
+
+# ---------------------------------------------------------------------------
+# 8: CLI face
+# ---------------------------------------------------------------------------
+
+
+class TestCliFace:
+    def test_empty_workspace_no_crash(self, tmp_path):
+        ws = tmp_path / "empty"
+        ws.mkdir()
+        r = subprocess.run(
+            [sys.executable, str(SCRIPTS / "progress_report.py"),
+             "--progress", str(ws)],
+            capture_output=True, text=True, timeout=60)
+        assert r.returncode == 0, r.stderr
+        assert "Traceback" not in r.stderr
+
+    def test_renders_per_pq_bars(self, tmp_path):
+        ws = _mk_ws(tmp_path, [{"id": "q1"}, {"id": "q2"}],
+                    [_claim("C-1", "PROVEN", "q1"),
+                     _claim("C-2", "PROVEN", "q1"),
+                     _claim("C-3", "PARTIALLY-VERIFIED", "q2"),
+                     _claim("C-4", "OPEN", "q2")], tier="hard")
+        ml.init(ws, None)
+        ml.update(ws)
+        r = subprocess.run(
+            [sys.executable, str(SCRIPTS / "progress_report.py"),
+             "--progress", str(ws)],
+            capture_output=True, text=True, timeout=60)
+        assert r.returncode == 0, r.stderr
+        assert "q1" in r.stdout and "q2" in r.stdout
+        assert "[" in r.stdout and "#" in r.stdout and "-" in r.stdout
+        assert "damp" in r.stdout.lower()  # damping flag visible


### PR DESCRIPTION
## Summary

Sub-PQ progress granularity (#14): the progress bar no longer treats each PQ
as one coarse vote.

- **Per-claim credit** (policy constants, rationale in code): PROVEN/VERIFIED
  settled = 1.0; PARTIALLY-VERIFIED = 0.5; IN_PROGRESS with fresh activity
  (24h window) = 0.25; OPEN = 0.0; other terminals = 0.0 (understates, never
  overstates).
- **PQ progress** = max(1.0 if answered, credit/max(1,claims) × damping);
  answered PQs stay 1.0 (settlement authoritative).
- **Difficulty damping**: fractional credit × 0.75 (hard) / × 0.5 (max);
  easy/medium/unknown/missing → undamped. High difficulty now understates
  remaining work instead of overstating it.
- **Outputs (additive)**: `value_m()` gains `progress_fraction` +
  `per_pq_progress` (separate key so the #10 byte-identical `per_pq` guard
  holds unmodified); `emit_snapshot` detail gains `progress_fraction`;
  cockpit gains fail-open `progress` key; `progress_report.py --progress`
  renders `[####----]` bars with claim counts and damping flags.
- Raw coverage/v_m/v_norm fields untouched.

Closes #14

Milestone: v0.1.5 (milestone #1)

## Anti-orphan gate (REQUIRED)

- Added code: credit/damping constants + progress_face/pq_progress/
  claim_credit/read_difficulty_tier in mission_ledger.py, progress CLI face,
  21 tests (tests/test_progress_granularity_14.py).
- Code moved/deleted: none; all existing output fields byte-identical.

## Test plan

- [x] RED first: 21/21 failed (missing keys, no flag)
- [x] GREEN: 21/21; #10/#823 guards pass unmodified
- [x] Full suite: 5579 passed / 10 skipped / 0 failed
- [x] ruff clean (4 files); deploy --write + --verify OK (377 entries)
