### PR TITLE
fix(#98,#99): decide DRAIN worker predicates + EXIT_CRASHED=65 — stop false-CONVERGED over live workers

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -243,7 +243,7 @@ files:
   - src: scripts/convergence_check.py
     dest: .claude/scripts/convergence_check.py
     kind: scaffold
-    sha256: eb4c622f3b509f834b8f61bb00ae3e92d701c8e602c94c0b41da4aa139c45f2c
+    sha256: e77915b6915d61f3a8d9dfaf3f9f8d2b82af20c9a94b61e0fe2f55ad0f71f99a
   - src: scripts/convergence_health.py
     dest: .claude/scripts/convergence_health.py
     kind: scaffold

--- a/scripts/convergence_check.py
+++ b/scripts/convergence_check.py
@@ -21,14 +21,18 @@ Decision matrix:
   open_claims>0 AND all open are blocked   → BLOCKED        (escalate with specifics)
   non-empty malformed primary_questions    → INVALID        (escalate, target undefined)
 
-Exit codes (machine-readable for hooks):
+Exit codes (machine-readable for hooks — consumer contract, see the
+registry constant block for #99):
   0 = CONVERGED (nothing to do)
   1 = DISPATCH (open work + free slots)
   2 = DISPATCH_VERIFIER (partial facts need checking)
   3 = SATURATED (busy, poll)
   4 = BLOCKED (open work but all blocked — escalate); INVALID (bad task_spec) reuses this
      so hooks that accept returncodes 0–4 keep parsing the JSON decision.
+  5 = PARK (#634: suspended on external gates — legal idle with wake_condition)
   64 = MISSING_WORKSPACE (no claim-register.yaml found — caller passed wrong path)
+  65 = CRASHED (#99: the check itself crashed — stdout {"decision": "CRASHED"},
+     traceback on stderr; never a decided state)
 
 Usage:
   python scripts/convergence_check.py [workspace]          # human-readable
@@ -66,13 +70,24 @@ from ws_layout import resolve_quiet as _resolve_ws
 
 WORKER_CAP = 3
 
-# Exit codes
+# Exit codes — CONSUMER CONTRACT (#99). Every rc-based consumer (hooks that
+# branch on 0-4, kunglao-decide, external tick loops) reads these bytes; a
+# collision makes one state masquerade as another. Before adding a value,
+# check the registry below AND skills/kunglao-agent/SKILL.md's decision
+# table (the human-facing copy of this contract).
 EXIT_CONVERGED = 0
 EXIT_DISPATCH = 1
 EXIT_VERIFY = 2
 EXIT_SATURATED = 3
 EXIT_BLOCKED = 4
 EXIT_PARK = 5  # #634: suspended on external gates — legal idle with wake_condition
+# #99: the check itself crashed (malformed YAML, unexpected error). 64 is
+# taken by MISSING_WORKSPACE (main()'s no-claim-register exit); 65 is the
+# next free byte. A crash must NEVER share EXIT_DISPATCH's byte — pre-#99 a
+# malformed register exited rc=1, which rc-based consumers read as
+# "dispatch now" while stdout was empty. On this exit: stdout carries
+# {"decision": "CRASHED"}, stderr keeps the traceback.
+EXIT_CRASHED = 65
 
 
 from harness_common import utc_now  # #863 Family F: single source (was a local def)
@@ -602,11 +617,18 @@ class Event(str, Enum):
     DISCOVERY_UNCONSUMED = "DISCOVERY_UNCONSUMED"     # #147 discovery consumption
     GLOBAL_CONTRADICTION = "GLOBAL_CONTRADICTION"     # #147 completion transaction
     ANOMALY_DETECTED = "ANOMALY_DETECTED"           # #663 anomaly observation gate
+    # #98: DRAIN worker gates. The DRAIN probe table had ZERO worker
+    # predicates — worker data was collected into the snapshot but never
+    # consulted — so an all-IN_PROGRESS claim surface (excluded from opens
+    # by _open_claims, by design) drained straight to CONVERGED over live
+    # work. STUCK is shared with SCHEDULE (one #595 semantics, two stages);
+    # ACTIVE is DRAIN-only (SCHEDULE already routes work by claim face).
+    STUCK_WORKERS_PRESENT = "STUCK_WORKERS_PRESENT"   # #595 SCHEDULE / #98 DRAIN: stuck workers gate both stages
+    ACTIVE_WORKERS_PRESENT = "ACTIVE_WORKERS_PRESENT"  # #98 DRAIN: live worker on a drained claim surface
     DRAIN_CLEAN = "DRAIN_CLEAN"                        # DRAIN catch-all
     # SCHEDULE stage
     WORK_AND_FREE_SLOT = "WORK_AND_FREE_SLOT"
     PARTIALS_AND_FREE_SLOT = "PARTIALS_AND_FREE_SLOT"
-    STUCK_WORKERS_PRESENT = "STUCK_WORKERS_PRESENT"   # #595: silent-detect consumes stuck_workers
     WORK_NO_FREE_SLOT = "WORK_NO_FREE_SLOT"
     FAILURE_ARTIFACTS_DUE = "FAILURE_ARTIFACTS_DUE"    # #495: analysis lacks
     #      validated_capability / identified_obstacle (or is absent/stale)
@@ -877,7 +899,17 @@ def _stuck_workers_present(s: _DecideInputs) -> bool:
     # #595: silent-detect — collected stuck_workers were never consumed by the
     # machine. Firing here escalates to BLOCKED so orchestrator intervention
     # can resolve instead of looping against a frozen worker.
+    # #98: now probed in DRAIN too — the drained claim face must not read
+    # CONVERGED while a worker has gone silent.
     return bool(s.stuck)
+
+
+def _active_workers_present(s: _DecideInputs) -> bool:
+    # #98 DRAIN leg: work is in flight even when the claim face looks empty
+    # (IN_PROGRESS is excluded from opens by design). A drained claim face
+    # with a live worker means the loop is busy, not done — poll, never
+    # deliver.
+    return s.active > 0
 
 
 def _work_no_free_slot(s: _DecideInputs) -> bool:
@@ -924,6 +956,7 @@ _EVENT_PREDICATES = {
     Event.WORK_AND_FREE_SLOT: _work_and_free_slot,
     Event.PARTIALS_AND_FREE_SLOT: _partials_and_free_slot,
     Event.STUCK_WORKERS_PRESENT: _stuck_workers_present,
+    Event.ACTIVE_WORKERS_PRESENT: _active_workers_present,
     Event.WORK_NO_FREE_SLOT: _work_no_free_slot,
     Event.FAILURE_ARTIFACTS_DUE: _failure_artifacts_due,
     Event.LADDER_REQUIRED_BLOCKER: _ladder_required_blocker,
@@ -1080,6 +1113,15 @@ def _act_verify_partials(s: _DecideInputs) -> str:
 def _act_saturated_queue(s: _DecideInputs) -> str:
     return (f"All {WORKER_CAP} slots busy with {len(s.unblocked_open)} open claim(s) queued. "
             f"Poll workers - do not wait idly.")
+
+
+def _act_active_workers(s: _DecideInputs) -> str:
+    # #98 DRAIN leg: healthy in-flight work on a drained claim face. SATURATED
+    # (busy: poll) rather than BLOCKED (escalate) — nothing is wrong, the loop
+    # is simply not done. Delivery over live work is forbidden either way.
+    return (f"{s.active} worker(s) still in flight on an otherwise-drained "
+            f"claim surface ({s.free_slots} free slot(s) under cap {WORKER_CAP}). "
+            f"Poll workers - do not deliver; re-check convergence after they report.")
 
 
 def _act_stuck_workers(s: _DecideInputs) -> str:
@@ -1267,11 +1309,18 @@ STAGE_PROBES = {
     State.SCHEMA: [Event.SCHEMA_INVALID, Event.WORK_PENDING, Event.DRAINED],
     # DRAIN: the pre-#443 completion-transaction order, frozen by the
     # regression anchor (orphan > unverified > note-gap > discovery >
-    # contradiction > clean).
+    # contradiction > clean). #98: worker gates sit AFTER that frozen order
+    # (every completeness gate keeps its verdict priority) but BEFORE the
+    # DRAIN_CLEAN catch-all — a drained claim face with live/stuck workers
+    # is busy (SATURATED: poll) or escalated (BLOCKED: #595 action, which
+    # also frees the stuck claims per #607), never CONVERGED. STUCK precedes
+    # ACTIVE: a stuck worker is also counted active, and its escalation must
+    # win.
     State.DRAIN: [Event.ORPHAN_TERMINAL_CLAIM, Event.PRIMARY_Q_UNVERIFIED,
                   Event.NOTE_LAYER_GAP, Event.OPEN_HYPOTHESIS_AT_CLOSE,
                   Event.DISCOVERY_UNCONSUMED,
                   Event.GLOBAL_CONTRADICTION, Event.ANOMALY_DETECTED,
+                  Event.STUCK_WORKERS_PRESENT, Event.ACTIVE_WORKERS_PRESENT,
                   Event.DRAIN_CLEAN],
     # SCHEDULE: dispatchable work first, then saturation, then WHY nothing
     # is dispatchable (#495 failure artifacts, #497 ladder flavors), then
@@ -1297,6 +1346,11 @@ TRANSITIONS = {
     (State.DRAIN, Event.DISCOVERY_UNCONSUMED): (State.DISPATCH, _act_discovery),
     (State.DRAIN, Event.GLOBAL_CONTRADICTION): (State.BLOCKED, _act_contradiction),
     (State.DRAIN, Event.ANOMALY_DETECTED): (State.BLOCKED, _act_anomaly),
+    # #98: worker predicates on the drained claim face — one #595 stuck
+    # semantics shared with SCHEDULE (same builder: stuck report + #607
+    # reopen), plus the DRAIN-only busy-poll face for live workers.
+    (State.DRAIN, Event.STUCK_WORKERS_PRESENT): (State.BLOCKED, _act_stuck_workers),
+    (State.DRAIN, Event.ACTIVE_WORKERS_PRESENT): (State.SATURATED, _act_active_workers),
     (State.DRAIN, Event.DRAIN_CLEAN): (State.CONVERGED, _act_converged),
     (State.SCHEDULE, Event.WORK_AND_FREE_SLOT): (State.DISPATCH, _act_dispatch_top),
     (State.SCHEDULE, Event.PARTIALS_AND_FREE_SLOT): (State.DISPATCH_VERIFIER, _act_verify_partials),
@@ -1550,7 +1604,18 @@ def main(argv: list[str] | None = None) -> int:
         print(f"FAIL: no claim-register.yaml under {workspace}", file=sys.stderr)
         return 64
 
-    d = decide(workspace)
+    # #99: decide() is untrusted input territory (claim-register.yaml is
+    # hand- and hook-edited YAML). An unguarded crash exits rc=1 — the SAME
+    # byte as EXIT_DISPATCH — so rc-based consumers read the crash as
+    # "dispatch now". Contain it: distinct EXIT_CRASHED byte, machine-
+    # readable stdout, traceback preserved on stderr.
+    try:
+        d = decide(workspace)
+    except Exception:  # noqa: BLE001 — #99: any crash must leave the decided-state byte space
+        import traceback
+        traceback.print_exc()
+        print(json.dumps({"decision": "CRASHED"}, ensure_ascii=False))
+        return EXIT_CRASHED
     _append_ledger(workspace, d)  # silent side channel for convergence_health.py
     # #287 observability: mirror the convergence decision to the structured
     # event log. #459: detail now carries the decision plus the counts a

--- a/skills/kunglao-agent/SKILL.md
+++ b/skills/kunglao-agent/SKILL.md
@@ -181,10 +181,11 @@ Act on the decision + exit code — it is a command, not a suggestion:
 | --- | --- | --- | --- |
 | `DISPATCH` | 1 | open claims + free slots | Run `priority_ratio.py`; dispatch the top claim — this turn, no exceptions. Dispatch = fire-and-continue: launch the worker as a BACKGROUND task, do NOT block on its return — the next turn is the tick that monitors it |
 | `DISPATCH_VERIFIER` | 2 | partial facts + free slots | Dispatch a verifier; do NOT declare PROVEN without sign-off |
-| `SATURATED` | 3 | open claims but 0 free slots | Poll stuck workers; do not idle |
-| `BLOCKED` | 4 | open claims all blocked | Resolve blockers (self-recovery), then re-check |
+| `SATURATED` | 3 | open claims but 0 free slots — or live workers on an otherwise-drained claim face (busy is not done) | Poll stuck workers; do not idle |
+| `BLOCKED` | 4 | open claims all blocked (or a stuck worker on a drained claim face) | Resolve blockers (self-recovery), then re-check |
 | `THINK` | - | tick waiting period - heartbeat_tick fired the THINK seat | Read the seat's `runs/.think-<ts>.md` and fill its three sections (patterns / hypotheses / value) IN PLACE - that artifact IS this tick's action_taken (EMPTY forbidden); execute any `suggested_searches` as the NEXT action; structured branching goes through the sequentialthinking chain (contract detail owned by the parallel worker-contract wave) |
 | `CONVERGED` | 0 | no open claims, no partials, all PQs have passes-notes, completion transaction clean | claim loop done — CONVERGED now requires zero global contradictions, zero unconsumed discoveries, and PROVEN provenance (recomputed in `convergence_check.py` + `completion_gate.py`). STOP dispatch; deliver |
+| `CRASHED` | 65 | the check itself crashed (malformed YAML, unexpected error) — never a decided state | Read the stderr traceback and repair the workspace file it names; 1/2/3 always mean a decided state, 65 always means a broken check — never dispatch on 65 |
 
 Manual fallback (script unavailable): scan `claim-register.yaml` for OPEN/PARTIALLY-VERIFIED, confirm `active_workers < 3`, scan `facts/_INDEX.md` for PARTIAL facts. DISPATCH and DISPATCH_VERIFIER must be acted on before this turn ends — dispatched as background launches, never awaited inline. A worker notification is a signal, not a trigger: process the result, then re-run the convergence check.
 

--- a/tests/test_convergence_crash_exit_99.py
+++ b/tests/test_convergence_crash_exit_99.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+"""Issue #99: a decide() crash exited rc=1 — byte-identical to EXIT_DISPATCH.
+
+main() called decide() unguarded: a malformed claim-register.yaml raised
+inside yaml.safe_load and Python exited 1 — the SAME byte as EXIT_DISPATCH.
+Any rc-based consumer (hooks that branch on 0-4) read the crash as
+"dispatch now". convergence_health got EXIT_CRASHED for its own face in #3;
+the decide face never did.
+
+Fix: EXIT_CRASHED = 65 (64 is taken by MISSING_WORKSPACE), a catch-all in
+main() around decide(): machine-readable {"decision": "CRASHED"} on stdout,
+traceback preserved on stderr. The exit-code registry is a consumer
+contract — every value must stay distinct.
+
+Covers:
+  RED1: the issue probe (register with ``title: [unclosed``) -> rc=65, not
+        1; stdout parses as JSON with decision CRASHED; stderr keeps the
+        YAML error class
+  RED2: synthetic decide() crash -> main() returns 65, stdout contract
+        holds, stderr carries the exception
+  PINS: registry distinctness (0-5 + 64 + 65); a healthy workspace keeps
+        its DISPATCH rc=1; MISSING_WORKSPACE keeps 64
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import convergence_check as cc  # noqa: E402
+
+SCRIPT = ROOT / "scripts" / "convergence_check.py"
+
+
+def _mk_ws(tmp_path: Path, name: str, register_text: str) -> Path:
+    ws = tmp_path / name
+    (ws / "runs").mkdir(parents=True)
+    (ws / "claim-register.yaml").write_text(register_text, encoding="utf-8")
+    (ws / "task_spec.yaml").write_text("primary_questions: []\n", encoding="utf-8")
+    return ws
+
+
+def _run(ws: Path):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(ws), "--json"],
+        capture_output=True, text=True, timeout=60,
+        env={k: v for k, v in __import__("os").environ.items()
+             if k != "KUNGLAO_VALUE_ALGO"})
+
+
+# =====================================================================
+# RED1: the issue probe — malformed register -> 65, not 1
+# =====================================================================
+
+def test_malformed_register_exits_65_not_1(tmp_path):
+    """The probe from the issue: ``title: [unclosed`` crashes yaml parsing.
+    Pre-fix: rc=1 (== EXIT_DISPATCH byte), 0-byte stdout, traceback only on
+    stderr — a crash masquerading as "dispatch now"."""
+    ws = _mk_ws(tmp_path, "bad_yaml", "title: [unclosed\nclaims: []\n")
+    r = _run(ws)
+    assert r.returncode == cc.EXIT_CRASHED, (
+        f"#99: crashed decide must exit {cc.EXIT_CRASHED} (CRASHED), "
+        f"not {r.returncode} (byte-identical to EXIT_DISPATCH); "
+        f"stderr: {r.stderr[:300]}")
+    assert r.returncode != cc.EXIT_DISPATCH, \
+        "#99: crash rc must never collide with EXIT_DISPATCH"
+    # machine-readable face: stdout parses and names the crash
+    out = json.loads(r.stdout)
+    assert out["decision"] == "CRASHED", \
+        f"#99: stdout must carry decision=CRASHED, got: {r.stdout[:200]}"
+    # traceback preserved on stderr, naming the YAML error class
+    assert "Traceback" in r.stderr, "#99: traceback must stay on stderr"
+    assert "yaml" in r.stderr.lower(), \
+        f"#99: stderr must name the yaml error layer, got: {r.stderr[-300:]}"
+
+
+# =====================================================================
+# RED2: synthetic decide() crash -> main() returns EXIT_CRASHED
+# =====================================================================
+
+def test_decide_crash_returns_exit_crashed(tmp_path, monkeypatch, capsys):
+    ws = _mk_ws(tmp_path, "synthetic", yaml.safe_dump({"claims": []}))
+
+    def boom(_ws, **_kw):
+        raise RuntimeError("synthetic decide failure (#99)")
+
+    monkeypatch.setattr(cc, "decide", boom)
+    rc = cc.main([str(ws), "--json"])
+    assert rc == cc.EXIT_CRASHED, f"#99: main() must return 65, got {rc}"
+    out = json.loads(capsys.readouterr().out)
+    assert out["decision"] == "CRASHED", \
+        f"#99: stdout contract violated: {out}"
+
+
+def test_decide_crash_stderr_keeps_exception(tmp_path, monkeypatch, capsys):
+    """stderr keeps the traceback (operators debug from it); stdout stays
+    clean JSON (machines parse it). The two channels must not merge."""
+    ws = _mk_ws(tmp_path, "stderr", yaml.safe_dump({"claims": []}))
+
+    def boom(_ws, **_kw):
+        raise ValueError("the specific failure (#99)")
+
+    monkeypatch.setattr(cc, "decide", boom)
+    cc.main([str(ws)])
+    captured = capsys.readouterr()
+    assert "ValueError" in captured.err, \
+        f"#99: exception class must reach stderr, got: {captured.err[-300:]}"
+    assert "the specific failure (#99)" in captured.err
+    assert json.loads(captured.out)["decision"] == "CRASHED"
+
+
+# =====================================================================
+# protocol pins: registry distinctness + healthy paths unchanged
+# =====================================================================
+
+def test_exit_code_registry_distinct():
+    """#99: the registry is a consumer contract — every face own byte."""
+    registry = {
+        "CONVERGED": cc.EXIT_CONVERGED,
+        "DISPATCH": cc.EXIT_DISPATCH,
+        "DISPATCH_VERIFIER": cc.EXIT_VERIFY,
+        "SATURATED": cc.EXIT_SATURATED,
+        "BLOCKED": cc.EXIT_BLOCKED,
+        "PARK": cc.EXIT_PARK,
+        "MISSING_WORKSPACE": 64,
+        "CRASHED": cc.EXIT_CRASHED,
+    }
+    assert len(set(registry.values())) == len(registry), \
+        f"#99: exit-code collision in the consumer contract: {registry}"
+    assert cc.EXIT_CRASHED == 65
+    assert cc.EXIT_CRASHED not in (0, 1, 2, 3, 4, 5, 64)
+
+
+def test_missing_workspace_still_64(tmp_path):
+    """Pre-existing face unchanged: no claim-register.yaml -> 64."""
+    r = _run(tmp_path / "absent")
+    assert r.returncode == 64, f"MISSING_WORKSPACE moved: rc={r.returncode}"
+
+
+def test_healthy_dispatch_still_1(tmp_path):
+    """The contract this fix protects: rc=1 means DISPATCH, never a crash."""
+    ws = _mk_ws(tmp_path, "healthy", yaml.safe_dump(
+        {"claims": [{"id": "C-1", "status": "OPEN"}]}))
+    r = _run(ws)
+    assert r.returncode == cc.EXIT_DISPATCH
+    assert json.loads(r.stdout)["decision"] == "DISPATCH"

--- a/tests/test_decide_regression_anchor.py
+++ b/tests/test_decide_regression_anchor.py
@@ -56,6 +56,23 @@ import convergence_check  # module under test (== baseline before #443 GREEN)
 BASELINE_COMMIT = "cabc7d9"  # the #51 value-flag-removal commit — decide() outputs frozen at the 2026-09-05 re-pin (see below)
 ANCHOR_FILE = Path(__file__).parent / "decide_anchor_cabc7d9.json"
 
+# 2026-09-06 zero-drift verification (#98 DRAIN worker gates): the DRAIN
+# probe table gained STUCK_WORKERS_PRESENT + ACTIVE_WORKERS_PRESENT,
+# appended AFTER the frozen completion-transaction order (orphan >
+# unverified > note-gap > hyp > discovery > contradiction > anomaly) and
+# BEFORE the DRAIN_CLEAN catch-all — every completeness gate keeps its
+# verdict priority, and the new gates can only fire on a drained claim
+# face with live workers. All 32 frozen cases re-verified byte-identical
+# after the change (the predicates read snapshot data the corpus's DRAIN
+# cases never populate: none of them writes a worker-status file), so NO
+# re-pin was needed. Live semantic change, documented but unanchored (the
+# matrix has no worker-bearing DRAIN case — covered by the #98 block in
+# tests/test_decide_state_machine.py instead): the issue #98 probe state
+# (single IN_PROGRESS claim + aged worker-status; pre-fix decision
+# CONVERGED / exit 0 / "STOP dispatch; deliver") now reads
+# BLOCKED / exit 4 via the shared #595 stuck action (CONVERGED -> BLOCKED);
+# the same face with a fresh worker now reads SATURATED / exit 3
+# (CONVERGED -> SATURATED, busy-poll).
 # 2026-09-05 re-pin (#51 value loop unification): #51 removed the
 # KUNGLAO_VALUE_ALGO experiment flag (no-backcompat policy), making
 # rho_checkpoint.attach_signals an UNCONDITIONAL part of decide() — the

--- a/tests/test_decide_state_machine.py
+++ b/tests/test_decide_state_machine.py
@@ -83,6 +83,7 @@ def test_event_enum_declared_with_landed_vocabulary() -> None:
         "DRAIN_CLEAN",
         "WORK_AND_FREE_SLOT", "PARTIALS_AND_FREE_SLOT", "WORK_NO_FREE_SLOT",
         "STUCK_WORKERS_PRESENT",     # #595 silent-detect consumes stuck_workers
+        "ACTIVE_WORKERS_PRESENT",    # #98 DRAIN: live worker on a drained claim surface
         "FAILURE_ARTIFACTS_DUE",     # #495 validated_capability/identified_obstacle
         "LADDER_REQUIRED_BLOCKER",   # #497 climb-the-ladder flavor
         "LADDER_EXHAUSTED_BLOCKER",  # #497 ladder-exhaustion marker
@@ -269,3 +270,119 @@ def test_decision_comes_from_verdict_mapping() -> None:
         state, _ = _run_machine(_decide_inputs(ws))
         assert (d["decision"], d["exit_code"]) == VERDICTS[state], \
             f"case {name}: decide() verdict disagrees with machine terminal state"
+
+
+# ------------------------------------------------------- #98 DRAIN worker gates
+
+def _backdate(path: Path, minutes: int) -> None:
+    import os
+    import time
+    old = time.time() - minutes * 60
+    os.utime(path, (old, old))
+
+
+def _mk_inprogress_ws(base: Path, name: str, worker_age_min: int) -> Path:
+    """Issue #98 probe shape: all-IN_PROGRESS claim surface (opens==0,
+    partials==0 -> SCHEMA routes DRAINED -> DRAIN) + one worker-status file
+    with a backdated mtime. `_open_claims` excludes IN_PROGRESS, so this
+    workspace has an EMPTY claim face while a worker is live — the exact
+    false-CONVERGED window the issue's probe reproduced on dev b1c54b7."""
+    ws = anchor._ws(base, name)
+    anchor._reg(ws, [anchor._claim("C-1", status="IN_PROGRESS")])
+    anchor._ts(ws, anchor._pq("[]"))
+    status_file = ws / "runs" / "worker-status-C-1.md"
+    status_file.write_text(
+        "claim C-1 | step x | status: in-progress\n", encoding="utf-8")
+    _backdate(status_file, worker_age_min)
+    return ws
+
+
+def test_drain_stuck_worker_not_converged_98(tmp_path: Path) -> None:
+    """#98 probe (the spec): single IN_PROGRESS claim + 35-min-old
+    worker-status (STUCK_MINUTES=20). Pre-fix this declared
+    CONVERGED / exit 0 / "STOP dispatch; deliver" over live work — the
+    DRAIN probe table never consulted worker data. Post-fix: BLOCKED with
+    the #595 stuck-worker action (which also frees the claim per #607)."""
+    ws = _mk_inprogress_ws(tmp_path, "drain_stuck_98", worker_age_min=35)
+    d = cc.decide(ws)
+    assert d["decision"] != "CONVERGED", (
+        f"#98: decide() declared {d['decision']} over a stuck worker "
+        f"(age {d['stuck_workers']})")
+    assert d["decision"] == "BLOCKED", \
+        f"#98: stuck worker must escalate BLOCKED, got {d['decision']}"
+    assert d["exit_code"] == cc.EXIT_BLOCKED
+    assert d["stuck_workers"], "#98: stuck data must feed the verdict"
+    assert "Stuck worker" in d["action"], \
+        f"#98: action must name the stuck workers, got: {d['action'][:200]}"
+
+
+def test_drain_active_worker_not_converged_98(tmp_path: Path) -> None:
+    """#98 (alive leg): a FRESH worker on an otherwise-drained claim surface
+    must not read CONVERGED either — work is in flight, so the verdict is
+    SATURATED (busy: poll workers, delivery forbidden) rather than BLOCKED
+    (which means escalate — nothing is wrong with a healthy worker)."""
+    ws = _mk_inprogress_ws(tmp_path, "drain_active_98", worker_age_min=1)
+    d = cc.decide(ws)
+    assert d["decision"] != "CONVERGED", (
+        f"#98: decide() declared {d['decision']} with {d['active_workers']} "
+        f"live worker(s) in flight")
+    assert d["decision"] == "SATURATED", \
+        f"#98: live worker on drained surface must poll (SATURATED), got {d['decision']}"
+    assert d["exit_code"] == cc.EXIT_SATURATED
+    assert "worker" in d["action"].lower(), \
+        f"#98: action must direct polling, got: {d['action'][:200]}"
+
+
+def test_drain_probe_table_consults_workers_98() -> None:
+    """#98: the DRAIN probe table must consult worker data BEFORE the
+    DRAIN_CLEAN catch-all (which is always-true, so anything after it can
+    never fire). STUCK precedes ACTIVE: a stuck worker is also counted
+    active, and its BLOCKED escalation (+ #607 claim reopen) must win over
+    the poll verdict."""
+    STAGE_PROBES, State, Event = (
+        _surface("STAGE_PROBES"), _surface("State"), _surface("Event"))
+    assert STAGE_PROBES and State and Event
+    drain = STAGE_PROBES[State.DRAIN]
+    assert Event.STUCK_WORKERS_PRESENT in drain, \
+        "#98: DRAIN has no stuck-worker predicate (root cause)"
+    assert Event.ACTIVE_WORKERS_PRESENT in drain, \
+        "#98: DRAIN has no active-worker predicate"
+    stuck_idx = drain.index(Event.STUCK_WORKERS_PRESENT)
+    active_idx = drain.index(Event.ACTIVE_WORKERS_PRESENT)
+    clean_idx = drain.index(Event.DRAIN_CLEAN)
+    assert stuck_idx < active_idx < clean_idx, (
+        f"#98: DRAIN worker gates must sit stuck<active<DRAIN_CLEAN, "
+        f"got stuck={stuck_idx} active={active_idx} clean={clean_idx}")
+
+
+def test_drain_worker_transition_rows_98() -> None:
+    """#98: the two new DRAIN rows bind stuck -> BLOCKED (sharing the #595
+    action builder with the SCHEDULE row — one stuck semantics, two stages)
+    and active -> SATURATED with a poll action."""
+    TRANSITIONS, State, Event = (
+        _surface("TRANSITIONS"), _surface("State"), _surface("Event"))
+    assert TRANSITIONS and State and Event
+    stuck_row = TRANSITIONS[(State.DRAIN, Event.STUCK_WORKERS_PRESENT)]
+    sched_stuck = TRANSITIONS[(State.SCHEDULE, Event.STUCK_WORKERS_PRESENT)]
+    assert stuck_row[0] is State.BLOCKED, \
+        f"#98: DRAIN stuck must land BLOCKED, got {stuck_row[0]}"
+    assert stuck_row[1] is sched_stuck[1], \
+        "#98: DRAIN and SCHEDULE stuck rows must share one #595 action builder"
+    active_row = TRANSITIONS[(State.DRAIN, Event.ACTIVE_WORKERS_PRESENT)]
+    assert active_row[0] is State.SATURATED, \
+        f"#98: DRAIN active-worker must land SATURATED, got {active_row[0]}"
+
+
+def test_active_workers_present_predicate_98(tmp_path: Path) -> None:
+    """#98: the new predicate reads the snapshot's worker count — true iff a
+    worker is alive (this is the data the DRAIN table used to ignore)."""
+    PRED, Event, _decide_inputs = (
+        _surface("_EVENT_PREDICATES"), _surface("Event"), _surface("_decide_inputs"))
+    assert PRED and Event and _decide_inputs
+    pred = PRED[Event.ACTIVE_WORKERS_PRESENT]
+    live = _mk_inprogress_ws(tmp_path, "pred_live", worker_age_min=1)
+    assert pred(_decide_inputs(live)) is True
+    quiet = anchor._ws(tmp_path, "pred_quiet")
+    anchor._reg(quiet, [])
+    anchor._ts(quiet, anchor._pq("[]"))
+    assert pred(_decide_inputs(quiet)) is False


### PR DESCRIPTION
Closes #98
Closes #99

## Summary
Two CRITICAL decision-machine fixes, TDD (11 new tests, RED-first verified), zero anchor drift.

### #98 — DRAIN no longer converges over live workers
- New `ACTIVE_WORKERS_PRESENT` event (Events + predicates + STAGE_PROBES[DRAIN] + TRANSITIONS, four-site sync)
- DRAIN probe order: frozen completion-transaction sequence, then `STUCK_WORKERS_PRESENT` (shares the #595 action: BLOCKED + stuck report + #607 reopen), then `ACTIVE_WORKERS_PRESENT` (SATURATED busy-poll), then DRAIN_CLEAN
- Probe reproduction: 1 IN_PROGRESS claim + 35-min-stale worker-status: before = CONVERGED rc=0 "STOP dispatch; deliver" / after = BLOCKED rc=4 with the claim reopened to OPEN (#607); fresh worker -> SATURATED rc=3

### #99 — crash containment
- `EXIT_CRASHED = 65` in the exit-code registry (now documented as a consumer contract), main() wraps decide(): catch-all -> stdout {"decision":"CRASHED"} + stderr keeps the traceback
- Probe: malformed register: before = rc=1 (byte-identical to EXIT_DISPATCH), 0-byte stdout / after = rc=65, parseable stdout, yaml error on stderr

## Anchor ledger
**Zero drift, no re-pin**: 32/32 frozen cases byte-identical (the new DRAIN predicates only read worker data the corpus's DRAIN cases do not have). Zero-drift verification + the two un-anchored live semantic changes (stuck: CONVERGED->BLOCKED rc=4; active: CONVERGED->SATURATED rc=3) recorded in the anchor test's precedent-chain header.

## Test plan
- [x] 11 new tests green (state machine 5 + crash-exit 6), including probe scenarios and exit-code distinctness
- [x] Full suite: 12 failed / 5695 passed — 11 dev README reds (#96 / PR #115) + 1 machine-local env_check (verified pre-existing on bare dev HEAD worktree)
- [x] deploy-manifest regenerated (380 entries verified); SKILL.md decision table carries CRASHED|65