### PR TITLE
fix(#103): fail-open tiering — discriminators survive bad bytes, per-claim tolerance, CJK grounding checks, except classification

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -243,7 +243,7 @@ files:
   - src: scripts/convergence_check.py
     dest: .claude/scripts/convergence_check.py
     kind: scaffold
-    sha256: 3431dead6e71a65ca60999053a3a131026d9354fb1e764411c00b1c2174cd1ef
+    sha256: eb4c622f3b509f834b8f61bb00ae3e92d701c8e602c94c0b41da4aa139c45f2c
   - src: scripts/convergence_health.py
     dest: .claude/scripts/convergence_health.py
     kind: scaffold
@@ -431,7 +431,7 @@ files:
   - src: scripts/kunglao-decide.py
     dest: .claude/scripts/kunglao-decide.py
     kind: scaffold
-    sha256: 8434031bae08019f500934deb61ee4ce30fdae488b0350b43c44d52d08ecd92e
+    sha256: 386d55662bb3338c670333f885bb7d21c54161fabefb74e5dda482abc0f1e220
   - src: scripts/kunglao-digest.py
     dest: .claude/scripts/kunglao-digest.py
     kind: scaffold
@@ -559,7 +559,7 @@ files:
   - src: scripts/notes_discriminator.py
     dest: .claude/scripts/notes_discriminator.py
     kind: scaffold
-    sha256: 2553703d1ab0ff8bb58463d89d962dc583b5a116938f0157185971763a178154
+    sha256: 3feec4b348ca3a7c875ba35ef4b298f3c7c1eb608807f1decf5130eaa04298b3
   - src: scripts/notes_gate.py
     dest: .claude/scripts/notes_gate.py
     kind: scaffold
@@ -611,7 +611,7 @@ files:
   - src: scripts/priority_ratio.py
     dest: .claude/scripts/priority_ratio.py
     kind: scaffold
-    sha256: d3c078bdde46d57fa43778c85a592381a57dc45c791135780100c6fd292e806a
+    sha256: 4b817584d03c8fba9d406ea35cd8c276e136e52c894915235173d1c9ff06b90c
   - src: scripts/progress_report.py
     dest: .claude/scripts/progress_report.py
     kind: scaffold
@@ -743,7 +743,7 @@ files:
   - src: scripts/summary_discriminator.py
     dest: .claude/scripts/summary_discriminator.py
     kind: scaffold
-    sha256: 73537b5e7c1377d5463a27a34acc077e203312da9d8379acb528f9539d6d852d
+    sha256: 360201f58a8f210e531a1ff0e8a2deeb7eef478be4aadd3ce1b1a970d2436c38
   - src: scripts/template_gen.py
     dest: .claude/scripts/template_gen.py
     kind: scaffold

--- a/scripts/convergence_check.py
+++ b/scripts/convergence_check.py
@@ -437,13 +437,23 @@ def _dispatched_ids(workspace: Path) -> list:
     recorded worker attempt (promotion_attempts >= 1). Terminal/PARK claims
     are never live frontier work. Consumer: convergence_health._stuck_claims
     — a claim sitting in open_ids is only "stuck" if it was ever dispatched;
-    open_ids minus this set is the never-dispatched queue. Best effort: any
-    read/parse failure returns [] (same side-channel posture as the ledger).
+    open_ids minus this set is the never-dispatched queue.
+
+    #103 per-claim tolerance: a dirty promotion_attempts on ONE claim must
+    not wipe the dispatch evidence of ALL claims — the pre-#103 blanket
+    except turned one bad row into [] for the whole register, killing stuck
+    detection downstream. Rows now degrade individually; only a whole-file
+    read/parse failure returns [] (absence of data, not silence about it).
     """
     try:
         reg = _load_yaml(workspace / "claim-register.yaml")
-        out = []
-        for c in (reg.get("claims") or []):
+    except (AttributeError, OSError, TypeError, ValueError, yaml.YAMLError):
+        # whole-register unread: settlement input keeps its absence shape,
+        # narrowed to the realistic IO/parse family (#103 tiering)
+        return []
+    out = []
+    for c in (reg.get("claims") or []):
+        try:
             if not c.get("id"):
                 continue
             status = (c.get("status") or "").upper()
@@ -451,9 +461,10 @@ def _dispatched_ids(workspace: Path) -> list:
                 continue
             if status in IN_PROGRESS_STATUSES or int(c.get("promotion_attempts") or 0) >= 1:
                 out.append(c["id"])
-        return out
-    except Exception:  # noqa: BLE001 — side channel, never blocks the decision
-        return []
+        except (AttributeError, TypeError, ValueError):
+            # dirty row (#103): skip it, keep the rest of the collection
+            continue
+    return out
 
 
 def _append_ledger(workspace: Path, d: dict) -> None:

--- a/scripts/convergence_check.py
+++ b/scripts/convergence_check.py
@@ -77,6 +77,15 @@ EXIT_PARK = 5  # #634: suspended on external gates — legal idle with wake_cond
 
 from harness_common import utc_now  # #863 Family F: single source (was a local def)
 
+# #103 exception tiering: the exception family a JUDGMENT-INPUT reader
+# (gate / discriminator / settlement input) may degrade on — IO, parse,
+# and data-shape errors from operator-editable files. Anything outside
+# this tuple is a programming error and must SURFACE (upstream it becomes
+# a conservative BLOCKED with an `error` field), not be eaten by a blanket
+# `except Exception` that silently turns a broken input into a pass.
+_GATE_INPUT_EXC = (AttributeError, ImportError, KeyError, OSError,
+                   TypeError, ValueError, yaml.YAMLError)
+
 
 def _load_yaml(p: Path):
     return (yaml.safe_load(p.read_text(encoding="utf-8")) or {}) if p.exists() else {}
@@ -533,7 +542,9 @@ def _failure_blocked(workspace: Path) -> list:
         return []
     try:
         return [b["claim_id"] for b in fag.scan_workspace(workspace) if b.get("state") == "BLOCKED"]
-    except Exception:
+    except _GATE_INPUT_EXC:
+        # #103 tiering: judgment input (failure-analysis gate) — IO/parse/
+        # shape errors degrade, programming errors surface, never blanket.
         return []
 
 
@@ -664,8 +675,8 @@ class _DecideInputs:
             try:
                 from hypothesis_store import HypothesisStore
                 hyps = HypothesisStore(self.workspace / "hypotheses").list_open()
-            except Exception:
-                hyps = []  # layer error — fail-open per design D7
+            except _GATE_INPUT_EXC:
+                hyps = []  # layer error — fail-open per design D7 (#103: narrowed to IO/parse/shape)
             self._open_hyps = hyps
         return self._open_hyps
 
@@ -686,7 +697,7 @@ class _DecideInputs:
                     self.workspace / "facts" / "_INDEX.md",
                     self.workspace / "facts",
                 )
-            except Exception:
+            except Exception:  # fail-open: telemetry side channel (informational observation, D5)
                 anomalies = []  # fail-open per design.md D5
             self._anomalies = anomalies
         return self._anomalies
@@ -708,7 +719,9 @@ class _DecideInputs:
                     reason = (
                         f"{len(discoveries)} unconsumed discovery(s) in {names} "
                         f"-> create child obligations or record materiality rejection")
-            except Exception as exc:
+            except _GATE_INPUT_EXC as exc:
+                # #103 tiering: obligation-gate input; degradation stays
+                # VISIBLE via the explicit "scan unavailable" reason.
                 reason = f"discovery scan unavailable ({type(exc).__name__})"
             self._discovery_reason = reason
         return self._discovery_reason
@@ -730,6 +743,9 @@ class _DecideInputs:
                             f"{c['fact_a']} <-> {c['fact_b']}" for c in conflicts)
                         reason = f"GLOBAL CONTRADICTION: {pairs}"
                 except Exception as exc:  # fail-closed: cannot verify → cannot converge
+                    # #103 classification: judgment input handled as an
+                    # explicit surfaced reason (any exception BLOCKS with
+                    # the cause) — intentional blanket, keep.
                     reason = f"contradiction scan unavailable ({type(exc).__name__})"
             self._contradiction_reason = reason
         return self._contradiction_reason
@@ -746,7 +762,7 @@ class _DecideInputs:
             try:
                 import ask_for_direction_gate as afdg
                 ids = list(afdg.find_ladder_exhaustion(self.workspace))
-            except Exception:
+            except Exception:  # fail-open: telemetry side channel (event-label flavor only)
                 ids = []
             open_ids = {c["id"] for c in self.opens}
             self._ladder_ids = [i for i in ids if i in open_ids]
@@ -952,7 +968,7 @@ def _scan_proven_facts(workspace: Path) -> dict[str, str]:
     proven: dict[str, str] = {}
     try:
         text = idx.read_text(encoding="utf-8", errors="replace")
-    except Exception:
+    except OSError:  # #103: only a read can fail here — narrowed, no blanket
         return {}
     for line in text.splitlines():
         if "|" not in line:
@@ -999,7 +1015,7 @@ def _detect_contradiction(hyp_body: str, candidates: list[str],
                         if cand.lower() == after:
                             snippet = conclusion[:80]
                             return f"Contradicted: {fid} ({kw.rstrip()} {cand}, conclusion: {snippet})"
-    except Exception:
+    except Exception:  # fail-open: telemetry side channel (annotation flavor on an already-blocking verdict)
         pass
     return None
 
@@ -1014,7 +1030,7 @@ def _act_open_hypothesis(s: _DecideInputs) -> str:
     # Scan PROVEN facts for contradiction annotations
     try:
         proven = _scan_proven_facts(s.workspace)
-    except Exception:
+    except OSError:  # #103: annotation input, read-only failure mode — narrowed
         proven = {}
     annotations: list[str] = []
     for h in hyps:
@@ -1376,7 +1392,7 @@ def decide(workspace: Path, *, emit_snapshot: bool = True) -> dict:
                                       "blockers; no active workers; no "
                                       "pending partials")
                 decision["wake_condition"] = wake
-        except Exception:  # noqa: BLE001 — downgrade is advisory-safe
+        except Exception:  # noqa: BLE001 — fail-open: telemetry side channel (advisory PARK downgrade; failure keeps the machine verdict)
             pass
     # #634: mission-level stall fingerprint — ΔV_m flat K checkpoints while
     # open work remains. Proposal semantics: annotate + emit, never mutate
@@ -1400,14 +1416,14 @@ def decide(workspace: Path, *, emit_snapshot: bool = True) -> dict:
                                  "(predicted_observation required); the "
                                  "bet leads the next dispatch"),
                 }
-            except Exception:  # noqa: BLE001 — advisory face only
+            except Exception:  # noqa: BLE001 — fail-open: telemetry side channel (advisory face only)
                 pass
             if emit_snapshot:
                 from kunglao_log import emit as _emit_stall
                 _emit_stall(workspace, actor="convergence_check",
                             action="mission_stall",
                             detail=json.dumps(ms, ensure_ascii=False))
-    except Exception:  # noqa: BLE001 — fingerprint unavailable → no annotation
+    except Exception:  # noqa: BLE001 — fail-open: telemetry side channel (fingerprint unavailable → no annotation)
         pass
     # #823 A2: N-arm first-order value signals — shadow posture (always-on
     # since #51: the dict gains the `value_signals` key and one shadow emit).
@@ -1419,7 +1435,7 @@ def decide(workspace: Path, *, emit_snapshot: bool = True) -> dict:
         try:
             from carrier_consistency import check as _carrier_check
             cv = _carrier_check(workspace)
-        except Exception as exc:  # noqa: BLE001 — drift includes checker error
+        except Exception as exc:  # noqa: BLE001 — fail-closed via explicit violation: drift includes checker error (#103: intentional blanket, keep)
             cv = {"ok": False,
                   "violations": ["(x) carrier checker error: " + str(exc)]}
         if not cv.get("ok", True):
@@ -1441,7 +1457,7 @@ def decide(workspace: Path, *, emit_snapshot: bool = True) -> dict:
     try:
         from heartbeat import gap_alarm as _gap_alarm
         gap = _gap_alarm(Path(workspace))
-    except Exception:  # noqa: BLE001 — advisory-safe, never deadlock decide
+    except Exception:  # noqa: BLE001 — fail-open: telemetry side channel (advisory alarm, never deadlocks decide)
         gap = None
     if gap is not None and gap.get("alarm") is True:
         decision["heartbeat_gap"] = gap
@@ -1478,7 +1494,7 @@ def _emit_decision_snapshot(ws, d: dict) -> None:
             rows = pr.priority_ratio(claims, {}, pr.EvidenceView())
             top = [{"id": r.claim_id, "score": round(float(r.score), 4)}
                    for r in rows[:5]]
-        except Exception:
+        except Exception:  # fail-open: telemetry side channel (top-5 preview inside the snapshot)
             top = []
         from kunglao_log import emit
         emit(ws, actor="convergence_check", action="decision_snapshot",
@@ -1487,7 +1503,7 @@ def _emit_decision_snapshot(ws, d: dict) -> None:
                  "status_counts": counts,
                  "top_priorities": top,
              }, ensure_ascii=False))
-    except Exception:
+    except Exception:  # fail-open: telemetry side channel (snapshot emit, #287 contract)
         pass
 
 
@@ -1547,7 +1563,7 @@ def main(argv: list[str] | None = None) -> int:
                      f"partial={d['partial_count']} slots={d['free_slots']} "
                      f"workers={d['active_workers']}"),
              exit=d["exit_code"])
-    except Exception:
+    except Exception:  # fail-open: telemetry side channel (event-log mirror, #287)
         pass
     if args.json:
         print(json.dumps(d, indent=2, ensure_ascii=False))

--- a/scripts/kunglao-decide.py
+++ b/scripts/kunglao-decide.py
@@ -69,7 +69,10 @@ def _cheapness_order(claims: list[dict], deps: dict) -> list[pr.Action]:
         cid = c.get("id")
         if not cid or not pr.is_open(c):
             continue
-        if int(c.get("promotion_attempts", 0)) >= 3:
+        # #103: same per-claim int guards as priority_ratio — a dirty
+        # register field must not freeze the whole DECIDE in conservative
+        # BLOCKED via _conservative_blocked.
+        if pr.attempts_of(c) >= 3:
             continue
         parents = depends_on.get(cid, []) or []
         if any(p not in terminal_ids for p in parents):
@@ -77,8 +80,8 @@ def _cheapness_order(claims: list[dict], deps: dict) -> list[pr.Action]:
         ch = pr.cheapness(c)
         rows.append(pr.Action(
             claim_id=cid, action=pr.classify_action(c), score=ch, skill=None,
-            tier=min(int(c.get("evidence_tier_attempted", 0)) + 1, 3),
-            attempts=int(c.get("promotion_attempts", 0)),
+            tier=pr.action_tier(c),
+            attempts=pr.attempts_of(c),
             leverage=0.0, discriminator=0.0, novelty=0.0, cost=pr.action_cost(c),
         ))
     rows.sort(key=lambda a: a.score, reverse=True)

--- a/scripts/notes_discriminator.py
+++ b/scripts/notes_discriminator.py
@@ -68,12 +68,16 @@ def check(notes_dir, facts_dir, max_overlap: float = DEFAULT_MAX_OVERLAP) -> dic
 
     ids = fact_ids(fact_files)
     corpus: set = set()
+    # #103: 读文件统一 errors="replace"——一个非法 UTF-8 字节降级为内容
+    # 继续判定，不许升格成 UnicodeDecodeError（否则 completion_gate 的
+    # fail-open 笼子会把它吞成 PASS，R1/R2/R3 全部失效）。
     for f in fact_files:
-        corpus |= _words(_body(f.read_text(encoding="utf-8")))
+        corpus |= _words(_body(f.read_text(encoding="utf-8",
+                                          errors="replace")))
 
     checked = 0
     for n in note_files:
-        body = _body(n.read_text(encoding="utf-8"))
+        body = _body(n.read_text(encoding="utf-8", errors="replace"))  # #103
         checked += 1
         words = _words(body)
         if not words:

--- a/scripts/notes_discriminator.py
+++ b/scripts/notes_discriminator.py
@@ -80,16 +80,17 @@ def check(notes_dir, facts_dir, max_overlap: float = DEFAULT_MAX_OVERLAP) -> dic
         body = _body(n.read_text(encoding="utf-8", errors="replace"))  # #103
         checked += 1
         words = _words(body)
-        if not words:
-            continue
-        # R1 复制即拒
-        overlap = len(words & corpus) / len(words)
-        if overlap > max_overlap:
-            violations.append(
-                f"{n.name}: copied fact body (word-set overlap "
-                f"{overlap:.2f} > max_overlap {max_overlap:.2f})")
-            continue
-        # R2/R3 引用检查
+        if words:
+            # R1 复制即拒——只有 R1 依赖词集。#103: _WORD_RE 只收 [a-z0-9]，
+            # 纯中文 note（本仓库工作语言！）词集为空；空词集仅跳过 R1，
+            # 决不能连 R2/R3 引用检查一起跳过——fact-id 正则与语言无关。
+            overlap = len(words & corpus) / len(words)
+            if overlap > max_overlap:
+                violations.append(
+                    f"{n.name}: copied fact body (word-set overlap "
+                    f"{overlap:.2f} > max_overlap {max_overlap:.2f})")
+                continue
+        # R2/R3 引用检查（语言无关，空词集照查）
         refs = {t.replace("-", "").upper() for t in _FACT_REF_RE.findall(body)}
         if not refs:
             violations.append(

--- a/scripts/priority_ratio.py
+++ b/scripts/priority_ratio.py
@@ -307,9 +307,28 @@ def classify_action(claim: dict) -> str:
 
 # ---------- VoI components ----------
 
+def _int_flag(value) -> tuple[int, bool]:
+    """int conversion with a dirty flag (#103 per-claim tolerance).
+
+    A register field that fails to parse ("two", a mapping, None) degrades
+    to (0, True) — never a ValueError/TypeError escaping one claim's row
+    into the whole-workspace conservative BLOCKED. The dirty flag feeds the
+    Action.feeds diagnostic instead of a crash.
+    """
+    try:
+        return int(value), False
+    except (TypeError, ValueError):
+        return 0, True
+
+
+def attempts_of(claim: dict) -> int:
+    """promotion_attempts → int; unparseable → 0 (#103)."""
+    return _int_flag(claim.get("promotion_attempts", 0))[0]
+
+
 def action_tier(claim: dict) -> int:
-    """Action tier = min(evidence_tier_attempted + 1, 3)."""
-    return min(int(claim.get("evidence_tier_attempted", 0)) + 1, 3)
+    """Action tier = min(evidence_tier_attempted + 1, 3); dirty value → tier 1 (#103)."""
+    return min(_int_flag(claim.get("evidence_tier_attempted", 0))[0] + 1, 3)
 
 
 def action_cost(claim: dict) -> float:
@@ -796,7 +815,7 @@ def priority_ratio(claims: list[dict], deps: dict, evidence: EvidenceView) -> li
         cid = c.get("id")
         if not cid or not is_open(c):
             continue
-        if int(c.get("promotion_attempts", 0)) >= 3:
+        if attempts_of(c) >= 3:  # #103: dirty value → 0, never a row-crash
             continue
         parents = depends_on.get(cid, []) or []
         if any(p not in terminal for p in parents):
@@ -850,6 +869,13 @@ def priority_ratio(claims: list[dict], deps: dict, evidence: EvidenceView) -> li
                    else "no dispatch history (runs/strategy-log.jsonl) — "
                         "repetition proxy inert")
         feeds = {"L": l_state, "D": d_state, "N": n_state}
+        # #103: attempts conversion is per-claim guarded; a dirty raw value
+        # scores as 0 and surfaces here as a feed diagnostic instead of
+        # freezing the whole DECIDE run in conservative BLOCKED.
+        attempts, attempts_dirty = _int_flag(c.get("promotion_attempts", 0))
+        if attempts_dirty:
+            feeds["A"] = (f"promotion_attempts={c.get('promotion_attempts')!r} "
+                          "unparseable -> treated as 0 (#103)")
         cost = action_cost(c)
         numerator = WEIGHTS["L"] * L + WEIGHTS["D"] * D + WEIGHTS["N"] * N
         # #759 H2: the user's structured worth ruling multiplies the final
@@ -872,7 +898,7 @@ def priority_ratio(claims: list[dict], deps: dict, evidence: EvidenceView) -> li
         score = round(numerator / cost_eff * weight * bonus, 3)
         actions.append(Action(
             claim_id=cid, action=action_cat, score=score, skill=None,
-            tier=action_tier(c), attempts=int(c.get("promotion_attempts", 0)),
+            tier=action_tier(c), attempts=attempts,
             leverage=round(L, 3), discriminator=round(D, 6),
             novelty=round(N, 3), cost=cost,
             weight=weight, gap_bucket=gap_bucket, feeds=feeds,

--- a/scripts/summary_discriminator.py
+++ b/scripts/summary_discriminator.py
@@ -52,12 +52,16 @@ def check(summary_path, facts_dir, ledger_path=None) -> dict:
 
     summary 缺失 → ok（无可查对象）。不可读输入抛异常（fail-open 归调用方）。
     ledger_path 缺省时自动发现 summary 同工作区的 runs/mission_ledger.yaml。
+
+    #103: 所有文件读取统一 errors="replace"——一个非法 UTF-8 字节必须降级
+    为内容（U+FFFD）继续判定，绝不许升格成 UnicodeDecodeError 把整条判别
+    链推进调用方的 fail-open 笼子变成 PASS。
     """
     summary_path = Path(summary_path)
     facts_dir = Path(facts_dir)
     if not summary_path.exists():
         return {"ok": True, "violations": [], "checked": 0}
-    text = summary_path.read_text(encoding="utf-8")
+    text = summary_path.read_text(encoding="utf-8", errors="replace")
     if ledger_path is None:
         cand = summary_path.parent / LEDGER_REL
         ledger_path = cand if cand.exists() else None
@@ -69,7 +73,7 @@ def check(summary_path, facts_dir, ledger_path=None) -> dict:
         fid = _fid(f.name)
         if fid is None:
             continue
-        raw = f.read_text(encoding="utf-8")
+        raw = f.read_text(encoding="utf-8", errors="replace")  # #103
         fm = _frontmatter(raw)
         status = ""
         m = _FM_STATUS_RE.search(fm)
@@ -99,7 +103,8 @@ def check(summary_path, facts_dir, ledger_path=None) -> dict:
                 f"但 summary 未提及且未 WAIVED")
     # R3 未答主问题节
     if ledger_path is not None and Path(ledger_path).exists():
-        led = yaml.safe_load(Path(ledger_path).read_text(encoding="utf-8")) or {}
+        led = yaml.safe_load(Path(ledger_path).read_text(
+            encoding="utf-8", errors="replace")) or {}  # #103
         pqs = (led.get("mission") or {}).get("pqs") or []
         open_pqs = [str(p.get("id")) for p in pqs
                     if str(p.get("state")) in ("unattempted", "blocked")]

--- a/tests/test_failopen_tiering_103.py
+++ b/tests/test_failopen_tiering_103.py
@@ -31,6 +31,7 @@ sys.path.insert(0, str(SCRIPTS))
 
 import notes_discriminator as nd  # noqa: E402
 import summary_discriminator as sd  # noqa: E402
+import convergence_check as cc  # noqa: E402
 import rollup  # noqa: E402
 from _factories import write_hook_state  # noqa: E402
 
@@ -168,6 +169,42 @@ def test_completion_gate_bad_byte_blocks_not_passes(tmp_path, capsys):
     decision = json.loads(out)
     assert decision["decision"] == "block"
     assert "SUMMARY_FAKE" in decision["reason"], decision["reason"]
+
+
+# ---------------------------------------------------------------------------
+# 场景 2：一行脏值抹掉全部 dispatch 证据
+# ---------------------------------------------------------------------------
+
+def test_dispatched_ids_survives_dirty_dict_row(tmp_path):
+    """{a: b} 脏行只损失它自己；C-2 的 attempts=1 证据保留。"""
+    reg = tmp_path / "claim-register.yaml"
+    reg.write_text(yaml.safe_dump({"claims": [
+        {"id": "C-1", "status": "OPEN",
+         "promotion_attempts": {"a": "b"}},
+        {"id": "C-2", "status": "OPEN", "promotion_attempts": 1},
+    ]}, allow_unicode=True), encoding="utf-8")
+    assert cc._dispatched_ids(tmp_path) == ["C-2"]
+
+
+def test_dispatched_ids_survives_dirty_string_row(tmp_path):
+    """promotion_attempts: two（issue 原例）同样 per-claim 容错。"""
+    reg = tmp_path / "claim-register.yaml"
+    reg.write_text(yaml.safe_dump({"claims": [
+        {"id": "C-1", "status": "OPEN", "promotion_attempts": "two"},
+        {"id": "C-2", "status": "OPEN", "promotion_attempts": 1},
+    ]}, allow_unicode=True), encoding="utf-8")
+    assert cc._dispatched_ids(tmp_path) == ["C-2"]
+
+
+def test_dispatched_ids_keeps_in_progress_despite_dirty_neighbor(tmp_path):
+    """IN_PROGRESS 行与脏行共存：状态证据与 attempts 证据都不被连带抹掉。"""
+    reg = tmp_path / "claim-register.yaml"
+    reg.write_text(yaml.safe_dump({"claims": [
+        {"id": "C-1", "status": "OPEN",
+         "promotion_attempts": {"a": "b"}},
+        {"id": "C-2", "status": "IN_PROGRESS", "promotion_attempts": 0},
+    ]}, allow_unicode=True), encoding="utf-8")
+    assert cc._dispatched_ids(tmp_path) == ["C-2"]
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_failopen_tiering_103.py
+++ b/tests/test_failopen_tiering_103.py
@@ -269,5 +269,61 @@ def test_action_tier_dirty_tier_degrades_not_raises():
     assert pr.action_tier({}) == 1
 
 
+# ---------------------------------------------------------------------------
+# 场景 4：CJK note 跳判（`if not words: continue` 连 R2/R3 一起跳）
+# ---------------------------------------------------------------------------
+
+def test_cjk_note_without_refs_gets_r2_violation(tmp_path):
+    """纯中文零引用 note 必须触发 R2（引用正则与语言无关）。"""
+    facts_dir = tmp_path / "facts"
+    facts_dir.mkdir()
+    (facts_dir / "F001.md").write_text(
+        "the payload registers its exception handler at 0x14002abcd.\n",
+        encoding="utf-8")
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "C-001.md").write_text(
+        "---\nid: C-001\nclaim_id: C-001\nverify_status: pending\n---\n"
+        "载荷在初始化阶段注册了异常处理钩子，并据此完成时序还原，结论成立。\n",
+        encoding="utf-8")
+    r = nd.check(notes_dir, facts_dir)
+    assert r["ok"] is False
+    assert any("no fact-id reference" in v for v in r["violations"]), r
+
+
+def test_cjk_note_with_ref_passes(tmp_path):
+    """带引用的中文 note 仍放行（R1 跳过空词集不误伤合法叙事）。"""
+    facts_dir = tmp_path / "facts"
+    facts_dir.mkdir()
+    (facts_dir / "F001.md").write_text(
+        "the payload registers its exception handler at 0x14002abcd.\n",
+        encoding="utf-8")
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "C-001.md").write_text(
+        "---\nid: C-001\nclaim_id: C-001\nverify_status: pending\n---\n"
+        "载荷在初始化阶段注册了异常处理钩子（F001），时序结论暂定，待动态复核。\n",
+        encoding="utf-8")
+    r = nd.check(notes_dir, facts_dir)
+    assert r["ok"] is True, r["violations"]
+
+
+def test_cjk_dangling_ref_gets_r3_violation(tmp_path):
+    """中文 note 引用了不存在的 fact id → R3 悬空照查。"""
+    facts_dir = tmp_path / "facts"
+    facts_dir.mkdir()
+    (facts_dir / "F001.md").write_text(
+        "the payload registers its exception handler at 0x14002abcd.\n",
+        encoding="utf-8")
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "C-001.md").write_text(
+        "---\nid: C-001\nclaim_id: C-001\nverify_status: pending\n---\n"
+        "载荷钩子时序已还原（F009），结论成立。\n", encoding="utf-8")
+    r = nd.check(notes_dir, facts_dir)
+    assert r["ok"] is False
+    assert any("unknown fact id" in v for v in r["violations"]), r
+
+
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_failopen_tiering_103.py
+++ b/tests/test_failopen_tiering_103.py
@@ -32,6 +32,7 @@ sys.path.insert(0, str(SCRIPTS))
 import notes_discriminator as nd  # noqa: E402
 import summary_discriminator as sd  # noqa: E402
 import convergence_check as cc  # noqa: E402
+import priority_ratio as pr  # noqa: E402
 import rollup  # noqa: E402
 from _factories import write_hook_state  # noqa: E402
 
@@ -205,6 +206,67 @@ def test_dispatched_ids_keeps_in_progress_despite_dirty_neighbor(tmp_path):
         {"id": "C-2", "status": "IN_PROGRESS", "promotion_attempts": 0},
     ]}, allow_unicode=True), encoding="utf-8")
     assert cc._dispatched_ids(tmp_path) == ["C-2"]
+
+
+# ---------------------------------------------------------------------------
+# 场景 3：DECIDE 整体冻结（int() 裸转换一路逃逸到 conservative BLOCKED）
+# ---------------------------------------------------------------------------
+
+def _decide_ws(tmp_path):
+    ws = tmp_path / "ws"
+    (ws / "runs").mkdir(parents=True)
+    (ws / "claim-register.yaml").write_text(yaml.safe_dump({"claims": [
+        {"id": "C-1", "status": "OPEN", "statement": "probe one",
+         "promotion_attempts": "two"},
+        {"id": "C-2", "status": "OPEN", "statement": "probe two",
+         "promotion_attempts": 1},
+    ]}, allow_unicode=True), encoding="utf-8")
+    return ws
+
+
+def _load_kd():
+    name = "kunglao_decide_103"
+    mod = sys.modules.get(name)
+    if mod is None:
+        spec = importlib.util.spec_from_file_location(
+            name, SCRIPTS / "kunglao-decide.py")
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+    return mod
+
+
+def test_decide_not_frozen_by_dirty_attempts(tmp_path):
+    """场景 3：promotion_attempts: two → 决策照常产出，不整体 BLOCKED。"""
+    kd = _load_kd()
+    ws = _decide_ws(tmp_path)
+    out = kd.decide(ws)
+    assert out.get("error") is None, out
+    assert out["decision"] == "DISPATCH", out
+    assert out["top_actions"], "both claims must remain dispatchable"
+
+
+def test_priority_ratio_dirty_attempts_zero_with_feed_note():
+    """场景 3 单元面：脏行按 0 计分 + feeds 诊断；干净行 attempts 不受影响。"""
+    claims = [
+        {"id": "C-1", "status": "OPEN", "promotion_attempts": "two"},
+        {"id": "C-2", "status": "OPEN", "promotion_attempts": 1},
+    ]
+    rows = {a.claim_id: a for a in
+            pr.priority_ratio(claims, {}, pr.EvidenceView())}
+    assert set(rows) == {"C-1", "C-2"}
+    assert rows["C-1"].attempts == 0
+    assert rows["C-2"].attempts == 1
+    assert any("unparseable" in s or "treated as 0" in s
+               for s in rows["C-1"].feeds.values()), rows["C-1"].feeds
+    assert "A" not in rows["C-2"].feeds
+
+
+def test_action_tier_dirty_tier_degrades_not_raises():
+    """场景 3 相邻面（pr:312）：脏 evidence_tier_attempted → tier 1，不 raise。"""
+    assert pr.action_tier({"evidence_tier_attempted": "two"}) == 1
+    assert pr.action_tier({"evidence_tier_attempted": 2}) == 3
+    assert pr.action_tier({}) == 1
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_failopen_tiering_103.py
+++ b/tests/test_failopen_tiering_103.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+"""tests/test_failopen_tiering_103.py — #103 四实例 TDD（audit A6 拆分）。
+
+fail-open 无分级，导致 "不能死锁" 被实现成 "任何异常 = 通过"。四个实例：
+  1. 坏字节过交付门：fact/summary 一个非法 UTF-8 字节 → 判别器 raise
+     UnicodeDecodeError → completion_gate 双笼吞成 PASS。修法：判别器
+     read_text 统一 errors="replace"（坏字节降级为内容，不降级为通过）。
+  2. 证据清零：_dispatched_ids 全吞 except——一行脏 promotion_attempts
+     抹掉全部 claim 的 dispatch 证据。修法：per-claim 容错。
+  3. DECIDE 整体冻结：promotion_attempts: "two" → int() ValueError 一路
+     逃逸到 kunglao-decide 的 conservative BLOCKED。修法：int 转换
+     per-claim 守护（不可解析 → 0 + feeds 诊断）。
+  4. CJK 跳判：纯中文 note 词集为空 → `if not words: continue` 连 R2/R3
+     引用检查一起跳过。修法：仅 R1 依赖词集，R2/R3 照查。
+
+数据全部合成（issue #103 验收表引用），无活体用户数据。
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import notes_discriminator as nd  # noqa: E402
+import summary_discriminator as sd  # noqa: E402
+import rollup  # noqa: E402
+from _factories import write_hook_state  # noqa: E402
+
+HOOKS = ROOT / "hooks"
+
+
+# ---------------------------------------------------------------------------
+# 场景 1：坏字节过交付门（判别器 errors="replace"）
+# ---------------------------------------------------------------------------
+
+FACT_PROVEN = (
+    "---\nid: F001\nstatus: PROVEN\n---\n"
+    "handler at 0x14002abcd, allocation 0x150 via size gate.\n")
+
+# 同一 fact 的坏字节形态：0x80 混进正文（PARTIALLY-VERIFIED + 不确定性词）
+FACT_PARTIAL_BAD_BYTE = (
+    b"---\nid: F002\nstatus: PARTIALLY-VERIFIED\n---\n"
+    b"offset 0x150 \x80 unconfirmed pending dynamic check.\n")
+
+
+def _mk_ws(tmp_path, *, facts_bytes: dict | None = None,
+           facts: dict | None = None, summary: str | bytes | None = None):
+    facts_dir = tmp_path / "facts"
+    facts_dir.mkdir(exist_ok=True)
+    for name, body in (facts or {}).items():
+        (facts_dir / name).write_text(body, encoding="utf-8")
+    for name, body in (facts_bytes or {}).items():
+        (facts_dir / name).write_bytes(body)
+    if summary is not None:
+        p = tmp_path / "summary.md"
+        if isinstance(summary, bytes):
+            p.write_bytes(summary)
+        else:
+            p.write_text(summary, encoding="utf-8")
+    return tmp_path
+
+
+def test_bad_byte_fact_summary_discriminator_reports_violation(tmp_path):
+    """场景 1：fact 文件含 0x80 → sd.check 返回带 violation 的结果，不 raise。"""
+    ws = _mk_ws(tmp_path,
+                facts={"F001.md": FACT_PROVEN},
+                facts_bytes={"F002.md": FACT_PARTIAL_BAD_BYTE},
+                summary="# 分析收敛完成\n\nq1 已全部闭合，协议已完整还原。\n")
+    r = sd.check(ws / "summary.md", ws / "facts")
+    assert isinstance(r, dict) and "violations" in r
+    assert r["ok"] is False
+    assert r["violations"], "bad byte must degrade to content, never to pass"
+
+
+def test_bad_byte_summary_summary_discriminator_reports_violation(tmp_path):
+    """场景 1b：summary.md 本身含 0x80（sd:60 的 read_text）→ 不 raise 且完成词仍判。"""
+    summary_bytes = ("# 分析收敛完成\n\nfully reverse complete \x80 done\n"
+                     ).encode("utf-8", errors="ignore") + b"\x80 rest\n"
+    ws = _mk_ws(tmp_path,
+                facts={"F001.md": FACT_PROVEN,
+                       "F002.md": FACT_PARTIAL_BAD_BYTE.decode(
+                           "utf-8", errors="replace")},
+                summary=summary_bytes)
+    r = sd.check(ws / "summary.md", ws / "facts")
+    assert isinstance(r, dict) and "violations" in r
+    assert r["ok"] is False
+    assert any("completion claim" in v for v in r["violations"]), r
+
+
+def test_bad_byte_fact_notes_discriminator_reports_violation(tmp_path):
+    """场景 1c：notes 判别器的 fact 语料读取（nd:72）同样 errors="replace"。"""
+    facts_dir = tmp_path / "facts"
+    facts_dir.mkdir()
+    (facts_dir / "F001.md").write_bytes(
+        b"---\nid: F001\nstatus: PROVEN\n---\n"
+        b"handler at 0x14002abcd allocates 0x150 bytes \x80 via gate.\n")
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "C-001.md").write_text(
+        "---\nid: C-001\nclaim_id: C-001\nverify_status: pending\n---\n"
+        "This narrative concludes without citing any evidence id at all: "
+        "quixotic velvet thunderstorm.\n", encoding="utf-8")
+    r = nd.check(notes_dir, facts_dir)
+    assert isinstance(r, dict) and "violations" in r
+    assert r["ok"] is False
+    assert any("no fact-id reference" in v for v in r["violations"]), r
+
+
+def _load_gate_shim():
+    name = "completion_gate_hook_103"
+    mod = sys.modules.get(name)
+    if mod is None:
+        spec = importlib.util.spec_from_file_location(
+            name, HOOKS / "completion_gate.py")
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+    return mod
+
+
+def _gate_ws(tmp_path):
+    """激活态 would-PASS workspace（形状照抄 test_summary_fake_826）。"""
+    ws = tmp_path / "ws"
+    (ws / "runs").mkdir(parents=True)
+    (ws / "claim-register.yaml").write_text(
+        yaml.safe_dump({"claims": [{"id": "C-302", "status": "PROVEN"}]},
+                       allow_unicode=True), encoding="utf-8")
+    rollup.sweep_terminal_claims(ws)
+    write_hook_state(ws, active_hooks=["completion_gate"],
+                     ts="2026-08-13T00:00:00Z", tier="none",
+                     phase="IDLE", user_override={},
+                     expires_minutes=30)
+    (ws / "task-oracle.yaml").write_text(yaml.safe_dump(
+        {"task_text": "analyze the payload",
+         "open_items": [{"id": "OC-1", "closed_by": "verifier"}]},
+        sort_keys=False), encoding="utf-8")
+    (ws / "facts").mkdir(exist_ok=True)
+    (ws / "facts" / "F001.md").write_text(FACT_PROVEN, encoding="utf-8")
+    (ws / "facts" / "F002.md").write_bytes(FACT_PARTIAL_BAD_BYTE)
+    (ws / "notes").mkdir(exist_ok=True)
+    (ws / "notes" / "C-302.md").write_text(
+        "---\nid: C-302\nclaim_id: C-302\nverify_status: pending\n"
+        "---\n# durable result\n\n"
+        "Timing analysis: the size gate precedes the handler write. "
+        "Evidence: F001, F002.\n", encoding="utf-8")
+    # summary 会蒸发 F002 的不确定性（完成词 + 无暂定节）——若坏字节被
+    # errors=replace 降级为内容，R1/R2 必然可见。
+    (ws / "summary.md").write_text(
+        "# 分析收敛完成\n\nq1 已全部闭合，协议已完整还原。\n", encoding="utf-8")
+    return ws
+
+
+def test_completion_gate_bad_byte_blocks_not_passes(tmp_path, capsys):
+    """场景 1 交付门：坏字节不再经 UnicodeDecodeError 笼子变成 PASS → rc=7。"""
+    shim = _load_gate_shim()
+    ws = _gate_ws(tmp_path)
+    rc = shim.process_event({"cwd": str(ws)})
+    out = capsys.readouterr().out
+    assert rc != 0, f"bad byte must not dissolve into PASS, got rc=0 out={out}"
+    decision = json.loads(out)
+    assert decision["decision"] == "block"
+    assert "SUMMARY_FAKE" in decision["reason"], decision["reason"]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Closes #103

## Summary
All four probe-verified silent-failure instances fixed + the 18-site except classification, TDD (13 new tests, RED-first), rebased on post-#115 dev.

1. **Bad-byte delivery bypass**: discriminators read with errors="replace" — a 0x80 byte in a fact now degrades to content; completion_gate blocks with SUMMARY_FAKE instead of PASSing
2. **Evidence wipe**: _dispatched_ids per-claim tolerance — one dirty promotion_attempts row no longer wipes all dispatch evidence
3. **DECIDE freeze**: dirty attempts values -> guarded conversion to 0 + feeds diagnostic (priority_ratio + kunglao-decide share the helpers)
4. **CJK grounding skip**: notes without ASCII words still get R2 (ungrounded) and R3 (dangling) checks; only R1 (word-overlap) needs the word set
5. **Except tiering**: 18 sites classified — 6 narrowed (gate inputs), 2 documented intentional fail-closed, 10 tagged fail-open telemetry side channels

## Test plan
- [x] 13 new tests green (4 scenarios + completion_gate rc=7 integration)
- [x] Rebased on post-#115 dev: docsync pair green (README contract inherited)
- [x] deploy-manifest --verify green (5 re-pinned script shas)
- [ ] CI green on this PR