### PR TITLE
fix(#100,#101): explore dependency gate aligns with exploit semantics + check_priority phase-aware authority

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -63,7 +63,7 @@ files:
   - src: hooks/worker_budget_core.py
     dest: .claude/hooks/worker_budget_core.py
     kind: hook
-    sha256: 269221d8ffdc239466dc3c9eb3d319f5475432633ed0ba9e4aa02a518fbd390e
+    sha256: dd2dbc13e92695109cc30ee824e912fdd16c918e9163fc04e88755d431cd49ac
   - src: hooks/worker_budget_gates.py
     dest: .claude/hooks/worker_budget_gates.py
     kind: hook
@@ -431,7 +431,7 @@ files:
   - src: scripts/kunglao-decide.py
     dest: .claude/scripts/kunglao-decide.py
     kind: scaffold
-    sha256: 386d55662bb3338c670333f885bb7d21c54161fabefb74e5dda482abc0f1e220
+    sha256: cabd8724342d40f34ce3ef1042f807ac811971baa14125e1d97addacecb81730
   - src: scripts/kunglao-digest.py
     dest: .claude/scripts/kunglao-digest.py
     kind: scaffold

--- a/hooks/worker_budget_core.py
+++ b/hooks/worker_budget_core.py
@@ -78,9 +78,22 @@ HOST_FORBIDDEN_TOOLS = (
 _SKILL_ROOT = Path(__file__).resolve().parent.parent
 ensure_scripts_path()  # #671 idempotent membership (was bare insert)
 try:
-    from priority_ratio import priority_ratio as _ratio_rank, EvidenceView as _EvidenceView
+    from priority_ratio import (priority_ratio as _ratio_rank,
+                                EvidenceView as _EvidenceView,
+                                Action as _Action,
+                                is_open as _ratio_is_open,
+                                attempts_of as _ratio_attempts,
+                                cheapness as _ratio_cheapness,
+                                classify_action as _ratio_classify,
+                                action_tier as _ratio_tier,
+                                action_cost as _ratio_cost)
     from retract_claim import RETRACTED  # retracted = terminal (#331)
     from status_defs import TERMINAL  # noqa: F401 — re-exported via gates surface
+    # #101: the explore-period threshold stays single-sourced in explore_gate
+    # (EXPLORE_THRESHOLD=5) — the audit must switch faces on the SAME gate
+    # DECIDE switches on, never a copied constant.
+    from explore_gate import (explore_gate as _explore_gate,
+                              EXPLORE_THRESHOLD as _EXPLORE_THRESHOLD)
     _PRIORITY_AVAILABLE = True
 except Exception:  # pragma: no cover - hook stays usable if the scorer moves
     _PRIORITY_AVAILABLE = False
@@ -219,10 +232,80 @@ def check_backtrack_gate(paths):
     return True, ''  # unknown rc -> fail open
 
 
+def _explore_cheapness_rank(claims, deps, evidence) -> list:
+    """#101 explore-period ranking authority — the SAME candidate filter,
+    cheapness score and claim_id tie-break as the DECIDE explore face
+    (scripts/kunglao-decide.py::_cheapness_order, #100): OPEN + attempts<3
+    + every depends_on parent holding a terminal fact
+    (evidence.terminal_fact_claims, #594/#596 per-claim fallback included),
+    sorted by (-cheapness, claim_id).
+
+    Mirrored rather than imported by design: the DECIDE face is a hyphenated
+    CLI no hook can import safely, and duplicating pr primitives keeps the
+    fail-open import posture. The dual-face agreement this mirror exists for
+    is pinned by tests/test_kunglao_decide.py (one ranking, never two — the
+    #499 posture, now explore-aware)."""
+    depends_on = (deps or {}).get('depends_on', {}) or {}
+    if not depends_on:
+        depends_on = {c['id']: list(c.get('depends_on') or [])
+                      for c in claims if c.get('id') and c.get('depends_on')}
+    terminal = evidence.terminal_fact_claims
+    rows = []
+    for c in claims:
+        cid = c.get('id')
+        if not cid or not _ratio_is_open(c):
+            continue
+        if _ratio_attempts(c) >= 3:  # #103 per-claim tolerance, same as DECIDE
+            continue
+        if any(p not in terminal for p in (depends_on.get(cid, []) or [])):
+            continue
+        rows.append(_Action(
+            claim_id=cid, action=_ratio_classify(c),
+            # rounded at construction like the VoI face — same 3-decimal
+            # advisory format; TIER_COST reciprocals stay distinct at 3dp,
+            # so the (-score, claim_id) ordering is unaffected.
+            score=round(_ratio_cheapness(c), 3), skill=None,
+            tier=_ratio_tier(c), attempts=_ratio_attempts(c),
+            leverage=0.0, discriminator=0.0, novelty=0.0, cost=_ratio_cost(c),
+        ))
+    rows.sort(key=lambda a: (-a.score, a.claim_id))
+    return rows
+
+
+def _audit_rank(claims, deps, evidence) -> tuple[list, str]:
+    """#101: ONE ranking authority per phase. During explore (verified facts
+    < EXPLORE_THRESHOLD, explore_gate single source) DECIDE ranks by
+    cheapness — so this audit must too, or a protocol-compliant dispatch of
+    DECIDE's own #1 is REJECTed as a "deviation" (the authority_mismatch
+    conflict class: REJECT must signal protocol failure, never a method
+    choice). Exploit period keeps the #499 VoI authority byte-identical.
+
+    Returns (actions, authority_tag) — the tag rides the advisory msg so a
+    deviation trace names the authority that judged it (post-mortem class
+    marker). explore_gate unavailable -> exploit face (fail-open to the
+    pre-#101 authority, never a crash)."""
+    try:
+        explore = _explore_gate(evidence.verified_fact_count, _EXPLORE_THRESHOLD)
+    except Exception:  # pragma: no cover - gate crash -> pre-#101 authority
+        explore = False
+    if explore:
+        return _explore_cheapness_rank(claims, deps, evidence), 'explore-cheapness'
+    return _ratio_rank(claims, deps, evidence), 'voi'
+
+
 def check_priority(reg_path, deps_path, task_spec_path, dispatched_cid, ws=None):
     """Best-first priority audit — v1.9.24 returns (ok, msg, deviated). #499:
     ranks by the authoritative VoI scorer (priority_ratio.py — specs/phase-4/
     contract.md §1), NOT the deprecated weighted module.
+
+    #101: the authority is phase-aware. During explore (verified facts <
+    EXPLORE_THRESHOLD, explore_gate single source) DECIDE ranks by cheapness,
+    so the audit uses the SAME face (_explore_cheapness_rank: same candidate
+    filter, same claim_id tie-break) — dispatching DECIDE's own #1 can never
+    REJECT as a "deviation" (the authority_mismatch conflict class). Exploit
+    period keeps the VoI authority byte-identical. The advisory msg tags the
+    authority (explore-cheapness / voi) so a deviation trace records WHICH
+    ranking judged it.
 
     Silent for rank-#1 dispatches; ADVISORY when the dispatched claim is not
     the top-ranked dispatchable one. `deviated=True` means the dispatch
@@ -268,7 +351,7 @@ def check_priority(reg_path, deps_path, task_spec_path, dispatched_cid, ws=None)
     # terminal-status row is kept: is_open already excludes it from candidacy,
     # and its row feeds the novelty fact counting (M4 guard).
     claims = [c for c in claims if (c.get('status') or '').upper() != RETRACTED]
-    actions = _ratio_rank(claims, deps, evidence)
+    actions, authority = _audit_rank(claims, deps, evidence)
     if not actions:
         return (True, '', False)
     top = actions[0]
@@ -277,9 +360,9 @@ def check_priority(reg_path, deps_path, task_spec_path, dispatched_cid, ws=None)
     rank = next((i + 1 for i, a in enumerate(actions) if a.claim_id == dispatched_cid), None)
     if rank is None:
         return (True, f'ADVISORY: {dispatched_cid} not in dispatchable set '
-                      f'(rank #1 = {top.claim_id} score {top.score}); '
+                      f'({authority} rank #1 = {top.claim_id} score {top.score}); '
                       f'blocked by deps/promotion, or already terminal?', False)
-    return (True, f'ADVISORY: dispatched {dispatched_cid} rank #{rank} '
+    return (True, f'ADVISORY [{authority}]: dispatched {dispatched_cid} rank #{rank} '
                   f'(score {actions[rank - 1].score}); rank #1 is {top.claim_id} '
                   f'(score {top.score}) - record a reasoning for the deviation.', True)
 

--- a/scripts/kunglao-decide.py
+++ b/scripts/kunglao-decide.py
@@ -59,11 +59,28 @@ def _load_yaml(path: Path) -> dict:
     return (yaml.safe_load(path.read_text(encoding="utf-8")) or {}) if path.exists() else {}
 
 
-def _cheapness_order(claims: list[dict], deps: dict) -> list[pr.Action]:
-    """Explore mode (design-spec §3.2 L132-134): same dispatchable filter; score = cheapness descending (T1 spread)."""
-    by_id = {c.get("id"): c for c in claims if c.get("id")}
+def _cheapness_order(claims: list[dict], deps: dict,
+                     evidence: pr.EvidenceView) -> list[pr.Action]:
+    """Explore mode (design-spec §3.2 L132-134): same dispatchable filter; score = cheapness descending (T1 spread).
+
+    #100: the dependency gate is the EXPLOIT-path standard, not "parent not
+    OPEN" — an IN_PROGRESS/PARK parent is work in flight or suspended, never
+    a satisfied dependency (PARK revival is explicit via mission_stall.revive,
+    #634). Satisfaction = the parent holds a terminal fact, so explore reuses
+    the very ``evidence.terminal_fact_claims`` set the VoI path gates its
+    candidates on (priority_ratio candidate filter) — both ranking faces
+    agree on what "unblocked" means. #594/#596: the same per-claim
+    depends_on fallback — claim_deps.yaml is authoritative, the
+    operator-natural register field feeds the ranking until it is populated.
+    L-1 (#100): score ties break by claim_id, not register file order — a
+    same-content register reorder must not silently reshuffle dispatch order
+    (cheapness remains a sort key, never a qualification gate).
+    """
     depends_on = (deps or {}).get("depends_on", {}) or {}
-    terminal_ids = {cid for cid, c in by_id.items() if not pr.is_open(c)}
+    if not depends_on:
+        depends_on = {c["id"]: list(c.get("depends_on") or [])
+                      for c in claims if c.get("id") and c.get("depends_on")}
+    terminal = evidence.terminal_fact_claims
     rows: list[pr.Action] = []
     for c in claims:
         cid = c.get("id")
@@ -75,7 +92,7 @@ def _cheapness_order(claims: list[dict], deps: dict) -> list[pr.Action]:
         if pr.attempts_of(c) >= 3:
             continue
         parents = depends_on.get(cid, []) or []
-        if any(p not in terminal_ids for p in parents):
+        if any(p not in terminal for p in parents):
             continue
         ch = pr.cheapness(c)
         rows.append(pr.Action(
@@ -84,7 +101,7 @@ def _cheapness_order(claims: list[dict], deps: dict) -> list[pr.Action]:
             attempts=pr.attempts_of(c),
             leverage=0.0, discriminator=0.0, novelty=0.0, cost=pr.action_cost(c),
         ))
-    rows.sort(key=lambda a: a.score, reverse=True)
+    rows.sort(key=lambda a: (-a.score, a.claim_id))
     return rows
 
 
@@ -170,7 +187,7 @@ def decide(ws: Path, scan_text: str | None = None) -> dict:
         claims = [c for c in (reg.get("claims") or []) if c.get("id") not in failure_blocked_ids]
         if eg.explore_gate(evidence.verified_fact_count, EXPLORE_THRESHOLD):
             out["explore_mode"] = True
-            actions = _cheapness_order(claims, deps)
+            actions = _cheapness_order(claims, deps, evidence)
         else:
             actions = pr.priority_ratio(claims, deps, evidence)
         for a in actions[: max(base["free_slots"], 0)]:

--- a/tests/test_kunglao_decide.py
+++ b/tests/test_kunglao_decide.py
@@ -1,0 +1,259 @@
+# -*- coding: utf-8 -*-
+"""tests/test_kunglao_decide.py — kd explore-face tests (#100, #101).
+
+#100 (explore dependency gate): the explore-mode candidate filter must use
+the EXPLOIT-path standard — a parent counts as satisfied only when it holds
+a terminal fact (``evidence.terminal_fact_claims``, the same set
+priority_ratio gates on). Pre-fix, ``terminal_ids = {cid | not is_open}``
+made IN_PROGRESS and PARK parents count as "satisfied", so explore (the
+cold-start default, verified facts < 5) dispatched children of in-flight or
+parked claims — bypassing the #634 revival protocol (revival is explicit via
+mission_stall.revive, never an explore side effect). Same per-claim
+depends_on fallback as the VoI path (#594/#596).
+
+L-1 (same card): explore ties break by claim_id, not register file order —
+a same-content register reorder must not silently reshuffle dispatch order.
+
+#101 (dual ranking authority): DECIDE explore ranks by cheapness while the
+dispatch-gate top-1 audit (worker_budget.check_priority) ranked by pure VoI
+with zero explore awareness — an orchestrator dispatching its own DECIDE #1
+was REJECTed as a "deviation" (authority_mismatch conflict class, exit 2
+without ``agent-reasoning:``). Post-fix the gate audits against the
+cheapness face during explore (same candidate filter, same tie-break) and
+keeps the VoI authority in exploit period (regression-pinned here and in
+tests/test_scorer_authority.py, whose fixtures are exploit-period seeded).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from _factories import write_claims_register
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = REPO_ROOT / "scripts"
+
+
+def _load_kd():
+    """kunglao-decide.py is hyphenated (CLI name) — importlib load, same
+    pattern as tests/test_failopen_emit.py (unique module name per file)."""
+    name = "kunglao_decide_100"
+    mod = sys.modules.get(name)
+    if mod is None:
+        spec = importlib.util.spec_from_file_location(
+            name, SCRIPTS / "kunglao-decide.py")
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_yaml(ws: Path, rel: str, doc: dict) -> None:
+    # JSON is valid YAML — keeps fixture literals readable
+    (ws / rel).write_text(json.dumps(doc), encoding="utf-8")
+
+
+def _ws(tmp_path: Path, claims: list[dict], *, deps: dict | None = None,
+        groups: dict | None = None, name: str = "ws") -> Path:
+    ws = tmp_path / name
+    (ws / "runs").mkdir(parents=True)
+    write_claims_register(ws, claims)
+    _write_yaml(ws, "claim_deps.yaml",
+                {"depends_on": deps or {}, "competitor_groups": groups or {}})
+    _write_yaml(ws, "task_spec.yaml", {"primary_questions": []})
+    return ws
+
+
+# ---------- #100: explore-mode dependency gate ------------------------------
+
+def _probe_claims(parent_status: str, *, per_claim_dep: bool) -> list[dict]:
+    child = {"id": "C-2", "status": "OPEN", "statement": "child work"}
+    if per_claim_dep:
+        child["depends_on"] = ["C-1"]
+    return [
+        {"id": "C-1", "status": parent_status, "statement": "parent work"},
+        child,
+        {"id": "C-3", "status": "OPEN", "statement": "free work"},
+    ]
+
+
+@pytest.mark.parametrize("parent_status", ["IN_PROGRESS", "PARK"])
+@pytest.mark.parametrize("per_claim_dep", [False, True],
+                         ids=["claim_deps", "per_claim_fallback"])
+def test_explore_blocks_child_of_inflight_or_park_parent(
+        tmp_path, parent_status, per_claim_dep):
+    """#100 probe: depends_on {C-2: [C-1]}, parent IN_PROGRESS/PARK →
+    explore must NOT dispatch C-2 (the #634 revival protocol is explicit;
+    an in-flight/parked parent is not a satisfied dependency). Both dep
+    faces: claim_deps.yaml authoritative and the #594/#596 per-claim
+    register fallback."""
+    kd = _load_kd()
+    deps = {} if per_claim_dep else {"C-2": ["C-1"]}
+    ws = _ws(tmp_path, _probe_claims(parent_status, per_claim_dep=per_claim_dep),
+             deps=deps)
+    out = kd.decide(ws)
+    assert out["explore_mode"] is True, out
+    ids = [a["claim_id"] for a in out["top_actions"]]
+    assert "C-2" not in ids, (
+        f"child of a {parent_status} parent must not dispatch in explore "
+        f"(#100); got top_actions={ids}")
+    assert ids == ["C-3"], f"only the dep-free claim stays dispatchable; got {ids}"
+
+
+def test_explore_allows_child_when_parent_holds_terminal_fact(tmp_path):
+    """No over-block: a parent holding a terminal fact is a satisfied
+    dependency even while its register row is still OPEN — the exact
+    evidence.terminal_fact_claims standard the VoI path applies."""
+    kd = _load_kd()
+    ws = _ws(tmp_path, _probe_claims("OPEN", per_claim_dep=False),
+             deps={"C-2": ["C-1"]})
+    facts = ws / "facts"
+    facts.mkdir()
+    (facts / "_INDEX.md").write_text(
+        "F-001 | PROVEN | C-1 | parent closed\n", encoding="utf-8")
+    out = kd.decide(ws)
+    assert out["explore_mode"] is True, out
+    ids = [a["claim_id"] for a in out["top_actions"]]
+    assert "C-2" in ids, (
+        f"a terminal-fact parent must satisfy the dependency gate; got {ids}")
+
+
+# ---------- #100 L-1: deterministic explore tie-break ------------------------
+
+def test_explore_tie_breaks_by_claim_id_not_register_order(tmp_path):
+    """Two equal-cheapness T1 claims: the dispatch order must follow
+    claim_id, not the register file order (pre-fix the stable sort kept
+    register order, so a same-content reorder silently reshuffled)."""
+    kd = _load_kd()
+    claims = [
+        {"id": "C-2", "status": "OPEN", "statement": "work two"},
+        {"id": "C-1", "status": "OPEN", "statement": "work one"},
+    ]
+    ws = _ws(tmp_path, claims)
+    out = kd.decide(ws)
+    ids = [a["claim_id"] for a in out["top_actions"]]
+    assert ids == ["C-1", "C-2"], (
+        f"equal-score ties must break by claim_id; got {ids}")
+
+
+def test_explore_dispatch_order_survives_register_reorder(tmp_path):
+    """Same register content, different file order → identical dispatch
+    order (the reorder-stability property the tie-break exists for)."""
+    kd = _load_kd()
+    claims = [
+        {"id": "C-2", "status": "OPEN", "statement": "work two"},
+        {"id": "C-1", "status": "OPEN", "statement": "work one"},
+        {"id": "C-3", "status": "OPEN", "statement": "work three",
+         "evidence_tier_attempted": 1},
+    ]
+    ws_a = _ws(tmp_path, claims, name="ws-a")
+    ws_b = _ws(tmp_path, list(reversed(claims)), name="ws-b")
+    out_a = kd.decide(ws_a)["top_actions"]
+    out_b = kd.decide(ws_b)["top_actions"]
+    assert out_a == out_b, (
+        f"register reorder must not change explore dispatch order; "
+        f"a={out_a} b={out_b}")
+
+
+# ---------- #101: one ranking authority per phase ----------------------------
+
+def _conflict_claims() -> list[dict]:
+    """Explore-period workspace where cheapness #1 != VoI #1:
+
+      C-1  plain T1            -> cheapness 1.0 (rank #1) / VoI 0.31 (#3)
+      C-2  g1 T2 + C-3 child   -> leverage 1.0 + live group D=1.0, cost 3
+                                  -> VoI 0.333 (#2) / cheapness 0.333 (#3)
+      C-3  dep-blocked child   -> not a candidate on either face
+      C-4  g1 T1               -> VoI 0.55 (#1) / cheapness 1.0 (rank #2)
+
+    Dispatching DECIDE's own explore #1 (C-1) must NOT register as a
+    deviation (pre-fix: deviated=True 'rank #3 ... rank #1 is C-4')."""
+    return [
+        {"id": "C-1", "status": "OPEN", "statement": "background work"},
+        {"id": "C-2", "status": "OPEN", "statement": "background work",
+         "competitor_group": "g1", "evidence_tier_attempted": 1},
+        {"id": "C-3", "status": "OPEN", "statement": "background work",
+         "depends_on": ["C-2"]},
+        {"id": "C-4", "status": "OPEN", "statement": "background work",
+         "competitor_group": "g1"},
+    ]
+
+
+def _conflict_ws(tmp_path, name="ws") -> Path:
+    return _ws(tmp_path, _conflict_claims(),
+               deps={"C-3": ["C-2"]},
+               groups={"g1": ["C-2", "C-4"]}, name=name)
+
+
+def test_explore_dispatch_of_decide_top1_passes_gate(tmp_path):
+    """#101 acceptance: during explore, dispatching DECIDE's own #1 passes
+    check_priority without agent-reasoning (deviated=False) — the gate
+    audits the same cheapness ranking DECIDE used."""
+    kd = _load_kd()
+    import worker_budget as wb
+    ws = _conflict_ws(tmp_path)
+    out = kd.decide(ws)
+    assert out["explore_mode"] is True, out
+    assert out["top_actions"], out
+    assert out["top_actions"][0]["claim_id"] == "C-1", (
+        f"explore #1 must be the cheap-T1 C-1; got {out['top_actions']}")
+    ok, msg, deviated = wb.check_priority(
+        str(ws / "claim-register.yaml"), str(ws / "claim_deps.yaml"),
+        str(ws / "task_spec.yaml"), "C-1", ws=ws)
+    assert (ok, deviated) == (True, False), (
+        f"dispatching DECIDE explore #1 must pass the gate silently "
+        f"(#101 authority_mismatch); got ok={ok} deviated={deviated} "
+        f"msg={msg!r}")
+
+
+def test_explore_deviation_msg_names_explore_authority(tmp_path):
+    """#101 trace requirement: an explore-period deviation is judged under
+    the cheapness authority — the advisory msg names it so post-mortems can
+    distinguish the authority class from a VoI deviation."""
+    import worker_budget as wb
+    ws = _conflict_ws(tmp_path, name="ws-auth")
+    _ok, msg, deviated = wb.check_priority(
+        str(ws / "claim-register.yaml"), str(ws / "claim_deps.yaml"),
+        str(ws / "task_spec.yaml"), "C-2", ws=ws)
+    assert deviated is True, f"C-2 is cheapness rank #3; got msg={msg!r}"
+    assert "explore" in msg.lower(), (
+        f"explore-period deviation msg must name the ranking authority "
+        f"(#101 authority class); got {msg!r}")
+
+
+def test_exploit_period_keeps_voi_authority(tmp_path):
+    """Regression guard: past the explore gate (verified facts >= 5) the
+    VoI authority is byte-preserved — C-4 (0.55) outranks C-1 (0.06), the
+    exact opposite of the explore face."""
+    import worker_budget as wb
+    ws = _conflict_ws(tmp_path, name="ws-exploit")
+    claims = [{"id": "C-T", "status": "DEFERRED", "statement": "background work"}]
+    reg = ws / "claim-register.yaml"
+    reg.write_text(reg.read_text(encoding="utf-8")
+                   + "\n".join(f"- id: {c['id']}\n  status: {c['status']}\n"
+                               f"  statement: {c['statement']}\n"
+                               for c in claims), encoding="utf-8")
+    facts = ws / "facts"
+    facts.mkdir()
+    (facts / "_INDEX.md").write_text(
+        "".join(f"F-90{i} | PROVEN | C-T | terminal evidence\n"
+                for i in range(1, 6)), encoding="utf-8")
+    kd = _load_kd()
+    out = kd.decide(ws)
+    assert out["explore_mode"] is False, out
+    ok, msg, deviated = wb.check_priority(
+        str(ws / "claim-register.yaml"), str(ws / "claim_deps.yaml"),
+        str(ws / "task_spec.yaml"), "C-4", ws=ws)
+    assert (ok, deviated) == (True, False), (
+        f"exploit-period VoI #1 (C-4) must stay a silent dispatch; "
+        f"got deviated={deviated} msg={msg!r}")
+    ok, msg, deviated = wb.check_priority(
+        str(ws / "claim-register.yaml"), str(ws / "claim_deps.yaml"),
+        str(ws / "task_spec.yaml"), "C-1", ws=ws)
+    assert deviated is True, (
+        f"exploit-period C-1 (VoI rank #3) must still register as a "
+        f"deviation; got msg={msg!r}")

--- a/tests/test_scorer_authority.py
+++ b/tests/test_scorer_authority.py
@@ -106,6 +106,17 @@ def _authority_ws(path: Path, *, failure_case: bool = False) -> Path:
     (path / "task_spec.yaml").write_text("primary_questions: []\n", encoding="utf-8")
     (path / "runs" / "worker-status-W-1.md").write_text(
         "[12:00] step: work done | status: done\n", encoding="utf-8")
+    # #101: these tests pin the VOI authority, which since #101 governs the
+    # EXPLOIT period only (explore period audits the cheapness face — see
+    # tests/test_kunglao_decide.py). Seed verified facts >= EXPLORE_THRESHOLD
+    # via rows citing C-0, a register-external claim id (facts outliving a
+    # pruned claim are a legal orphan state): novelty counts derive from
+    # in-register claims only, so NO scoring input moves — exactly one thing
+    # changes, the gate phase, and every pinned rank/score below stays true.
+    (path / "facts").mkdir()
+    (path / "facts" / "_INDEX.md").write_text(
+        "".join(f"F-90{i} | PROVEN | C-0 | terminal evidence\n"
+                for i in range(1, 6)), encoding="utf-8")
     write_hook_state(path, active_hooks=["worker_pulse"],
                      phase="test", tier="none", user_override={},
                      expires_at=None)
@@ -196,11 +207,17 @@ def _novelty_ws(path: Path) -> Path:
     (path / "claim_deps.yaml").write_text(
         json.dumps({"depends_on": {}, "competitor_groups": {}}), encoding="utf-8")
     (path / "task_spec.yaml").write_text("primary_questions: []\n", encoding="utf-8")
+    # #101: five PROVEN rows (not three) push the workspace past the explore
+    # gate — this test pins the EXPLOIT-period VoI authority. The extra rows
+    # cite the SAME terminal claims, so the per-claim category counts (the
+    # thing the novelty assertion is about) are untouched.
     (path / "facts").mkdir()
     (path / "facts" / "_INDEX.md").write_text(
         "F-101 | PROVEN | C-D1 | c2 config extracted\n"
         "F-102 | PROVEN | C-D2 | c2 config extracted\n"
-        "F-103 | PROVEN | C-D3 | c2 config extracted\n", encoding="utf-8")
+        "F-103 | PROVEN | C-D3 | c2 config extracted\n"
+        "F-104 | PROVEN | C-D1 | c2 config extracted\n"
+        "F-105 | PROVEN | C-D2 | c2 config extracted\n", encoding="utf-8")
     return path
 
 


### PR DESCRIPTION
Closes #100
Closes #101

## Summary
- **#100**: `_cheapness_order` dependency gate now reuses `EvidenceView.terminal_fact_claims` (same semantics as the exploit candidate filter) + the #594/#596 per-claim depends_on fallback; tie-break gains the claim_id final key (register reorders no longer flip dispatch order). Probe: IN_PROGRESS/PARK parent -> child NOT dispatched (before: dispatched); OPEN parent with terminal fact -> correctly dispatched (the fix also removed an over-blocking case).
- **#101**: `check_priority` becomes phase-aware — explore period ranks by the same cheapness ordering DECIDE uses (one authority per phase), exploit period keeps VoI byte-identical; explore_gate unavailable -> fail-open to VoI. True deviations still flagged, now with an authority tag (`explore-cheapness` / `voi`) in the ADVISORY message. Probe: dispatching DECIDE's own explore #1 no longer yields deviated=True.

## Test plan
- [x] 10 new tests RED-first (dependency gates x4 faces, tie-break x2, #101 probe x3, exploit-period VoI regression guard)
- [x] Anchors: decide-regression + kd + priority_ratio suites 53 passed — zero drift
- [x] Full suite: 1 failed / 5718 passed (machine-local env_check only)
- [x] deploy-manifest re-pinned (380 entries verified)