### PR TITLE
fix(#102): cross-process contract single-source — ledger action-field classify, plan_drift crash face, contracts.py registry

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -19,7 +19,7 @@ files:
   - src: hooks/dispatch_gate.py
     dest: .claude/hooks/dispatch_gate.py
     kind: hook
-    sha256: fc1a855054e141d9240af3c0309cd16a57a79e204540caa0b2e444e1c043bdc5
+    sha256: a86d60b82354b8a8ffb074852d9d52327c9c95a939f950ff598124dfbf358d34
   - src: hooks/env_check_gate.py
     dest: .claude/hooks/env_check_gate.py
     kind: hook
@@ -240,10 +240,14 @@ files:
     dest: .claude/scripts/content_hash.py
     kind: scaffold
     sha256: 91c582700d08363dcd6c19525bf4dde93b1128d1aa16444432f7d04f3d695c7c
+  - src: scripts/contracts.py
+    dest: .claude/scripts/contracts.py
+    kind: scaffold
+    sha256: a45248e8ae7cb1d7e98975a3b7042331ab811766948e96e41164779e5a3dafb0
   - src: scripts/convergence_check.py
     dest: .claude/scripts/convergence_check.py
     kind: scaffold
-    sha256: e77915b6915d61f3a8d9dfaf3f9f8d2b82af20c9a94b61e0fe2f55ad0f71f99a
+    sha256: d7dfaa9679cb56391a6798bbba38f6600606cff0cc2202571ded5f0e54367b1a
   - src: scripts/convergence_health.py
     dest: .claude/scripts/convergence_health.py
     kind: scaffold
@@ -331,7 +335,7 @@ files:
   - src: scripts/event_taxonomy.py
     dest: .claude/scripts/event_taxonomy.py
     kind: scaffold
-    sha256: 0cf5e9985f05b850f6894c82d40fff728abd7f0f38faa64be99677f6494bd9ee
+    sha256: 5a83dddcee364d6cde0deaf304524bb4131aaf7792b4daddd41c7442d3bef8f4
   - src: scripts/explore_gate.py
     dest: .claude/scripts/explore_gate.py
     kind: scaffold

--- a/hooks/dispatch_gate.py
+++ b/hooks/dispatch_gate.py
@@ -745,7 +745,8 @@ def _capability_guard(ws: Path, claim_id: str, prompt_text: str,
         "the validated family.")
 
 
-def _plan_drift_auto(ws: Path, claim_id: str, prompt_text: str) -> int | None:
+def _plan_drift_auto(ws: Path, claim_id: str, prompt_text: str,
+                     trace_id: str | None = None) -> int | None:
     """#602: plan-drift auto-integration wire-up for L621 dispatch path entry.
 
     Shells out to scripts/plan_drift_detector.py --auto and translates its
@@ -753,7 +754,13 @@ def _plan_drift_auto(ws: Path, claim_id: str, prompt_text: str) -> int | None:
       - exit 2 (drift-severe, 1+ non-WARN drift)     -> return 2 (BLOCKED)
       - exit 3 (WARN-only, STALE_PLAN_ON_NEW_EVIDENCE) -> return 3 (SATURATED)
       - exit 0 (no drift)                            -> return None (fall through)
-      - any other / missing / unparseable workspace  -> return None (fail-open)
+      - any OTHER rc (crash / unknown drift)         -> crash face (#102):
+          return None (fail-open) BUT observed — stderr note + a
+          plan_drift_crashed trace row carrying the rc and the detector's
+          last stderr line. Under --auto the only contracted bytes are the
+          contracts.PLAN_DRIFT_AUTO_RCS trio; pre-#102 anything else fell
+          through SILENTLY (dispatch proceeded, traceback discarded, zero
+          telemetry).
 
     NON-FATAL by design: a false-positive is acceptable — the operator
     can re-dispatch. This is a PreToolUse safety net, NOT a hard gate;
@@ -770,6 +777,13 @@ def _plan_drift_auto(ws: Path, claim_id: str, prompt_text: str) -> int | None:
     script = SKILL_DIR / "scripts" / "plan_drift_detector.py"
     if not script.exists():
         return None
+    try:
+        with scripts_on_path():  # #671 scoped membership
+            from contracts import PLAN_DRIFT_AUTO_RCS
+    except Exception:  # noqa: BLE001 — registry unavailable: degraded copy
+        # of the documented trio (hook crash-safety, NOT a second authority;
+        # contracts.py owns the value — #102).
+        PLAN_DRIFT_AUTO_RCS = frozenset({0, 2, 3})
     try:
         proc = _sp.run(
             [sys.executable, str(script), str(ws), "--auto"],
@@ -796,7 +810,29 @@ def _plan_drift_auto(ws: Path, claim_id: str, prompt_text: str) -> int | None:
               "WARN-only, observe-first",
               file=sys.stderr, flush=True)
         return 3
-    # rc 0 (no drift) or any unexpected -> fall through
+    if rc == 0:
+        # no drift -> fall through
+        return None
+    # #102 crash face: rc outside contracts.PLAN_DRIFT_AUTO_RCS (rc=1 = an
+    # unhandled exception inside the detector, e.g. a malformed
+    # claim-register.yaml). Fail-open stays (NON-FATAL posture), but the
+    # degradation is OBSERVABLE on both channels — stderr for the operator
+    # tail, plan_drift_crashed trace row (exit=rc + stderr tail) for the
+    # post-mortem. Never a silent fall-through again.
+    try:
+        err_lines = [ln.strip() for ln in (proc.stderr or "").splitlines()
+                     if ln.strip()]
+        err_tail = err_lines[-1] if err_lines else ""
+    except Exception:  # noqa: BLE001 — the observation must not be the crash
+        err_tail = ""
+    print(f"dispatch_gate: plan-drift auto CRASHED (rc={rc}) ({claim_id}): "
+          f"detector degraded, dispatch proceeding (fail-open). "
+          f"last stderr: {err_tail[:200]}",
+          file=sys.stderr, flush=True)
+    _emit_trace(ws, "plan_drift_crashed", claim_id,
+                f"reason=plan_drift_crash; rc={rc}; "
+                f"stderr_tail={err_tail[:200]}",
+                exit_code=rc, trace_id=trace_id)
     return None
 
 
@@ -1332,8 +1368,10 @@ def main() -> int:
     # #602: plan-drift auto-integration — runs BEFORE the existing dispatch
     # block. Drift-severe -> BLOCKED (rc=2); drift-warning -> SATURATED
     # (rc=3); no drift -> None (fall through). NON-FATAL: false-positive is
-    # acceptable (operator can re-dispatch).
-    rc = _plan_drift_auto(ws, claim_id, prompt_text)
+    # acceptable (operator can re-dispatch). #102: a crash rc takes the
+    # observable degrade face (plan_drift_crashed trace row) — trace_id
+    # rides so the row attributes to the mission chain.
+    rc = _plan_drift_auto(ws, claim_id, prompt_text, trace_id=trace_id)
     if rc is not None:
         return rc
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -194,6 +194,7 @@ scripts (count in parens) · `tests` = exercised by tests/ only.
 | --- | --- | --- |
 | `gate_telemetry.py` | gate telemetry wrapper (decorator + ledger) | lib(8) |
 | `content_hash.py` | fact/content hashing (golden capture too) | tools, tests |
+| `contracts.py` | cross-process contract registry (#102) — exit-code registry (convergence 0-5 + 64/65, plan_drift --auto trio `PLAN_DRIFT_AUTO_RCS`), event field schema (`EVENT_FIELD="action"`), gate-subprocess legal rc sets; single definition imported by every producer/consumer face (drift of this class can no longer pass CI) | hooks, lib(2: convergence_check, event_taxonomy), tests |
 | `normalize_trace.py` | dynamic trace normalization | tools, tests |
 | `fixture_excerpt_lint.py` | fixture excerpt lint (standalone CLI) | tests, docs |
 | `references_recall.py` | references scored-recall CLI over the layered index — scenario → primary/supplementary; keyword → top-K ranked rows with score (no file dumps); `--list-categories` / `--scene-map` / `--ws` | tests, docs |

--- a/scripts/contracts.py
+++ b/scripts/contracts.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""contracts.py — cross-process contract registry (#102, split from #95 A5).
+
+Root cause of the #102 drift family: producers and consumers each defined
+the same byte-level contract in separate comments (event field name, exit
+codes, subprocess rc sets). When one side moved, the other silently read
+fabricated zeros or misattributed a crash as a pass. This module is the
+single source both sides import; a contract change lands here FIRST.
+
+Scope discipline (#102 review note): this file only REGISTERS contracts
+that already exist in shipped code — it invents nothing. Each block names
+its owning face. Declarations are alignment obligations, not runtime
+enforcement: consumers import their face, and the cross-parser contract
+test (tests/test_contracts_drift_102.py) pins the round trip.
+"""
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Exit-code registry — the CONSUMER CONTRACT (#99 wording, moved here by
+# #102). scripts/convergence_check.py imports these names (the definition
+# lives ONLY here; convergence_check's `cc.EXIT_*` attributes are this
+# module's objects). Every rc-based consumer — hooks that branch on 0-4,
+# kunglao-decide, external tick loops — reads the same bytes. Before adding
+# a value: keep the registry distinct AND update skills/kunglao-agent/
+# SKILL.md's decision table (the human-facing copy of this contract).
+# ---------------------------------------------------------------------------
+
+# --- convergence_check face (scripts/convergence_check.py decide() rc) ----
+EXIT_CONVERGED = 0
+EXIT_DISPATCH = 1
+EXIT_VERIFY = 2
+EXIT_SATURATED = 3
+EXIT_BLOCKED = 4
+EXIT_PARK = 5  # #634: suspended on external gates — legal idle with wake_condition
+EXIT_MISSING_WORKSPACE = 64  # convergence_check.main(): no claim-register.yaml
+# #99: the check itself crashed (malformed YAML, unexpected error). 64 is
+# taken by MISSING_WORKSPACE; 65 is the next free byte. A crash must NEVER
+# share EXIT_DISPATCH's byte — pre-#99 a malformed register exited rc=1,
+# which rc-based consumers read as "dispatch now" while stdout was empty.
+# On this exit: stdout carries {"decision": "CRASHED"}, stderr the traceback.
+EXIT_CRASHED = 65
+
+# --- plan_drift_detector --auto face (#602 integration remap) -------------
+# The ONLY bytes --auto may exit with: 0 no-drift (proceed) / 2 drift-severe
+# (BLOCKED) / 3 WARN-only (SATURATED). Any OTHER rc is not a contract value
+# — it is a detector crash (rc=1: unhandled exception, e.g. a malformed
+# claim-register.yaml) or an unknown drift. hooks/dispatch_gate.
+# _plan_drift_auto must take the explicit crash face on everything outside
+# this set (#102: fail-open dispatch, OBSERVED degradation — never a silent
+# fall-through).
+PLAN_DRIFT_AUTO_RCS = frozenset({0, 2, 3})
+
+# ---------------------------------------------------------------------------
+# Event field schema
+# ---------------------------------------------------------------------------
+
+# The field carrying the event word in the kunglao_log stream
+# (scripts/kunglao_log.py emit(): "action": action). The ledger stream's
+# sibling face (kunglao_record.record_event) writes the SAME controlled
+# word in `event_type`; event_taxonomy's ledger branch reads BOTH fields
+# through LEDGER_EVENT_MAP. #102 drift instance 1: the taxonomy keyed on
+# `event_type` only, so every kunglao_log-shaped row classified as None —
+# seven main-stream classes read as fabricated zeros in statusline/digest.
+EVENT_FIELD = "action"

--- a/scripts/convergence_check.py
+++ b/scripts/convergence_check.py
@@ -70,24 +70,18 @@ from ws_layout import resolve_quiet as _resolve_ws
 
 WORKER_CAP = 3
 
-# Exit codes — CONSUMER CONTRACT (#99). Every rc-based consumer (hooks that
-# branch on 0-4, kunglao-decide, external tick loops) reads these bytes; a
-# collision makes one state masquerade as another. Before adding a value,
-# check the registry below AND skills/kunglao-agent/SKILL.md's decision
-# table (the human-facing copy of this contract).
-EXIT_CONVERGED = 0
-EXIT_DISPATCH = 1
-EXIT_VERIFY = 2
-EXIT_SATURATED = 3
-EXIT_BLOCKED = 4
-EXIT_PARK = 5  # #634: suspended on external gates — legal idle with wake_condition
-# #99: the check itself crashed (malformed YAML, unexpected error). 64 is
-# taken by MISSING_WORKSPACE (main()'s no-claim-register exit); 65 is the
-# next free byte. A crash must NEVER share EXIT_DISPATCH's byte — pre-#99 a
-# malformed register exited rc=1, which rc-based consumers read as
-# "dispatch now" while stdout was empty. On this exit: stdout carries
-# {"decision": "CRASHED"}, stderr keeps the traceback.
-EXIT_CRASHED = 65
+# Exit codes — CONSUMER CONTRACT (#99). The registry itself moved to
+# scripts/contracts.py (#102: producers and consumers kept re-stating the
+# same bytes in separate comments — the root cause of the #102 drift
+# family). This module imports its face; the names below ARE the registry
+# values (single definition in contracts.py; the human-facing copy stays
+# skills/kunglao-agent/SKILL.md's decision table). The #99 rationale for
+# EXIT_CRASHED=65 (64 taken by MISSING_WORKSPACE; a crash must never share
+# EXIT_DISPATCH's byte — stdout {"decision": "CRASHED"}, stderr traceback)
+# lives with the definition.
+from contracts import (EXIT_BLOCKED, EXIT_CONVERGED, EXIT_CRASHED,  # noqa: E402
+                       EXIT_DISPATCH, EXIT_MISSING_WORKSPACE, EXIT_PARK,
+                       EXIT_SATURATED, EXIT_VERIFY)
 
 
 from harness_common import utc_now  # #863 Family F: single source (was a local def)
@@ -1602,7 +1596,7 @@ def main(argv: list[str] | None = None) -> int:
     workspace = _resolve_ws(args.workspace)
     if not (workspace / "claim-register.yaml").exists():
         print(f"FAIL: no claim-register.yaml under {workspace}", file=sys.stderr)
-        return 64
+        return EXIT_MISSING_WORKSPACE
 
     # #99: decide() is untrusted input territory (claim-register.yaml is
     # hand- and hook-edited YAML). An unguarded crash exits rc=1 — the SAME

--- a/scripts/event_taxonomy.py
+++ b/scripts/event_taxonomy.py
@@ -77,6 +77,7 @@ def _worker_protocol():
 # restating a hard number here would rot silently when the value changes).
 from liveness_policy import STUCK_MINUTES  # noqa: E402
 from kunglao_log import iter_jsonl  # noqa: E402  (#863 Family K single source)
+from contracts import EVENT_FIELD  # noqa: E402  (#102 event-field schema single source)
 STUCK_SECONDS = STUCK_MINUTES * 60
 
 # ---------------------------------------------------------------------------
@@ -212,6 +213,7 @@ EMIT_ACTIONS = [
     "must_stop",
     "orchestrator_mcp_reject",  # #601 main-agent direct MCP host-channel REJECT face (orchestrator_tool_guard)
     "orchestrator_tool_violation",  # #608 orchestrator Bash-face analysis-binary WARN (emitted since #608; registered late — its literal hides behind a parenthesized emit arg)
+    "plan_drift_crashed",  # #102 dispatch_gate: plan_drift --auto crash face (fail-open, observed)
     "plan_review",        # #822 stage-plan review ritual: maintain/adjust/replan verdict face
     "plan_stall",
     "priority_deviation",
@@ -254,6 +256,16 @@ EMIT_ACTIONS = [
     "zero_output_break",  # #823 A4 same-type action thrash circuit face
 ]
 
+# #102: word -> taxonomy class for the ledger stream. The stream has TWO
+# producer faces sharing one scan (classify_workspace reads BOTH
+# ledger.jsonl and runs/logs/kunglao-*.jsonl with source="ledger"):
+#   - kunglao_record.record_event writes the word in `event_type`
+#   - kunglao_log.emit writes the SAME controlled word in `action`
+#     (contracts.EVENT_FIELD — #102 drift instance 1: this branch keyed on
+#     `event_type` only, so every kunglao_log-shaped row classified as None
+#     and the seven classes read as fabricated zeros in statusline/digest)
+# One map serves both fields — same seven words, same classes. A word under
+# either field that is not in the map classifies as None (never fabricated).
 LEDGER_EVENT_MAP = {
     "fact_written": FACT_WRITTEN,
     "fact_verified": FACT_VERIFIED,
@@ -292,9 +304,16 @@ CLAIM_STATUS_MAP = {
 
 
 def classify_event(event: dict, source: str) -> str | None:
-    """Classify one event row from a known source; None when unclassifiable."""
+    """Classify one event row from a known source; None when unclassifiable.
+
+    #102: the ledger branch reads both producer faces' word fields —
+    `event_type` (kunglao_record) and `action` (kunglao_log.emit,
+    contracts.EVENT_FIELD) — through the same LEDGER_EVENT_MAP. The
+    event_type face wins when both are present (the words are identical, so
+    the result is the same either way)."""
     if source == "ledger":
-        return LEDGER_EVENT_MAP.get(event.get("event_type", ""))
+        word = event.get("event_type") or event.get(EVENT_FIELD)
+        return LEDGER_EVENT_MAP.get(str(word) if word else "")
     if source == "convergence":
         row_type = event.get("type") or SNAPSHOT
         if row_type == SNAPSHOT:

--- a/tests/test_contracts_drift_102.py
+++ b/tests/test_contracts_drift_102.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""TDD — issue #102 (split from #95 A5): cross-process contract drift.
+
+Root cause of the drift family: producers and consumers define the same
+byte-level contract in separate comments. Three instances, one fix layer:
+
+  1. event field name: event_taxonomy's ledger branch keyed on `event_type`
+     (kunglao_record.record_event face), but kunglao_log.emit writes the
+     word in `action` (contracts.EVENT_FIELD). Seven main-stream classes
+     (fact_written / fact_verified / claim_promoted / claim_refuted /
+     failure_recorded / intent_opened / intent_closed) classified as None —
+     fabricated zeros in every statusline/digest.
+  2. bandit row shape: the CONSUMER (scripts/optimizer_bandit.py) was
+     DELETED (#95 A7, closed by #104) — per the issue note ("keep the fix
+     at the contracts layer; don't resurrect the module") this item closes
+     with the deletion. Nothing to assert beyond the contracts registry
+     existing: the row-shape lesson generalizes as contracts.py, and no
+     producer/consumer pair for the old top-level arm/z shape survives.
+  3. plan_drift crash fall-through: dispatch_gate._plan_drift_auto treated
+     any rc outside (0,2,3) as pass-through — a detector crash (rc=1 on a
+     malformed claim-register.yaml) let dispatch proceed with the traceback
+     discarded and zero telemetry. Fix: fail-open is kept (a PreToolUse
+     safety net must not block on its own breakage) but the degradation is
+     OBSERVABLE — stderr note + `plan_drift_crashed` trace row carrying the
+     rc and the detector's last stderr line.
+
+Fix architecture (#102): scripts/contracts.py as the single source —
+exit-code registry, event field schema, gate-subprocess legal rc sets.
+Producers and consumers import from it; a drift of this class can never
+again pass CI silently.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+HOOKS_DIR = REPO_ROOT / "hooks"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import event_taxonomy as et  # noqa: E402
+from kunglao_log import emit, iter_jsonl, log_path  # noqa: E402
+
+# the seven controlled ledger words (kunglao_record.EVENT_TYPES) — the same
+# words kunglao_log-shaped rows carry in the `action` field
+SEVEN_WORDS = ("fact_written", "fact_verified", "claim_promoted",
+               "claim_refuted", "failure_recorded", "intent_opened",
+               "intent_closed")
+
+
+def _load_dispatch_gate():
+    """Load hooks/dispatch_gate.py as a module (test_plan_drift_auto_602
+    convention: by-spec, because scripts/ historically shipped another
+    dispatch_gate)."""
+    spec = importlib.util.spec_from_file_location(
+        "_dispatch_gate_for_102", HOOKS_DIR / "dispatch_gate.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# =====================================================================
+# RED 1 — event field name drift (classify_event vs kunglao_log.emit)
+# =====================================================================
+
+class TestLedgerActionFieldDrift:
+    """kunglao_log.emit-shaped rows must classify through the ledger branch.
+
+    The ledger stream has TWO producer faces sharing one scan
+    (event_taxonomy.classify_workspace reads BOTH ledger.jsonl and
+    runs/logs/kunglao-*.jsonl with source="ledger"):
+      - kunglao_record.record_event writes the word in `event_type`
+      - kunglao_log.emit writes the word in `action` (EVENT_FIELD)
+    Pre-#102 the branch read `event_type` only, so every kunglao_log-shaped
+    row classified as None.
+    """
+
+    def test_classify_event_accepts_emit_action_rows(self):
+        for word in SEVEN_WORDS:
+            row = {"ts": "2026-09-06T00:00:00Z", "actor": "worker",
+                   "action": word, "claim": "C-1", "exit": None,
+                   "detail": None}
+            assert et.classify_event(row, source="ledger") == word, (
+                f"#102: kunglao_log.emit-shaped row with action={word!r} "
+                f"classified as "
+                f"{et.classify_event(row, source='ledger')!r} (fabricated "
+                f"zero in statusline/digest)")
+
+    def test_classify_event_event_type_face_unchanged(self):
+        """kunglao_record rows keep their classification (no regression)."""
+        for word in SEVEN_WORDS:
+            assert et.classify_event({"event_type": word},
+                                     source="ledger") == word
+        assert et.classify_event({"event_type": "unknown_kind"},
+                                 source="ledger") is None
+
+    def test_classify_event_unknown_action_stays_none(self):
+        """Unknown action words (real EMIT_ACTIONS words among them) must
+        NOT be fabricated into a taxonomy class — None is the
+        unattributed-rate signal, a wrong class is worse."""
+        assert et.classify_event({"action": "dispatch"},
+                                 source="ledger") is None
+        assert et.classify_event({"action": "tool_call"},
+                                 source="ledger") is None
+        assert et.classify_event({"action": None}, source="ledger") is None
+        assert et.classify_event({"action": ""}, source="ledger") is None
+
+    def test_event_field_schema_constant_used_by_taxonomy(self):
+        """The field name comes from contracts.py, not a local literal."""
+        import contracts
+        assert contracts.EVENT_FIELD == "action"
+        assert et.EVENT_FIELD == contracts.EVENT_FIELD, (
+            "#102: event_taxonomy must import the event-field schema from "
+            "contracts (a second local literal is the drift class itself)")
+
+    def test_roundtrip_real_emitter_through_consumer_parser(self):
+        """The #102 contract test: a row emitted by the REAL kunglao_log
+        emitter, read back by the REAL stream reader, classifies through the
+        REAL consumer parser. Drift of this class can never pass CI."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            emit(ws, "worker", "fact_written", claim="C-1",
+                 detail="facts/F001.md")
+            rows = list(iter_jsonl(
+                log_path(ws).read_text(encoding="utf-8").splitlines()))
+            assert len(rows) == 1
+            assert et.classify_event(rows[0], source="ledger") == \
+                "fact_written"
+
+    def test_fixture_digest_seven_classes_nonzero(self):
+        """Acceptance: the seven main-stream classes are non-zero in a
+        fixture digest built purely from kunglao_log.emit rows."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            ws = Path(td)
+            for word in SEVEN_WORDS:
+                emit(ws, "worker", word, claim="C-1")
+            counts = et.classify_workspace(ws)
+            zero = [w for w in SEVEN_WORDS if counts.get(w, 0) != 1]
+            assert not zero, (
+                f"#102 acceptance: classes {zero} still read as fabricated "
+                f"zeros in the digest; counts={ {w: counts.get(w) for w in SEVEN_WORDS} }")
+            digest = et.round_digest_text(ws)
+            for word in SEVEN_WORDS:
+                assert f"{word}=1" in digest
+
+
+# =====================================================================
+# RED 2 — plan_drift crash fall-through
+# =====================================================================
+
+class TestPlanDriftCrashFace:
+    """A detector crash must degrade LOUDLY, never silently.
+
+    Contract (post-#102): under --auto the only legal bytes are the
+    contracts.PLAN_DRIFT_AUTO_RCS trio {0, 2, 3}; any other rc (rc=1 = an
+    unhandled exception inside plan_drift_detector, e.g. a malformed
+    claim-register.yaml) takes the explicit crash face:
+      - dispatch verdict stays fail-open (None) — NON-FATAL by design;
+      - stderr carries an operator-visible note;
+      - one `plan_drift_crashed` trace row lands in the unified event log
+        with exit=rc and the detector's last stderr line.
+    """
+
+    def _ws(self, tmp_path: Path) -> Path:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        return ws
+
+    def _trace_rows(self, ws: Path) -> list[dict]:
+        logs = ws / "runs" / "logs"
+        if not logs.is_dir():
+            return []
+        rows: list[dict] = []
+        for p in sorted(logs.glob("kunglao-*.jsonl")):
+            rows.extend(iter_jsonl(
+                p.read_text(encoding="utf-8", errors="replace").splitlines()))
+        return rows
+
+    def test_crash_rc_returns_fail_open_and_is_observable(
+            self, tmp_path, monkeypatch, capsys):
+        """rc=1 (crash) -> None (fail-open) + stderr note + trace row."""
+        dg = _load_dispatch_gate()
+        ws = self._ws(tmp_path)
+
+        class FakeProc:
+            returncode = 1
+            stdout = ""
+            stderr = "yaml.YAMLError: expected ',' or ']'"
+
+        monkeypatch.setattr(sys.modules["subprocess"], "run",
+                            lambda *a, **k: FakeProc())
+        rc = dg._plan_drift_auto(ws, "C-1", "prompt")
+        captured = capsys.readouterr()
+        assert rc is None, (
+            f"#102: crash face must stay fail-open (None), got {rc!r}")
+        assert "plan-drift auto CRASHED" in captured.err, (
+            f"#102: crash must draw an operator-visible stderr note, got: "
+            f"{captured.err!r}")
+        rows = [r for r in self._trace_rows(ws)
+                if r.get("action") == "plan_drift_crashed"]
+        assert len(rows) == 1, (
+            f"#102: exactly one plan_drift_crashed trace row expected, got "
+            f"{len(rows)}: {rows}")
+        row = rows[0]
+        assert row.get("exit") == 1, f"trace row must carry rc, got {row}"
+        assert "YAMLError" in str(row.get("detail")), (
+            f"#102: trace detail must carry the detector stderr tail "
+            f"(post-mortem without source re-read), got {row.get('detail')!r}")
+        assert row.get("claim") == "C-1"
+
+    def test_unexpected_rc_also_takes_crash_face(self, tmp_path, monkeypatch,
+                                                 capsys):
+        """The registry set is the whole contract: rc=42 (an unknown byte)
+        takes the SAME explicit crash face — never a silent fall-through."""
+        dg = _load_dispatch_gate()
+        ws = self._ws(tmp_path)
+
+        class FakeProc:
+            returncode = 42
+            stdout = ""
+            stderr = ""
+
+        monkeypatch.setattr(sys.modules["subprocess"], "run",
+                            lambda *a, **k: FakeProc())
+        rc = dg._plan_drift_auto(ws, "C-1", "prompt")
+        captured = capsys.readouterr()
+        assert rc is None
+        assert "plan-drift auto CRASHED" in captured.err
+        rows = [r for r in self._trace_rows(ws)
+                if r.get("action") == "plan_drift_crashed"]
+        assert len(rows) == 1 and rows[0].get("exit") == 42
+
+    def test_real_detector_crash_on_malformed_register(
+            self, tmp_path, capsys):
+        """End-to-end with the REAL detector: a workspace whose
+        claim-register.yaml carries bad YAML crashes plan_drift_detector
+        --auto with rc=1 (verified probe) — the helper must return fail-open
+        with the crash observed on both channels."""
+        dg = _load_dispatch_gate()
+        ws = self._ws(tmp_path)
+        (ws / "claim-register.yaml").write_text(
+            "claims:\n- id: C-1\n  status: OPEN\ntitle: [unclosed\n",
+            encoding="utf-8")
+        (ws / "global_plan.txt").write_text("C-1 in plan\n", encoding="utf-8")
+
+        rc = dg._plan_drift_auto(ws, "C-1", "prompt")
+        captured = capsys.readouterr()
+        assert rc is None, (
+            f"#102: malformed-register crash must fail open, got {rc!r}")
+        assert "plan-drift auto CRASHED" in captured.err, captured.err
+        rows = [r for r in self._trace_rows(ws)
+                if r.get("action") == "plan_drift_crashed"]
+        assert rows, "#102: real crash produced no plan_drift_crashed row"
+        assert rows[0].get("exit") == 1
+
+    def test_plan_drift_crashed_registered_in_emit_actions(self):
+        """#459 discipline: the new action word must be a member of the
+        controlled vocabulary (test_event_stream_adoption's anchor scans the
+        _emit_trace literal)."""
+        assert "plan_drift_crashed" in et.EMIT_ACTIONS
+
+    def test_crash_face_does_not_change_legal_rc_behavior(
+            self, tmp_path, monkeypatch):
+        """Regression guard: 0 -> None, 2 -> 2, 3 -> 3 (the #602 pins keep
+            their bytes; the crash face only claims the space OUTSIDE the
+            registry set)."""
+        dg = _load_dispatch_gate()
+        ws = self._ws(tmp_path)
+        for code, expected in ((0, None), (2, 2), (3, 3)):
+            class FakeProc:
+                returncode = code
+                stdout = f"DRIFT_AUTO rc={code}"
+                stderr = ""
+
+            monkeypatch.setattr(sys.modules["subprocess"], "run",
+                                lambda *a, **k: FakeProc())
+            got = dg._plan_drift_auto(ws, "C-1", "prompt")
+            assert got == expected, (
+                f"#102: rc={code} must map to {expected!r}, got {got!r}")
+
+
+# =====================================================================
+# contracts.py — the single source (#102 architectural fix)
+# =====================================================================
+
+class TestContractsRegistry:
+    """scripts/contracts.py registers the bytes both sides already speak.
+
+    Scope discipline: the file collects EXISTING facts (convergence_check's
+    0-5 + 64 + 65 registry, plan_drift's --auto trio, the event field name)
+    — it invents no new contract. convergence_check imports its face, so
+    there is exactly ONE definition.
+    """
+
+    def test_contracts_module_exists_with_registry(self):
+        import contracts
+        assert contracts.EXIT_CONVERGED == 0
+        assert contracts.EXIT_DISPATCH == 1
+        assert contracts.EXIT_VERIFY == 2
+        assert contracts.EXIT_SATURATED == 3
+        assert contracts.EXIT_BLOCKED == 4
+        assert contracts.EXIT_PARK == 5
+        assert contracts.EXIT_MISSING_WORKSPACE == 64
+        assert contracts.EXIT_CRASHED == 65
+        assert contracts.EVENT_FIELD == "action"
+        assert contracts.PLAN_DRIFT_AUTO_RCS == frozenset({0, 2, 3})
+
+    def test_registry_values_distinct(self):
+        """The #99 consumer contract: every face owns its byte."""
+        import contracts
+        values = [contracts.EXIT_CONVERGED, contracts.EXIT_DISPATCH,
+                  contracts.EXIT_VERIFY, contracts.EXIT_SATURATED,
+                  contracts.EXIT_BLOCKED, contracts.EXIT_PARK,
+                  contracts.EXIT_MISSING_WORKSPACE, contracts.EXIT_CRASHED]
+        assert len(set(values)) == len(values), f"byte collision: {values}"
+
+    def test_convergence_check_imports_its_face(self):
+        """Single definition: convergence_check's names ARE contracts'
+        objects (imported, not re-stated) — the drift class is structurally
+        impossible."""
+        import contracts
+        import convergence_check as cc
+        for name in ("EXIT_CONVERGED", "EXIT_DISPATCH", "EXIT_VERIFY",
+                     "EXIT_SATURATED", "EXIT_BLOCKED", "EXIT_PARK",
+                     "EXIT_CRASHED"):
+            assert getattr(cc, name) == getattr(contracts, name), (
+                f"#102: convergence_check.{name} drifted from the registry")
+        assert cc.EXIT_CRASHED == 65 and cc.EXIT_MISSING_WORKSPACE == 64
+
+    def test_dispatch_gate_uses_registry_rc_set(self):
+        """The gate branches on the contracts set, not a local literal
+        (0,2,3) — the plan_drift --auto face."""
+        import contracts
+        dg = _load_dispatch_gate()
+        src = (HOOKS_DIR / "dispatch_gate.py").read_text(encoding="utf-8")
+        assert "PLAN_DRIFT_AUTO_RCS" in src, (
+            "#102: dispatch_gate must branch on the contracts rc set")
+        assert dg is not None and contracts.PLAN_DRIFT_AUTO_RCS == \
+            frozenset({0, 2, 3})
+
+    def test_bandit_row_shape_item_closed_by_deletion(self):
+        """Issue #102 item 2 (bandit row shape): the only consumer
+        (optimizer_bandit.attribute_rows) is DELETED (#95 A7 / #104). The
+        issue itself rules the fix stays at the contracts layer — the
+        module must NOT be resurrected; the shape lesson survives as
+        contracts.py. This test pins the deletion so the unproducible-shape
+        consumer cannot silently return."""
+        assert not (SCRIPTS_DIR / "optimizer_bandit.py").exists(), (
+            "#102 item 2: optimizer_bandit was deleted by #95 A7 — do not "
+            "resurrect it (its pinned row shape was unproducible)")


### PR DESCRIPTION
Closes #102

## Summary
Three drift instances from the audit, TDD (16 new tests RED-first), plus the architectural fix:

1. **Event-field drift closed**: event_taxonomy's ledger branch now reads both producers' vocab fields (`event_type` from kunglao_record and `action` from kunglao_log.emit) through one map — the 7 main-stream event classes classify again; unknown vocab stays None (no fabricated classification).
2. **plan_drift crash face**: any rc outside the registry set gets an explicit crash path — stderr note + `plan_drift_crashed` trace (exit=rc + detector stderr tail); dispatch stays fail-open but observable.
3. **contracts.py** (new, leaf-only): exit-code registry (incl. #99's EXIT_CRASHED), PLAN_DRIFT_AUTO_RCS, EVENT_FIELD="action". convergence_check imports its face (single ownership); event_taxonomy imports EVENT_FIELD; dispatch_gate branches on the registry set. Nothing invented — only existing facts centralized.
4. bandit-row item closed by deletion (noted in a pinning test per the issue's own adjudication).

## Test plan
- [x] 16 new tests RED-first; targeted sets 145 passed
- [x] Full suite: 6 failed pre-fixes -> all resolved in-branch; final 1 red = machine-local env_check (python 3.14 vs 3.11), reproduced on untouched master worktree
- [x] deploy-manifest regenerated (379 entries, --verify rc=0)