### PR TITLE
docs: README de-monologued — teach task-writing, drop fixed-pipeline framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ From any directory, in Claude Code:
 > Constraints: static-only — no VM available this week.
 ```
 
-The shape matters more than the wording: **primary questions** (what must be answered), **success criteria** (what counts as answered), **constraints** (what the loop may and may not do). The orchestrator records them in `task_spec.yaml` and enters the convergence loop — dispatching workers and blind verifiers until every primary question reaches PROVEN and the loop exits 0.
+Write the brief so an independent reviewer could judge the result: **analysis goal** (what you need to know), **verification logic** (what makes an answer trustworthy — e.g. "the signature must be reproducible from the same inputs"), **constraints** (e.g. "no execution on the host"). Everything is recorded in `task_spec.yaml`; from there the loop drives itself.
 
 ### 4. Read the deliverable
 
@@ -89,7 +89,7 @@ runs/                 # session audit trail
 > "What does this binary do, and where does it phone home?"
 ```
 
-From there the loop runs itself. Static workers take the binary apart first — structure, imports mapped to capability classes, embedded strings — and every fact they produce is re-derived blind by an independent verifier before it counts. Artifacts land in `evidence/` (`die.json`, `floss-filtered.json`, `static-ghidra.json`) with findings in `facts/`. Anything needing execution waits until static is genuinely exhausted, and each dynamic dispatch declares the static gap it closes. You can walk away — the loop keeps itself alive (see [Long-horizon autonomy](#long-horizon-autonomy)). When it converges, you read the verdict: every claim in `claim-register.yaml` terminal and verifier-signed, every fact reproducible from a raw artifact.
+From there the loop runs itself — the route adapts to what the sample turns out to be. You can walk away (see [Long-horizon autonomy](#long-horizon-autonomy)). When it converges, read the deliverable below.
 
 ## Scenarios
 
@@ -101,17 +101,13 @@ Two more end-to-end paths — pick the one matching your target (for a plain Win
 ```bash
 /kunglao-agent:init ~/cases/sample.apk --type android
 /kunglao-agent
-> "capability / persistence / network entry points"
+> "Does this APK load code dynamically or fight debugging? If so, where is
+>   the hidden logic and what does it do?"
 ```
 
-```
-APK → aapt/apktool unpack → jadx (DEX → Java) → gitnexus graph → graph-assisted static analysis
-  → dynamic only when static stalls: ADB → root → renamed frida-server (1337) or android_server (23946)
-  → last resort: frida hook + unidbg
-```
-
-- **Lands in:** `bins/<sha256>` (the APK), `facts/F001..` (class graph), `facts/F050..` (native `.so` inventory), `evidence/` (captures, dumps).
-- **Done looks like:** every primary question backed by a PROVEN fact; the loop exits 0.
+- **Lands in:** `bins/<sha256>` (the APK), `facts/` (class graph, native `.so` inventory), `evidence/` (captures, dumps).
+- **Done looks like:** every question backed by reproducible evidence.
+- **The route adapts.** Some APKs close with pure static DEX work; others need on-device debugging — the loop decides from what the sample actually is.
 
 </details>
 
@@ -124,13 +120,7 @@ APK → aapt/apktool unpack → jadx (DEX → Java) → gitnexus graph → graph
 > "how is the XHR request signed, and where does the nonce come from?"
 ```
 
-```
-site → camoufox-reverse (anti-detect Firefox: hooks / trace / capture)
-  → unpack (wakaru / webcrack routing) → deobfuscate → index functions and endpoints
-  → signed-parameter tracing → verify-by-replay: re-derive the signature from inputs only
-```
-
-- **Lands in:** `evidence/<capture>.har`, `evidence/<bundle>.js` (deobfuscated), `facts/` (signing key, nonce derivation). The verifier confirms the model by blind re-derivation.
+- **Lands in:** `evidence/` (captures, deobfuscated code), `facts/` (signing key, nonce derivation).
 - **Note:** `web` is a beta-stage target — the toolchain bar is deliberately light; missing capability surfaces when the loop actually needs it, not at init.
 
 </details>
@@ -166,26 +156,6 @@ provenance:
 reproduce: python -c "import struct; ..."               # runs against the cited artifact
 verifier_sign_off: {verifier: kunglao-redteam, verdict: CONFIRMED}
 ```
-
-## How it works
-
-Each round, the orchestrator picks the highest-value open question and dispatches one specialist worker — static first. Every partial fact goes to an independent blind verifier, which must re-derive it from the raw evidence before it counts as proven. Blocked work gets recovered instead of idled; when every primary question is answered with byte-proof, the loop converges and builds the report.
-
-```mermaid
-flowchart TD
-    spec[task_spec.yaml] --> orch{orchestrator each round}
-    orch --> w[specialist worker - static first]
-    w --> part[fact PARTIAL]
-    part --> ver[independent blind verifier]
-    ver -->|exact-match re-derivation| more{all primary questions answered?}
-    ver -->|refuted| orch
-    more -->|no| orch
-    more -->|yes| conv[converged - report built]
-```
-
-### Analysis principle
-
-Static first, always: a task that closes statically never touches dynamic tooling. When static genuinely stalls, emulation strips obfuscation and feeds the result back into static analysis; dynamic debugging is reserved for explicitly declared gaps, and building a runnable environment is the last resort. Every escalation is declared, audited, and revisited downward as soon as static can take over.
 
 ## Long-horizon autonomy
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,7 +60,7 @@ kunglao-agent 跑在 Claude Code 里。从磁盘上的样本到 verdict：
 > 约束：只做静态 —— 本周没有 VM。
 ```
 
-句式比措辞重要：**主问题**（必须回答什么）、**成功标准**（答到什么程度算答了）、**约束**（循环可以做什么、不可以做什么）。编排器把它们记进 `task_spec.yaml`，然后进入收敛循环 —— 派 worker 和盲验证者往复，直到每个主问题都达到 PROVEN，循环退出码 0。
+把需求写成第三方能据此评判结果的程度：**分析目标**（你要知道什么）、**验证逻辑**（凭什么信答案——比如"同一输入必须能重推出同样签名"）、**约束**（比如"宿主机上不许执行"）。全部记入 `task_spec.yaml`，之后循环自己推进。
 
 ### 4. 看交付物
 
@@ -91,7 +91,7 @@ runs/                 # 会话审计轨迹
 > "这个二进制干了什么，回连到哪里？"
 ```
 
-接下来循环自己跑：静态 worker 先把二进制拆开 —— 结构、按能力类别归类的 imports、内嵌字符串 —— 每条产出的 fact 都要经过独立验证者盲重推一致才算数。产物落在 `evidence/`（`die.json`、`floss-filtered.json`、`static-ghidra.json`），结论落在 `facts/`。需要执行的部分会等到静态确实山穷水尽才启动，而且每次动态派工都要声明它要补的静态 gap。你可以走开 —— 循环自己能活（见[长时程自主运行](#长时程自主运行)）。收敛之后读结论：`claim-register.yaml` 里每条 claim 都 terminal 且有验证者签核，`facts/` 里每条 fact 都能从原始证据复现。
+接下来循环自己跑 —— 路线随样本实际情况调整，不是固定剧本。你可以走开（见[长时程自主运行](#长时程自主运行)）。收敛之后读下面的交付物。
 
 ## 场景演练
 
@@ -106,14 +106,15 @@ runs/                 # 会话审计轨迹
 > "capability / persistence / network entry points"
 ```
 
-```
-APK → aapt/apktool 解包 → jadx（DEX → Java）→ gitnexus 图谱 → 图谱辅助的静态分析
-  → 静态卡住了才走动态：ADB → root → 改名 frida-server（1337）或 android_server（23946）
-  → 最后兜底：frida hook + unidbg
+```bash
+/kunglao-agent:init ~/cases/sample.apk --type android
+/kunglao-agent
+> "这个 APK 有没有动态加载和反调试？如果有，代码藏在哪，做了什么？"
 ```
 
-- **产物落在哪：** `bins/<sha256>`（APK 本身）、`facts/F001..`（class 图谱）、`facts/F050..`（native `.so` 清单）、`evidence/`（抓包、dump）。
-- **"完成"长什么样：** 每个主问题都有 PROVEN fact 支撑；循环退出码 0。
+- **产物落在哪：** `bins/<sha256>`（APK 本身）、`facts/`（类图谱、native `.so` 清单）、`evidence/`（抓包、dump）。
+- **"完成"长什么样：** 每个问题都有可复现的证据支撑。
+- **路线由系统定。** 有的 APK 纯静态 DEX 分析就能闭环，有的必须上真机调试 —— 取决于样本实际是什么。
 
 </details>
 
@@ -126,13 +127,7 @@ APK → aapt/apktool 解包 → jadx（DEX → Java）→ gitnexus 图谱 → �
 > "XHR 签名是怎么算的，nonce 从哪来？"
 ```
 
-```
-site → camoufox-reverse（反检测 Firefox：hook / trace / 抓包）
-  → 解包（wakaru / webcrack 分流）→ 去混淆 → 索引函数与接口
-  → 带签参数追踪 → verify-by-replay：只从输入重推签名
-```
-
-- **产物落在哪：** `evidence/<capture>.har`、`evidence/<bundle>.js`（已去混淆）、`facts/`（签名密钥、nonce 推导）。验证者通过盲重推确认模型正确。
+- **产物落在哪：** `evidence/`（抓包、去混淆后的代码）、`facts/`（签名密钥、nonce 推导）。
 - **注意：** `web` 是 beta 阶段目标 —— 工具链门槛刻意放得很低；能力缺失由循环在实际需要时浮出来，而不是 init 卡住。
 
 </details>
@@ -168,26 +163,6 @@ provenance:
 reproduce: python -c "import struct; ..."               # 对着引用的证据跑
 verifier_sign_off: {verifier: kunglao-redteam, verdict: CONFIRMED}
 ```
-
-## 循环怎么跑
-
-每一轮，编排器挑出价值最高的未解问题，派一个专家 worker —— 静态优先。每条半成品 fact 都交给一个独立的盲验证者，必须从原始证据重推一致才算成立。卡住的任务会被自愈而不是空转；当每个主问题都有字节级证据时，循环收敛并生成报告。
-
-```mermaid
-flowchart TD
-    spec[task_spec.yaml] --> orch{编排器 每一轮}
-    orch --> w[专家 worker - 静态优先]
-    w --> part[fact PARTIAL]
-    part --> ver[独立盲验证者]
-    ver -->|盲重推一致| more{所有主问题都答了？}
-    ver -->|被推翻| orch
-    more -->|否| orch
-    more -->|是| conv[收敛 - 生成报告]
-```
-
-### 分析原则
-
-静态优先，始终如此：能静态闭环的任务绝不碰动态工具。静态确实山穷水尽时，用仿真剥掉混淆层再喂回静态分析；动态调试只针对显式声明的 gap；搭一个能跑起来的环境是最后手段。每次升级都要显式声明、留有审计，静态一旦能接管就立刻降回来。
 
 ## 长时程自主运行
 


### PR DESCRIPTION
## Summary

Second owner review round on the README rewrite (#91 follow-up):

1. **Task section rewritten** — it listed jargon ("primary questions /
   success criteria") without teaching what to actually write. Now states
   the three concrete things a good brief contains — analysis goal,
   verification logic, constraints — each with an inline example
   (e.g. verification: "the signature must be reproducible from the same
   inputs").
2. **Fixed-pipeline walkthroughs deleted** — the scenarios read like the
   product follows a hard-coded script (APK → unpack → jadx → graph → …).
   Replaced with adaptive-route framing ("the route depends on what the
   sample actually is") plus a concrete example question per scenario.
3. **"How it works" / "Analysis principle" sections removed** — internal
   mechanics are docs/ material; the README asserts the property (blind
   re-derivation, static-first) in one line each where needed.

Closes #90 (follow-up; README rewrite lineage: #91 → #92 → this)

Milestone: v0.1.5 (milestone #1)

## Test plan

- [x] Docs-only change (18 insertions / 73 deletions)
- [x] EN/zh structural sync maintained
- [x] CI release-check success on branch