### PR TITLE
feat(#106): two probability objects — oracle case Bernoulli + PQ categorical + posterior ledger (pure library)

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -604,6 +604,10 @@ files:
     dest: .claude/scripts/platform_paths.py
     kind: scaffold
     sha256: 247e8a0621d7d423796f46edc63bc8eadaf980f9cfac8f1bc53d02771eed520f
+  - src: scripts/posteriors.py
+    dest: .claude/scripts/posteriors.py
+    kind: scaffold
+    sha256: a0649e4f951b8741864a647376e7200f53e9955891725c30ad8d451bbad4159c
   - src: scripts/premature_termination_detect.py
     dest: .claude/scripts/premature_termination_detect.py
     kind: scaffold

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -158,6 +158,7 @@ scripts (count in parens) · `tests` = exercised by tests/ only.
 | `local_gate.py` | 本地质量门统一入口 (#873) — __file__ 自定位 cwd 免疫；pytest+ext-scan+deploy_manifest 一条命令 | CLI |
 | `rollup.py` | terminal-transition write loop — claim→outcome_capture+lessons+narrative+checkpoint (#524) | tests |
 | `hypothesis_store.py` | hypothesis layer carrier (#528) — H-*.md parse + open→refuted/superseded state machine over `hypotheses/` | digest_build (sec_g), hooks/state_anchor, kunglao-init stub, tests |
+| `posteriors.py` | #106 两个概率对象库 — oracle case=Bernoulli（CasePosterior，Beta(1,1) 先验，runner 红绿唯一 reward 信号，pending_entries 只报告不更新）+ PQ hypothesis=categorical（PQCategorical，消除/证据双更新通道，熵可计算）+ PosteriorLedger 持久层（`runs/posteriors.yaml`，schema `posteriors-schema/1`，未知版本 raise，坏 YAML fail-open 降级）；纯库，decide/priority_ratio 接线属 #107/#108 | tests |
 | `verifier_identity.py` | verifier machine-identity extraction + verdict anchoring (#825) — md header / l2 field; ledger verdict_anchor append-only | register_proven_gate, write_gate, tests |
 | `dual_gate.py` | #868 双门验证引擎 — redteam 反例切分(disclosed/held-out) + verifier 正向核验 + 失败签名分流(CEGAR/Goodhart) + N=3 升级; 宪法隔离只出裁决 | hooks, tests |
 | `user_signal.py` | #868 用户信号核心 — 本体三分类（意愿/事实/元）路由 + 意愿域 repin 生效 + 事实域双门立案 + 座舱数据面 | hooks, tests |

--- a/scripts/posteriors.py
+++ b/scripts/posteriors.py
@@ -1,0 +1,261 @@
+# -*- coding: utf-8 -*-
+"""posteriors.py — #106 两个概率对象（库层，纯函数 + 持久化）。
+
+#97 重建卡的数据模型半张：公式层从此有随机变量——
+
+  对象 1 — oracle case = Bernoulli。每个 `oracle/cases/*.yaml` 案例是一
+  个 Bernoulli 变量（过/不过），先验 Beta(1,1)，观测 = runner 裁决。
+  **runner 红绿是系统需要的唯一 reward 信号。** 案例 scaffold 态（N 个
+  pending expected entry）随对象携带为 `pending_entries` 计数——只报告，
+  不参与 Beta 更新（decomposition 目标另有记账层）。
+
+  对象 2 — PQ hypothesis 层 = categorical。每个 primary_question 的
+  candidates 变成竞争解释上的分布：先验 = 声明候选上的归一化权重；观测
+  通道两条——`update_eliminate(name)`（eliminates_candidate，质量转移）
+  与 `update_evidence(name, strength)`（keyword/source 类证据的
+  prior-only 通道，#112 证据词表）。**PQ 熵从此可计算：H(categorical)
+  前后对比。**
+
+  持久层 — PosteriorLedger → `<ws>/runs/posteriors.yaml`，schema
+  `posteriors-schema/1`（版本字段强制；未知版本显式 raise
+  PosteriorSchemaError 响亮失败，不静默——no-backcompat 政策下读者必须
+  能探测格式）。缺失→空、坏 YAML→空+告警字段（fail-open，与 #103
+  分层一致：坏字节降级不阻塞）。
+
+边界（issue #106 Scope）：本卡只交付对象定义 + 更新律 + 持久化 + 熵——
+纯库、全测。谁消费它们做排序（#107/#108 的 decide/priority_ratio 接线）
+不在此卡。全库确定性：Thompson 抽样的 rng 由调用方注入
+`random.Random(seed)`，无全局状态。
+"""
+from __future__ import annotations
+
+import math
+import os
+from pathlib import Path
+
+import yaml
+
+SCHEMA_ID = "posteriors-schema/1"
+LEDGER_REL = "runs/posteriors.yaml"
+
+_ALPHA0 = 1.0  # Beta(1,1) 均匀先验
+_BETA0 = 1.0
+
+
+class PosteriorSchemaError(ValueError):
+    """后验账本 schema 版本未知/缺失 — 响亮拒绝，不静默降级。"""
+
+
+def entropy_bits(probs: list[float]) -> float:
+    """H = -Σ p·log2 p（bit）。纯函数；零质量项跳过（0·log0 = 0）。"""
+    h = 0.0
+    for p in probs:
+        if p < 0.0:
+            raise ValueError(f"negative probability: {p!r}")
+        if p > 0.0:
+            h -= p * math.log2(p)
+    return h
+
+
+def _require_pos(name: str, v: float) -> float:
+    fv = float(v)
+    if not (fv > 0.0) or math.isinf(fv):
+        raise ValueError(f"{name} must be a positive finite number, got {v!r}")
+    return fv
+
+
+class CasePosterior:
+    """oracle case 的 Bernoulli 后验（Beta 共轭）。
+
+    alpha/beta 即当前后验参数（构造默认 = Beta(1,1) 先验）；
+    update(passed) 按闭式共轭更新：绿 +alpha，红 +beta。
+    """
+
+    def __init__(self, case_id: str, alpha: float = _ALPHA0,
+                 beta: float = _BETA0, pending_entries: int = 0):
+        self.case_id = str(case_id)
+        self.alpha = _require_pos("alpha", alpha)
+        self.beta = _require_pos("beta", beta)
+        pe = int(pending_entries)
+        if pe < 0:
+            raise ValueError(f"pending_entries must be >= 0, got {pending_entries!r}")
+        self.pending_entries = pe
+
+    def update(self, passed: bool) -> None:
+        """一次 runner 观测的共轭闭式更新（绿 +1 alpha / 红 +1 beta）。"""
+        if passed:
+            self.alpha += 1.0
+        else:
+            self.beta += 1.0
+
+    def mean(self) -> float:
+        """后验均值 alpha/(alpha+beta) — 通过率的当前估计。"""
+        return self.alpha / (self.alpha + self.beta)
+
+    def sample(self, rng: random.Random) -> float:
+        """Thompson 抽样：Beta(alpha, beta) 一次采样。rng 由调用方注入。"""
+        return rng.betavariate(self.alpha, self.beta)
+
+    def to_dict(self) -> dict:
+        return {"alpha": self.alpha, "beta": self.beta,
+                "pending_entries": self.pending_entries}
+
+    @classmethod
+    def from_dict(cls, case_id: str, d: dict) -> "CasePosterior":
+        if not isinstance(d, dict):
+            raise ValueError(f"case {case_id!r}: payload must be a mapping")
+        return cls(case_id, alpha=d["alpha"], beta=d["beta"],
+                   pending_entries=d.get("pending_entries", 0))
+
+
+class PQCategorical:
+    """PQ hypothesis 层的 categorical 分布（竞争解释空间）。
+
+    构造时归一化；update_eliminate 把候选质量清零后重归一；
+    update_evidence 按 strength 乘概率后重归一（prior-only 通道）。
+    """
+
+    def __init__(self, pq_id: str, candidates: dict[str, float]):
+        self.pq_id = str(pq_id)
+        if not candidates:
+            raise ValueError(f"PQ {pq_id!r}: candidate set must be non-empty")
+        probs: dict[str, float] = {}
+        for name, w in dict(candidates).items():
+            fw = float(w)
+            if not (fw >= 0.0) or math.isinf(fw):
+                raise ValueError(
+                    f"PQ {pq_id!r} candidate {name!r}: weight must be "
+                    f"finite and >= 0, got {w!r}")
+            probs[str(name)] = fw
+        total = sum(probs.values())
+        if total <= 0.0:
+            raise ValueError(f"PQ {pq_id!r}: candidate weights sum to zero")
+        self._probs: dict[str, float] = {k: v / total for k, v in probs.items()}
+
+    @property
+    def probs(self) -> dict[str, float]:
+        """当前分布的只读快照（副本 — 调用方改不动内部状态）。"""
+        return dict(self._probs)
+
+    def _renormalize(self) -> None:
+        total = sum(self._probs.values())
+        if total <= 0.0:
+            raise ValueError(
+                f"PQ {self.pq_id!r}: update left zero total mass")
+        self._probs = {k: v / total for k, v in self._probs.items()}
+
+    def update_eliminate(self, name: str) -> None:
+        """eliminates_candidate 观测：该候选清零，质量归其余竞争者。"""
+        if name not in self._probs:
+            raise KeyError(f"PQ {self.pq_id!r}: unknown candidate {name!r}")
+        if len(self._probs) == 1:
+            raise ValueError(
+                f"PQ {self.pq_id!r}: cannot eliminate the last candidate")
+        self._probs[name] = 0.0
+        self._renormalize()
+
+    def update_evidence(self, name: str, strength: float) -> None:
+        """证据通道：strength>1 抬升 / <1 压低，重归一保持 Σp=1。"""
+        if name not in self._probs:
+            raise KeyError(f"PQ {self.pq_id!r}: unknown candidate {name!r}")
+        fs = float(strength)
+        if not (fs >= 0.0) or math.isinf(fs):
+            raise ValueError(f"strength must be finite and >= 0, got {strength!r}")
+        self._probs[name] *= fs
+        self._renormalize()
+
+    def entropy(self) -> float:
+        """H(categorical)，bit — 熵差就是这次观测的信息增益。"""
+        return entropy_bits(list(self._probs.values()))
+
+    def argmax(self) -> str:
+        """当前最大质量候选（并列取声明序首个 — 确定性）。"""
+        return max(self._probs, key=lambda k: self._probs[k])
+
+    def to_dict(self) -> dict:
+        return {"candidates": dict(self._probs)}
+
+    @classmethod
+    def from_dict(cls, pq_id: str, d: dict) -> "PQCategorical":
+        if not isinstance(d, dict) or not isinstance(d.get("candidates"), dict):
+            raise ValueError(f"PQ {pq_id!r}: payload must carry candidates mapping")
+        return cls(pq_id, d["candidates"])
+
+
+class PosteriorLedger:
+    """两个命名空间（cases/pqs）的后验账本，落 `<ws>/runs/posteriors.yaml`。
+
+    load 容错谱系：文件缺失 → 空 ledger（不 degraded）；坏 YAML / 顶层
+    形状坏 → 空 ledger + degraded=True + warnings（fail-open，冷启动
+    不被坏字节卡死）；schema 版本缺失或未知 → PosteriorSchemaError
+    （版本墙，响亮拒绝）。save 原子写（tmp + os.replace）。
+    """
+
+    def __init__(self, cases: dict[str, CasePosterior] | None = None,
+                 pqs: dict[str, PQCategorical] | None = None,
+                 degraded: bool = False, warnings: list[str] | None = None):
+        self.cases: dict[str, CasePosterior] = dict(cases or {})
+        self.pqs: dict[str, PQCategorical] = dict(pqs or {})
+        self.degraded = bool(degraded)
+        self.warnings: list[str] = list(warnings or [])
+
+    # ---------- persistence ----------
+
+    def to_doc(self) -> dict:
+        return {
+            "schema": SCHEMA_ID,
+            "cases": {k: v.to_dict() for k, v in self.cases.items()},
+            "pqs": {k: v.to_dict() for k, v in self.pqs.items()},
+        }
+
+    @classmethod
+    def from_doc(cls, doc: dict) -> "PosteriorLedger":
+        if doc.get("schema") != SCHEMA_ID:
+            raise PosteriorSchemaError(
+                f"posteriors ledger schema mismatch: expected "
+                f"{SCHEMA_ID!r}, got {doc.get('schema')!r} — refusing to "
+                f"read an unknown format (no-backcompat policy)")
+        led = cls()
+        for cid, d in (doc.get("cases") or {}).items():
+            try:
+                led.cases[str(cid)] = CasePosterior.from_dict(str(cid), d)
+            except (KeyError, TypeError, ValueError) as exc:
+                led.warnings.append(f"case {cid!r} skipped: {exc}")
+        for pid, d in (doc.get("pqs") or {}).items():
+            try:
+                led.pqs[str(pid)] = PQCategorical.from_dict(str(pid), d)
+            except (KeyError, TypeError, ValueError) as exc:
+                led.warnings.append(f"pq {pid!r} skipped: {exc}")
+        return led
+
+    def save(self, ws) -> Path:
+        """原子写（同目录 tmp + os.replace）；runs/ 缺失则建。"""
+        path = Path(ws) / LEDGER_REL
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(
+            yaml.safe_dump(self.to_doc(), allow_unicode=True, sort_keys=True),
+            encoding="utf-8")
+        os.replace(tmp, path)
+        return path
+
+    @classmethod
+    def load(cls, ws) -> "PosteriorLedger":
+        path = Path(ws) / LEDGER_REL
+        if not path.exists():
+            return cls()
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            return cls(degraded=True,
+                       warnings=[f"unreadable {LEDGER_REL}: {exc}"])
+        if not isinstance(doc, dict):
+            return cls(degraded=True,
+                       warnings=[f"{LEDGER_REL}: top level is not a mapping"])
+        try:
+            return cls.from_doc(doc)
+        except PosteriorSchemaError:
+            raise
+        except Exception as exc:  # 形状坏但 schema 合法 — 不该发生，兜底降级
+            return cls(degraded=True,
+                       warnings=[f"{LEDGER_REL}: malformed payload: {exc}"])

--- a/tests/test_posteriors_106.py
+++ b/tests/test_posteriors_106.py
@@ -1,0 +1,236 @@
+# -*- coding: utf-8 -*-
+"""tests/test_posteriors_106.py — #106 two probability objects (library tier).
+
+oracle case = Bernoulli (Beta posterior, runner red/green is the only
+reward signal); PQ hypothesis = categorical over competing explanations
+(elimination + prior-only evidence channel). Persistence = the
+`runs/posteriors.yaml` posterior ledger (schema `posteriors-schema/1`).
+
+Anti-fool assertions pinned by issue #106 acceptance:
+  - Beta update on red/green changes the posterior per the closed form
+  - elimination shifts categorical mass and entropy decreases strictly
+  - ledger round-trips byte-for-byte field-equal; survives a simulated
+    session restart
+  - unknown schema version fails LOUDLY (PosteriorSchemaError), never
+    silently
+"""
+from __future__ import annotations
+
+import math
+import random
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import posteriors as po  # noqa: E402
+
+# 前置实验 4 候选序列（主会话实测 2.000→~1.922→1.585→1.000→0.000）
+_PQ4 = {"alpha": 1.0, "beta": 1.0, "gamma": 1.0, "delta": 1.0}
+
+
+# ---------- Beta 闭式验证 ----------
+
+def test_beta_update_closed_form():
+    c = po.CasePosterior("C-001", alpha=2.0, beta=3.0)
+    c.update(True)
+    assert (c.alpha, c.beta) == (3.0, 3.0)
+    assert math.isclose(c.mean(), 3.0 / 6.0, abs_tol=1e-12)
+    c.update(False)
+    assert (c.alpha, c.beta) == (3.0, 4.0)
+    assert math.isclose(c.mean(), 3.0 / 7.0, abs_tol=1e-12)
+
+
+def test_beta_uniform_prior_default():
+    c = po.CasePosterior("C-001")
+    assert (c.alpha, c.beta) == (1.0, 1.0)
+    assert math.isclose(c.mean(), 0.5, abs_tol=1e-12)
+
+
+# ---------- 消除更新熵单调递减（前置实验序列） ----------
+
+def test_eliminate_entropy_strictly_monotonic():
+    pq = po.PQCategorical("PQ-1", dict(_PQ4))
+    h0 = pq.entropy()
+    assert math.isclose(h0, 2.0, abs_tol=1e-9)
+
+    # 先验-only 证据通道压低 delta，再走消除链
+    pq.update_evidence("delta", 0.4)
+    h1 = pq.entropy()
+    assert math.isclose(sum(pq.probs.values()), 1.0, abs_tol=1e-9)
+    assert h1 < h0
+
+    pq.update_eliminate("delta")
+    h2 = pq.entropy()
+    assert math.isclose(h2, math.log2(3), abs_tol=1e-9)
+    assert h2 < h1
+
+    pq.update_eliminate("gamma")
+    h3 = pq.entropy()
+    assert math.isclose(h3, 1.0, abs_tol=1e-9)
+    assert h3 < h2
+
+
+def test_eliminate_to_single_candidate_zero_entropy():
+    pq = po.PQCategorical("PQ-1", dict(_PQ4))
+    for name in ("alpha", "beta", "gamma"):
+        pq.update_eliminate(name)
+    # 置 0 语义：键保留、质量全归最后存活候选（issue 卡原文"置 0 后归一化"）
+    assert set(pq.probs) == set(_PQ4)
+    assert math.isclose(pq.probs["delta"], 1.0, abs_tol=1e-9)
+    assert all(pq.probs[k] == 0.0 for k in ("alpha", "beta", "gamma"))
+    assert pq.entropy() == 0.0
+
+
+# ---------- 证据通道保持归一化 ----------
+
+def test_update_evidence_keeps_normalization_and_direction():
+    pq = po.PQCategorical("PQ-1", {"a": 0.5, "b": 0.3, "c": 0.2})
+    pq.update_evidence("a", 3.0)
+    assert math.isclose(sum(pq.probs.values()), 1.0, abs_tol=1e-9)
+    assert pq.probs["a"] == max(pq.probs.values())  # strength>1 抬升
+    pq.update_evidence("b", 0.1)
+    assert math.isclose(sum(pq.probs.values()), 1.0, abs_tol=1e-9)
+    assert pq.probs["b"] < pq.probs["c"]  # strength<1 压低
+
+
+def test_categorical_constructor_normalizes_weights():
+    pq = po.PQCategorical("PQ-1", {"x": 2.0, "y": 2.0})
+    assert math.isclose(sum(pq.probs.values()), 1.0, abs_tol=1e-9)
+    assert math.isclose(pq.entropy(), 1.0, abs_tol=1e-9)
+    assert pq.argmax() in ("x", "y")
+
+
+def test_argmax_picks_largest_mass():
+    pq = po.PQCategorical("PQ-1", {"a": 0.2, "b": 0.5, "c": 0.3})
+    assert pq.argmax() == "b"
+
+
+# ---------- ledger round-trip + 容错/版本墙 ----------
+
+def test_ledger_roundtrip_and_restart(tmp_path):
+    led = po.PosteriorLedger()
+    led.cases["C-001"] = po.CasePosterior(
+        "C-001", alpha=3.0, beta=1.0, pending_entries=2)
+    led.pqs["PQ-1"] = po.PQCategorical(
+        "PQ-1", {"AES": 0.7, "ChaCha20": 0.3})
+
+    led.save(tmp_path)
+    back = po.PosteriorLedger.load(tmp_path)
+    assert back.degraded is False
+    assert back.warnings == []
+    assert math.isclose(back.cases["C-001"].mean(), 0.75, abs_tol=1e-12)
+    assert back.cases["C-001"].pending_entries == 2
+    assert math.isclose(back.pqs["PQ-1"].probs["AES"], 0.7, abs_tol=1e-12)
+
+    # 模拟会话重启后继续更新再落盘
+    back.cases["C-001"].update(False)
+    back.pqs["PQ-1"].update_eliminate("ChaCha20")
+    back.save(tmp_path)
+    again = po.PosteriorLedger.load(tmp_path)
+    assert math.isclose(again.cases["C-001"].mean(), 3.0 / 5.0, abs_tol=1e-12)
+    assert again.pqs["PQ-1"].entropy() == 0.0
+
+
+def test_load_missing_file_is_empty_not_degraded(tmp_path):
+    led = po.PosteriorLedger.load(tmp_path)
+    assert led.cases == {} and led.pqs == {}
+    assert led.degraded is False
+    assert led.warnings == []
+
+
+def test_bad_yaml_degrades_to_empty(tmp_path):
+    (tmp_path / "runs").mkdir()
+    (tmp_path / "runs" / "posteriors.yaml").write_text(
+        "schema: [unclosed\n  bad", encoding="utf-8")
+    led = po.PosteriorLedger.load(tmp_path)
+    assert led.cases == {} and led.pqs == {}
+    assert led.degraded is True
+    assert led.warnings, "degraded load must carry the reason"
+
+
+def test_unknown_schema_version_raises(tmp_path):
+    (tmp_path / "runs").mkdir()
+    (tmp_path / "runs" / "posteriors.yaml").write_text(
+        yaml.safe_dump({"schema": "posteriors-schema/999",
+                        "cases": {}, "pqs": {}}), encoding="utf-8")
+    try:
+        po.PosteriorLedger.load(tmp_path)
+    except po.PosteriorSchemaError:
+        pass
+    else:
+        raise AssertionError("unknown schema version must fail loudly")
+
+
+def test_missing_schema_field_raises(tmp_path):
+    (tmp_path / "runs").mkdir()
+    (tmp_path / "runs" / "posteriors.yaml").write_text(
+        yaml.safe_dump({"cases": {}, "pqs": {}}), encoding="utf-8")
+    try:
+        po.PosteriorLedger.load(tmp_path)
+    except po.PosteriorSchemaError:
+        pass
+    else:
+        raise AssertionError("missing schema field must fail loudly")
+
+
+# ---------- Thompson sample 确定性 ----------
+
+def test_thompson_sample_deterministic_same_seed():
+    c = po.CasePosterior("C-001", alpha=7.0, beta=3.0)
+    rng_a, rng_b = random.Random(2026), random.Random(2026)
+    seq_a = [c.sample(rng_a) for _ in range(8)]
+    seq_b = [c.sample(rng_b) for _ in range(8)]
+    assert seq_a == seq_b
+    assert all(0.0 <= x <= 1.0 for x in seq_a)
+    assert len(set(seq_a)) > 1  # 真抽样，非常数
+
+
+# ---------- pending_entries 不参与 Beta ----------
+
+def test_pending_entries_do_not_touch_beta_mean():
+    c0 = po.CasePosterior("C-001")
+    c1 = po.CasePosterior("C-002", pending_entries=4)
+    assert (c0.alpha, c0.beta) == (c1.alpha, c1.beta)
+    assert c0.mean() == c1.mean()
+    c1.update(True)
+    assert math.isclose(c1.mean(), 2.0 / 3.0, abs_tol=1e-12)
+    assert c1.pending_entries == 4  # 报告字段，不被动更新改写
+
+
+# ---------- 模块级纯函数 + 边界 ----------
+
+def test_entropy_bits_module_function():
+    assert math.isclose(po.entropy_bits([1.0]), 0.0, abs_tol=1e-12)
+    assert math.isclose(po.entropy_bits([0.5, 0.5]), 1.0, abs_tol=1e-12)
+    assert math.isclose(po.entropy_bits([0.25] * 4), 2.0, abs_tol=1e-12)
+
+
+def test_eliminate_last_candidate_rejected():
+    pq = po.PQCategorical("PQ-1", {"only": 1.0})
+    try:
+        pq.update_eliminate("only")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("eliminating the last candidate leaves zero "
+                             "mass — must be rejected")
+
+
+def test_unknown_candidate_name_rejected():
+    pq = po.PQCategorical("PQ-1", dict(_PQ4))
+    for bad in (lambda: pq.update_eliminate("nope"),
+                lambda: pq.update_evidence("nope", 1.0)):
+        try:
+            bad()
+        except KeyError:
+            pass
+        else:
+            raise AssertionError("unknown candidate must raise KeyError")
+
+
+def test_schema_id_is_versioned():
+    assert po.SCHEMA_ID == "posteriors-schema/1"


### PR DESCRIPTION
Closes #106

## Summary
The two probability objects the v0.1.5 rebuild ranks on — pure library, zero consumers wired (that is #107/#108), exactly as scoped.

- `CasePosterior`: oracle case = Bernoulli, Beta(1,1) prior, `update(passed)`, `mean()`, `sample(rng)` (Thompson, caller-injected RNG = deterministic), pending-entry count carried but never touching the Beta update
- `PQCategorical`: hypothesis layer = categorical, normalized at construction, `update_eliminate` / `update_evidence` (#112's prior-only channel) / `entropy()` / deterministic `argmax()`
- `PosteriorLedger`: `runs/posteriors.yaml` persistence, schema `posteriors-schema/1` (versioned per the no-backcompat policy — unknown versions raise loudly), atomic write, tolerant load with explicit degraded flag
- `entropy_bits`: module-level pure function

## Experiment-backed design
Pre-implementation experiments (documented in the v0.1.5 plan): categorical+elimination entropy is strictly monotone decreasing (2.000→1.000 bits sequence now frozen as a test); Thompson vs greedy-mean validated 67% vs 52% optimal recovery on our low-prior-good-arms shape (drives #107).

## Test plan
- [x] 18 tests RED-first (closed-form Beta check, entropy monotonicity, ledger round-trip + restart, bad-YAML degradation, unknown-schema rejection, Thompson determinism, pending-entries isolation)
- [x] Full suite: 1 failed / 5726 passed — the 1 is the machine-local env_check (python 3.14 vs pinned 3.11), zero new
- [x] deploy-manifest regenerated (posteriors.py joins the pinned surface)