### PR TITLE
feat(#109): hypothesis admission gate — first dispatch into a PQ neighborhood requires >=2 competing candidates

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -19,7 +19,7 @@ files:
   - src: hooks/dispatch_gate.py
     dest: .claude/hooks/dispatch_gate.py
     kind: hook
-    sha256: a86d60b82354b8a8ffb074852d9d52327c9c95a939f950ff598124dfbf358d34
+    sha256: afd3b977fe3d682827f690df14eb578145fe1ff1986dc0f0ac0b65d90f1ed687
   - src: hooks/env_check_gate.py
     dest: .claude/hooks/env_check_gate.py
     kind: hook
@@ -335,7 +335,7 @@ files:
   - src: scripts/event_taxonomy.py
     dest: .claude/scripts/event_taxonomy.py
     kind: scaffold
-    sha256: 9bed1b1a5f9dc8abcae0e93bf901b5e8380c835db12ad19fb59eccd09f3488bc
+    sha256: fd58fceb5c2904d19f3a319c7e277f7e4bc52d71f15570108593609b491fd708
   - src: scripts/explore_gate.py
     dest: .claude/scripts/explore_gate.py
     kind: scaffold
@@ -403,7 +403,7 @@ files:
   - src: scripts/hypothesis_store.py
     dest: .claude/scripts/hypothesis_store.py
     kind: scaffold
-    sha256: 2d36e392bf264cfb7ced294d675ceb82f3b10fb19d223d53aba7e28ab583e6d5
+    sha256: 88cd6758e87e0ec492f0d005678ba61a485f4bb0ab65bb2b6f1289996d3a9b5f
   - src: scripts/infeasible_proposal.py
     dest: .claude/scripts/infeasible_proposal.py
     kind: scaffold

--- a/hooks/dispatch_gate.py
+++ b/hooks/dispatch_gate.py
@@ -387,17 +387,19 @@ STRATEGY_LOG = "runs/strategy-log.jsonl"
 STRATEGY_LOG_MAX = 200
 
 
-def _reject_with_guidance(name: str, msg: str, fix: str) -> int:
+def _reject_with_guidance(name: str, msg: str, fix: str,
+                          issue: str = "496") -> int:
     """#496: REJECT with guidance — the exact structure worker_budget._reject
     and _warn_must_stop already use: stderr `REJECT <name>` summary + stdout
     hookSpecificOutput.additionalContext carrying a concrete fix path +
-    exit 2 (block the Agent call)."""
+    exit 2 (block the Agent call). `issue` attributes the face to its own
+    issue (default keeps the four #496-era call sites byte-identical)."""
     print(f"REJECT {name}: {msg}", file=sys.stderr, flush=True)
     print(json.dumps({
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "additionalContext": _gate_verdict(
-                f"dispatch_gate: REJECT {name} (#496). {msg}\n\n"
+                f"dispatch_gate: REJECT {name} (#{issue}). {msg}\n\n"
                 f"How to fix:\n{fix}"
             ),
         },
@@ -1134,6 +1136,171 @@ def _tools_rack_gate(payload: dict, prompt_text: str) -> int | None:
         f"in-process interpreters; that output is untrusted by design.")
 
 
+# ===================== #109 hypothesis admission gate =====================
+
+# THE other roi-intents face (read side): #105 made the dispatch ALLOW tail
+# the producer of runs/roi-intents.jsonl; the first-dispatch face here reads
+# the SAME file back as one of the two production dispatch-history sources
+# (the other being the #496/#120 strategy-log read path below). Together
+# they answer "was this PQ neighborhood already dispatched once?" —
+# claim-keyed rows joined to claim-register answers_question.
+ROI_INTENTS_LOG = Path("runs/roi-intents.jsonl")
+# #109 admission bar: fewer competing candidates than this in the hypothesis
+# layer for a PQ means nothing can contradict the one story being chased.
+MIN_ADMITTED_CANDIDATES = 2
+
+
+def _claim_question_map(ws: Path) -> dict[str, str]:
+    """claim id -> answers_question, from claim-register.yaml. Empty map on
+    any read failure (an unreadable register cannot identify PQ claims —
+    the gate stays silent, same posture as _capability_guard)."""
+    try:
+        reg = yaml.safe_load(
+            (ws / "claim-register.yaml").read_text(encoding="utf-8")) or {}
+    except Exception:  # noqa: BLE001 — unreadable register -> no PQ map
+        return {}
+    out: dict[str, str] = {}
+    for c in (reg.get("claims") or []):
+        if isinstance(c, dict) and c.get("id") and c.get("answers_question"):
+            out[str(c["id"])] = str(c["answers_question"])
+    return out
+
+
+def _workspace_pq_ids(ws: Path) -> set[str]:
+    """Primary-question ids from task_spec.yaml via THE canonical parse
+    (#77 — the same parser hypothesis_seeder and mission_ledger consume;
+    a local twin would re-create the two-parsers drift #77 exists to
+    prevent). Empty set on absence/read failure: a workspace with no
+    readable task_spec has no PQ neighborhoods, so the admission gate has
+    nothing to guard (fail-open)."""
+    try:
+        spec = yaml.safe_load(
+            (ws / "task_spec.yaml").read_text(encoding="utf-8")) or {}
+    except Exception:  # noqa: BLE001 — no/unreadable task_spec -> no PQs
+        return set()
+    try:
+        with scripts_on_path():  # #671 scoped membership
+            from convergence_check import _parse_primary_questions
+        pqs, _err = _parse_primary_questions(
+            spec if isinstance(spec, dict) else {})
+    except Exception:  # noqa: BLE001 — parser outage -> no PQs, gate silent
+        return set()
+    return {str(qid) for qid, _need in (pqs or [])}
+
+
+def _pq_dispatched_before(ws: Path, qid: str,
+                          claim_question: dict[str, str]) -> bool:
+    """#109 first-dispatch face: True when any dispatch-history row's claim
+    answers `qid`. Two production row sources, both claim-keyed:
+      - runs/strategy-log.jsonl  event=dispatch rows (#496 writer / #120
+        priority_ratio read path);
+      - runs/roi-intents.jsonl   claim_id rows (#105 producer).
+    Fail-open by direction: an unreadable/absent face reads as "no history",
+    which can only make the gate check MORE (the admission itself then
+    decides), never silently allow. A REJECTed dispatch writes no row
+    (both faces sit on the ALLOW tail), so the REJECT->file-candidates->
+    re-dispatch loop stays inside "first dispatch" until it passes."""
+    faces = (
+        (ws / STRATEGY_LOG, "event", "claim"),
+        (ws / ROI_INTENTS_LOG, None, "claim_id"),
+    )
+    for path, event_key, claim_key in faces:
+        try:
+            if not path.is_file():
+                continue
+            lines = path.read_text(
+                encoding="utf-8", errors="replace").splitlines()
+        except OSError:  # unreadable face -> no history from it
+            continue
+        for ln in lines:
+            ln = ln.strip()
+            if not ln:
+                continue
+            try:
+                row = json.loads(ln)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(row, dict):
+                continue
+            if event_key is not None and row.get(event_key) != "dispatch":
+                continue
+            cid = str(row.get(claim_key) or "").strip()
+            if cid and claim_question.get(cid) == qid:
+                return True
+    return False
+
+
+def _hypothesis_admission(ws: Path, claim_id: str, payload: dict,
+                          trace_id: str | None = None) -> int | None:
+    """#109: PQ-neighborhood first-dispatch admission (framework-rigidity
+    layer — protocol completeness, not strategy judgment; per the owner's
+    two-layer ruling the REJECT reason is "protocol not fulfilled", never
+    "method looks bad").
+
+    Trigger: the target claim's answers_question names a task_spec
+    primary_question AND that PQ is being dispatched for the FIRST time
+    (no claim-keyed dispatch-history row answers it yet). The check: the
+    hypothesis layer (#528 store) must hold >= 2 non-adjudicated candidates
+    for the PQ — the #412 seeding contract's "orchestrator fills candidates
+    BEFORE dispatching the first C-NN", now enforced on the one
+    un-bypassable face. Subsequent dispatches on the same PQ are
+    unrestricted: the first hypothesis round supplies the prior.
+    Parks/reinstatements are unaffected (answers_question null -> silent).
+
+    Same enforcement layer as must-stop/top1: activated main flow,
+    REJECT-capable (exit 2 + <gate-verdict> repair path via
+    _reject_with_guidance). Fail-open (#103 tiering): a hypothesis-store
+    read failure emits hypothesis_admission_fail_open (WARN + trace) and
+    proceeds — a broken store must not block dispatch.
+    """
+    claim_question = _claim_question_map(ws)
+    qid = claim_question.get(claim_id)
+    if not qid or qid not in _workspace_pq_ids(ws):
+        return None  # non-PQ claim (or PQ-less workspace) — never triggers
+    if _pq_dispatched_before(ws, qid, claim_question):
+        return None  # not the first dispatch — the prior exists, pass
+    try:
+        with scripts_on_path():  # #671 scoped membership
+            import hypothesis_store as hs
+        candidates = hs.open_candidates_for_question(
+            hs.HypothesisStore(ws / "hypotheses").list_all(), qid,
+            claim_question)
+    except Exception as exc:  # noqa: BLE001 — #103 tiering: store outage
+        # must not block. WARN + trace, dispatch proceeds unadmitted.
+        print(
+            f"dispatch_gate: WARN hypothesis-admission fail-open (#109) — "
+            f"hypothesis store unreadable ({type(exc).__name__}), admission "
+            f"not enforced for {qid}",
+            file=sys.stderr, flush=True,
+        )
+        _emit_trace(ws, "hypothesis_admission_fail_open", claim_id,
+                    f"qid={qid}; reason=store_read_failed; "
+                    f"exc={type(exc).__name__}: {exc}", trace_id=trace_id)
+        return None
+    if len(candidates) >= MIN_ADMITTED_CANDIDATES:
+        return None
+    # #459: the REJECT face reaches the unified log like top1/capability.
+    _emit_trace(ws, "hypothesis_admission_reject", claim_id,
+                f"qid={qid}; candidates={len(candidates)}; "
+                f"need>={MIN_ADMITTED_CANDIDATES}", exit_code=2,
+                trace_id=trace_id)
+    return _reject_with_guidance(
+        "hypothesis_admission",
+        f"{claim_id} answers {qid}, but the hypothesis layer holds only "
+        f"{len(candidates)} non-adjudicated candidate(s) for {qid} — the "
+        f"first dispatch into a PQ neighborhood requires competing "
+        f"explanations (anchoring risk is highest exactly when the system "
+        f"knows least; a single-hypothesis entry is how edge findings get "
+        f"chased as major ones).",
+        f"file ≥2 competing candidates for {qid}, each naming its falsifier "
+        f"(what observation would eliminate it — the falsifier-library "
+        f"semantics: a candidate that cannot say what would kill it is an "
+        f"opinion, not a candidate): fill `candidates:` "
+        f"on the open `pq:{qid}` scaffold hypothesis in hypotheses/ (or "
+        f"file one hypothesis per competitor via hypothesis_store), then "
+        f"re-dispatch.", issue="109")
+
+
 # ===================== #772 redo-leak WARN (L4) =====================
 
 # A prompt wearing a redo marker is subject to the GAP-ONLY contract (#772):
@@ -1372,6 +1539,15 @@ def main() -> int:
     # observable degrade face (plan_drift_crashed trace row) — trace_id
     # rides so the row attributes to the mission chain.
     rc = _plan_drift_auto(ws, claim_id, prompt_text, trace_id=trace_id)
+    if rc is not None:
+        return rc
+
+    # #109 hypothesis admission — same enforcement layer as must-stop/top1
+    # (activated main flow, REJECT-capable). Protocol completeness precedes
+    # the value teeth: a dispatch into an empty PQ competitor field is a
+    # protocol violation (#412's unguarded back half) and must not burn a
+    # top1 deviation trace first. Fail-open on store outages (#103 tiering).
+    rc = _hypothesis_admission(ws, claim_id, payload, trace_id=trace_id)
     if rc is not None:
         return rc
 

--- a/scripts/event_taxonomy.py
+++ b/scripts/event_taxonomy.py
@@ -184,6 +184,8 @@ EMIT_ACTIONS = [
     "git_anchor_skipped",  # #753 pre-migration rollback anchor untakeable (git missing/failed) — kunglao_upgrade
     "git_snapshot_skipped",  # #739 WARN faces — kunglao_upgrade (snapshot untakeable: git missing/failed) + kunglao-init (workspace snapshot skip)
     "heartbeat_gap",      # #618 dead-window alarm: durable sidecar newest tick over threshold
+    "hypothesis_admission_fail_open",  # #109 store-read failure WARN face — admission not enforced, dispatch proceeds
+    "hypothesis_admission_reject",  # #109 PQ first-dispatch admission REJECT face (empty competitor field)
     "hypothesis_seed",    # #662 PQ scaffold seeding
     "hypothesis_superseded",  # #759 note-supersedes-hypothesis wiring (K3)
     "infeasible_candidate",  # #823 A4 doomed-trajectory early-stop signal

--- a/scripts/hypothesis_store.py
+++ b/scripts/hypothesis_store.py
@@ -56,6 +56,64 @@ _TERMINAL_STATUSES = frozenset(("refuted", "superseded"))
 
 _FRONT_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
 
+# #109 PQ-neighborhood binding faces. A hypothesis is bound to primary
+# question `qid` through ANY of:
+#   - body carries the seeder scaffold marker `pq:<qid>` (#662);
+#   - competitor_group matches the seeder shape `pq-<qid>` (or the colon
+#     variant `pq:<qid>`);
+#   - its claim_id resolves via a claim_id -> answers_question map to qid.
+# Kept as literal formats (not imported from hypothesis_seeder — hooks and
+# store consumers must not pull the seeder's convergence_check dependency;
+# the shapes are pinned by tests/test_hypothesis_admission_109.py).
+PQ_BODY_MARKER_FMT = "pq:{qid}"
+PQ_GROUP_FMTS = ("pq-{qid}", "pq:{qid}")
+
+
+def open_candidates_for_question(
+    hypotheses: list[Hypothesis],
+    qid: str,
+    claim_question: dict[str, str] | None = None,
+) -> list[str]:
+    """#109 admission read: non-adjudicated candidate strings bound to PQ
+    `qid`, file order deduplicated.
+
+    Only `open` hypotheses count — refuted/superseded are terminal
+    adjudications and confirmed is decided; their candidates are history,
+    not a live competitor field (the anchor is what contradicts you, and a
+    decided hypothesis contradicts nothing anymore).
+
+    Falsifier declaration (TODO, #112 intent): every candidate must enter
+    naming what observation would eliminate it, but Hypothesis.candidates
+    is a plain string list (the #528 frontmatter round-trip drops
+    per-candidate structure), so existence is the only computable predicate
+    today. When candidates gain structure (mapping frontmatter or
+    per-candidate files), tighten this to require a non-empty falsifier per
+    candidate — the dispatch gate's repair text already promises it.
+
+    Pure function over the parsed list: read failures happen upstream in
+    HypothesisStore.list_all (fail-open, skips unparseable files), so this
+    never raises on store content.
+    """
+    cq = claim_question or {}
+    group_hits = tuple(g.format(qid=qid) for g in PQ_GROUP_FMTS)
+    marker = PQ_BODY_MARKER_FMT.format(qid=qid)
+    out: list[str] = []
+    for h in hypotheses:
+        if h.status != "open":
+            continue
+        bound = (
+            marker in (h.body or "")
+            or (h.competitor_group or "") in group_hits
+            or cq.get(h.claim_id) == qid
+        )
+        if not bound:
+            continue
+        for c in h.candidates or []:
+            c = str(c).strip()
+            if c and c not in out:
+                out.append(c)
+    return out
+
 
 class InvalidTransition(ValueError):
     """A hypothesis state change violated the state machine."""
@@ -72,8 +130,6 @@ class Hypothesis:
     superseded_by: str | None = None
     predicted_observation: str = ""   # #711: falsifiable bet — what a probe should show
     confirming_fact_id: str | None = None  # #711: evidence that confirmed the bet
-    body: str = ""
-    path: Path | None = None
     body: str = ""
     path: Path | None = None
 

--- a/tests/test_hypothesis_admission_109.py
+++ b/tests/test_hypothesis_admission_109.py
@@ -1,0 +1,410 @@
+# -*- coding: utf-8 -*-
+"""tests/test_hypothesis_admission_109.py — #109 hypothesis admission gate.
+
+#412's seeding contract has an unguarded back half: "the orchestrator fills
+candidates BEFORE dispatching the first C-NN for this question" — nothing
+enforced it (audit: zero guards). #109 closes it on the un-bypassable face
+(hooks/dispatch_gate.py, same enforcement layer as must-stop/top1):
+
+  A dispatch whose target claim `answers_question: qX` (qX a task_spec
+  primary_question) is the FIRST dispatch into that PQ neighborhood only
+  while the workspace has no dispatch-history row for any claim answering
+  qX. That first dispatch REJECTs (exit 2, `<gate-verdict>` repair path)
+  unless the hypothesis layer holds >= 2 non-adjudicated candidates for qX.
+
+Framework-rigidity layer (protocol completeness, per the owner's two-layer
+ruling): the REJECT reason is "protocol not fulfilled" — no declared
+competing explanations — never "method looks bad". Subsequent dispatches on
+the same PQ are unrestricted (the first hypothesis round supplies the
+prior). Fail-open (#103 tiering): a hypothesis-store read failure WARNs +
+traces and does not block.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from _factories import write_hook_state
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------- fixtures ----------
+
+def _write_yaml(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, allow_unicode=True, sort_keys=False),
+                    encoding="utf-8")
+
+
+def _write_hyp(ws: Path, hyp_id: str, *, candidates: list[str],
+               status: str = "open", claim_id: str = "C-PENDING",
+               group: str = "pq-q1", body_marker: str = "pq:q1") -> Path:
+    """One hypotheses/<id>.md file in the #528 frontmatter shape."""
+    p = ws / "hypotheses" / f"{hyp_id}.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        "---\n"
+        f"id: {hyp_id}\n"
+        f"claim_id: {claim_id}\n"
+        f"competitor_group: {group}\n"
+        "candidates: [" + ", ".join(candidates) + "]\n"
+        f"status: {status}\n"
+        "schema_rev: 1\n"
+        "---\n"
+        + (f"\n{body_marker}\n\nSeeded scaffold — orchestrator fills "
+           "candidates BEFORE the first dispatch (#412).\n"),
+        encoding="utf-8")
+    return p
+
+
+def _mk_ws(root: Path, *, pq_ids: tuple[str, ...] = ("q1",)) -> Path:
+    """Activated single-claim workspace: C-1 answers q1, q1 is a primary
+    question, hypotheses/ NOT yet written (caller adds what it needs)."""
+    ws = root / "malware-analysis-workspace"
+    ws.mkdir(parents=True)
+    _write_yaml(ws / "claim-register.yaml", {"claims": [
+        {"id": "C-1", "status": "OPEN", "statement": "recover the header mac",
+         "answers_question": "q1"}]})
+    _write_yaml(ws / "claim_deps.yaml",
+                {"depends_on": {}, "competitor_groups": {}})
+    _write_yaml(ws / "task_spec.yaml",
+                {"primary_questions": list(pq_ids)})
+    write_hook_state(ws, active_hooks=["dispatch_gate"])
+    (ws / "runs").mkdir()
+    return ws
+
+
+def _run_gate(root: Path, ws: Path, prompt: str,
+              agent: str = "kunglao-worker") -> subprocess.CompletedProcess:
+    payload = json.dumps({
+        "cwd": str(root),
+        "tool_input": {"prompt": prompt, "subagent_type": agent},
+    })
+    return subprocess.run(
+        [sys.executable, str(REPO_ROOT / "hooks" / "dispatch_gate.py")],
+        input=payload, capture_output=True, text=True, timeout=90,
+        cwd=str(REPO_ROOT), errors="replace",
+        env={"PYTHONIOENCODING": "utf-8", **os.environ},
+    )
+
+
+def _event_rows(ws: Path) -> list[dict]:
+    """All rows from the unified event log (runs/logs/kunglao-*.jsonl)."""
+    out: list[dict] = []
+    logs = ws / "runs" / "logs"
+    if not logs.is_dir():
+        return out
+    for p in sorted(logs.glob("kunglao-*.jsonl")):
+        for line in p.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out
+
+
+def _intent_rows(ws: Path) -> list[dict]:
+    p = ws / "runs" / "roi-intents.jsonl"
+    if not p.exists():
+        return []
+    return [json.loads(ln) for ln in
+            p.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+_PROMPT = "[T1 tools=Read,Write] claim C-1 probe the header mac path"
+
+
+# ---------- AC 1: first dispatch into an empty PQ neighborhood REJECTs ----
+
+class TestFirstDispatchAdmission:
+    def test_empty_candidates_first_dispatch_rejects(self, tmp_path) -> None:
+        """Scaffold exists (candidates=[] per #412) -> first dispatch into
+        q1 REJECTs (exit 2) with the gate-verdict repair path naming q1."""
+        root = tmp_path
+        ws = _mk_ws(root)
+        _write_hyp(ws, "H-001", candidates=[])
+        r = _run_gate(root, ws, _PROMPT)
+        assert r.returncode == 2, (
+            f"first dispatch into an empty PQ neighborhood must REJECT; "
+            f"rc={r.returncode} stderr={r.stderr!r}")
+        assert "REJECT hypothesis_admission" in r.stderr, f"stderr={r.stderr!r}"
+        assert "REJECT hypothesis_admission (#109)" in r.stdout, (
+            f"the face must carry its own issue attribution; {r.stdout!r}")
+        assert "<gate-verdict>" in r.stdout, (
+            f"the REJECT face must carry the #55 producer tag; "
+            f"stdout={r.stdout!r}")
+        assert "q1" in r.stdout, f"repair text must name the PQ; {r.stdout!r}"
+        assert ("file ≥2 competing candidates for q1, each naming its "
+                "falsifier") in r.stdout, (
+            f"repair path must carry the #109 wording; stdout={r.stdout!r}")
+
+    def test_absent_hypotheses_dir_rejects(self, tmp_path) -> None:
+        """No hypotheses/ at all = zero candidates — same REJECT (the layer
+        was never scaffolded is not an exemption, it is the worst case)."""
+        root = tmp_path
+        ws = _mk_ws(root)
+        assert not (ws / "hypotheses").exists()
+        r = _run_gate(root, ws, _PROMPT)
+        assert r.returncode == 2, f"stderr={r.stderr!r}"
+        assert "REJECT hypothesis_admission" in r.stderr
+
+    def test_single_candidate_still_rejects(self, tmp_path) -> None:
+        """One candidate is the anchoring maximum: nothing can contradict
+        the one story being chased (#109 problem statement)."""
+        root = tmp_path
+        ws = _mk_ws(root)
+        _write_hyp(ws, "H-001", candidates=["AES-CBC"])
+        r = _run_gate(root, ws, _PROMPT)
+        assert r.returncode == 2, f"stderr={r.stderr!r}"
+        assert "REJECT hypothesis_admission" in r.stderr
+
+    def test_adjudicated_candidates_do_not_count(self, tmp_path) -> None:
+        """A refuted hypothesis's candidates are history, not a live
+        competitor field — they cannot satisfy the admission."""
+        root = tmp_path
+        ws = _mk_ws(root)
+        _write_hyp(ws, "H-001", candidates=["AES-CBC", "ChaCha20"],
+                   status="refuted")
+        r = _run_gate(root, ws, _PROMPT)
+        assert r.returncode == 2, f"stderr={r.stderr!r}"
+        assert "REJECT hypothesis_admission" in r.stderr
+
+    def test_reject_leaves_trace_and_skips_intent_record(
+            self, tmp_path) -> None:
+        """The REJECT face reaches the unified log (#459 word
+        hypothesis_admission_reject, exit 2) and the #105 intent producer
+        never fires — a blocked dispatch declares no intent."""
+        root = tmp_path
+        ws = _mk_ws(root)
+        _write_hyp(ws, "H-001", candidates=[])
+        prompt = _PROMPT + "\nuncertainty: which mac the header uses"
+        r = _run_gate(root, ws, prompt)
+        assert r.returncode == 2
+        rows = [e for e in _event_rows(ws)
+                if e.get("action") == "hypothesis_admission_reject"]
+        assert rows, f"reject trace missing; rows={_event_rows(ws)}"
+        assert rows[0].get("claim") == "C-1"
+        assert rows[0].get("exit") == 2
+        assert "q1" in str(rows[0].get("detail"))
+        assert _intent_rows(ws) == [], (
+            "a REJECTed dispatch must not record a roi-intent row")
+
+
+# ---------- AC 2: filing the candidates admits the same dispatch ---------
+
+class TestAdmissionSatisfied:
+    def test_two_candidates_on_one_scaffold_pass(self, tmp_path) -> None:
+        root = tmp_path
+        ws = _mk_ws(root)
+        _write_hyp(ws, "H-001", candidates=["AES-CBC", "ChaCha20"])
+        r = _run_gate(root, ws, _PROMPT)
+        assert r.returncode == 0, (
+            f"filled candidate field must admit the dispatch; "
+            f"stderr={r.stderr!r}")
+
+    def test_two_open_hypotheses_one_candidate_each_pass(
+            self, tmp_path) -> None:
+        """The unit is the candidate, not the file: two open hypotheses
+        holding one candidate each also clear the bar."""
+        root = tmp_path
+        ws = _mk_ws(root)
+        _write_hyp(ws, "H-001", candidates=["AES-CBC"])
+        _write_hyp(ws, "H-002", candidates=["custom-rolling-mac"])
+        r = _run_gate(root, ws, _PROMPT)
+        assert r.returncode == 0, f"stderr={r.stderr!r}"
+
+    def test_claim_linked_hypothesis_counts(self, tmp_path) -> None:
+        """A hypothesis bound via claim_id (its claim answers q1) counts
+        even without the seeder marker/competitor_group shape."""
+        root = tmp_path
+        ws = _mk_ws(root)
+        _write_hyp(ws, "H-001", candidates=["AES-CBC"],
+                   claim_id="C-1", group="mac-structure", body_marker="")
+        _write_hyp(ws, "H-002", candidates=["truncated-digest"],
+                   claim_id="C-1", group="mac-structure", body_marker="")
+        r = _run_gate(root, ws, _PROMPT)
+        assert r.returncode == 0, f"stderr={r.stderr!r}"
+
+    def test_colon_group_shape_counts(self, tmp_path) -> None:
+        """`pq:q1` (colon variant) binds like the seeder's `pq-q1`."""
+        root = tmp_path
+        ws = _mk_ws(root)
+        _write_hyp(ws, "H-001", candidates=["AES-CBC"], group="pq:q1")
+        _write_hyp(ws, "H-002", candidates=["ChaCha20"], group="pq:q1")
+        r = _run_gate(root, ws, _PROMPT)
+        assert r.returncode == 0, f"stderr={r.stderr!r}"
+
+
+# ---------- AC 3: second dispatch on the same PQ is unrestricted ---------
+
+class TestSecondDispatchUnrestricted:
+    def test_redispatch_after_allowed_first_passes(self, tmp_path) -> None:
+        """First dispatch admits (candidates filed, uncertainty declared ->
+        roi-intents row). Stripping the candidates afterwards must NOT
+        re-arm the gate: the history face (runs/roi-intents.jsonl claim
+        association, #105 producer) shows q1 was already dispatched."""
+        root = tmp_path
+        ws = _mk_ws(root)
+        _write_hyp(ws, "H-001", candidates=["AES-CBC", "ChaCha20"])
+        first = _PROMPT + "\nuncertainty: which mac the header uses"
+        assert _run_gate(root, ws, first).returncode == 0
+        assert _intent_rows(ws), "first dispatch must land the history row"
+        # strip the competitor field — the gate must stay open on history
+        _write_hyp(ws, "H-001", candidates=[])
+        second = _PROMPT + "\nuncertainty: re-check the mac branch"
+        r = _run_gate(root, ws, second)
+        assert r.returncode == 0, (
+            f"a second dispatch on the same PQ must not re-trigger the "
+            f"admission; stderr={r.stderr!r}")
+        assert "REJECT hypothesis_admission" not in r.stderr
+
+    def test_strategy_log_history_counts(self, tmp_path) -> None:
+        """The #120-face dispatch history (runs/strategy-log.jsonl
+        event=dispatch rows) also marks the PQ as already dispatched."""
+        root = tmp_path
+        ws = _mk_ws(root)
+        log = ws / "runs" / "strategy-log.jsonl"
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text(json.dumps({
+            "ts": "2026-09-06T00:00:00Z", "event": "dispatch",
+            "strategy": "s1", "claim": "C-1",
+            "attempts_at_snapshot": 0}) + "\n", encoding="utf-8")
+        r = _run_gate(root, ws, _PROMPT)
+        assert r.returncode == 0, (
+            f"strategy-log dispatch history must satisfy the first-dispatch "
+            f"face; stderr={r.stderr!r}")
+
+
+# ---------- guards: what must NOT trigger the gate ------------------------
+
+class TestGateScopeGuards:
+    def test_non_pq_claim_never_triggers(self, tmp_path) -> None:
+        """answers_question null -> no PQ neighborhood -> no admission
+        (parks/reinstatements and plain task claims stay unaffected)."""
+        root = tmp_path
+        ws = _mk_ws(root)
+        reg = {"claims": [{"id": "C-1", "status": "OPEN",
+                           "statement": "background sweep"}]}
+        _write_yaml(ws / "claim-register.yaml", reg)
+        r = _run_gate(root, ws, _PROMPT)
+        assert r.returncode == 0, f"stderr={r.stderr!r}"
+        assert "REJECT hypothesis_admission" not in r.stderr
+
+    def test_answers_to_unknown_id_is_not_a_pq(self, tmp_path) -> None:
+        """qX must be a task_spec primary_question: a claim pointing at an
+        id task_spec never declared is register drift, not an admission
+        concern (the PQ neighborhood does not exist)."""
+        root = tmp_path
+        ws = _mk_ws(root, pq_ids=("q1",))
+        reg = yaml.safe_load(
+            (ws / "claim-register.yaml").read_text(encoding="utf-8"))
+        reg["claims"][0]["answers_question"] = "q99"
+        _write_yaml(ws / "claim-register.yaml", reg)
+        r = _run_gate(root, ws, _PROMPT)
+        assert r.returncode == 0, f"stderr={r.stderr!r}"
+
+    def test_inactive_gate_stays_asleep(self, tmp_path) -> None:
+        """v1.9.7 hooks-sleep discipline: no activation -> no admission,
+        rc 0 (the gate never fires outside the activated main flow)."""
+        root = tmp_path
+        ws = _mk_ws(root)
+        write_hook_state(ws, active_hooks=[])
+        r = _run_gate(root, ws, _PROMPT)
+        assert r.returncode == 0, f"stderr={r.stderr!r}"
+
+
+# ---------- fail-open: store outage warns + traces, never blocks ---------
+
+class TestStoreFailureFailOpen:
+    def test_store_read_failure_fails_open(self, tmp_path,
+                                            monkeypatch) -> None:
+        """A hypothesis-store read failure -> WARN + trace
+        (hypothesis_admission_fail_open) and the dispatch proceeds."""
+        import hypothesis_store as hs
+        import dispatch_gate as dg
+
+        def _boom(self):
+            raise OSError("hypotheses/ unreadable")
+
+        monkeypatch.setattr(hs.HypothesisStore, "list_all", _boom)
+        ws = _mk_ws(tmp_path)
+        _write_hyp(ws, "H-001", candidates=[])
+        payload = {"tool_input": {"prompt": _PROMPT}}
+        rc = dg._hypothesis_admission(ws, "C-1", payload)
+        assert rc is None, "a store outage must not block the dispatch"
+        rows = [e for e in _event_rows(ws)
+                if e.get("action") == "hypothesis_admission_fail_open"]
+        assert rows, f"fail-open trace missing; rows={_event_rows(ws)}"
+        assert rows[0].get("claim") == "C-1"
+        assert "OSError" in str(rows[0].get("detail"))
+
+    def test_register_unreadable_stays_silent(self, tmp_path,
+                                              monkeypatch) -> None:
+        """An unreadable claim register means the PQ neighborhood cannot be
+        identified — the gate stays silent (no crash, no false REJECT)."""
+        import dispatch_gate as dg
+        ws = _mk_ws(tmp_path)
+        (ws / "claim-register.yaml").write_text("::: not yaml :::[",
+                                                encoding="utf-8")
+        assert dg._hypothesis_admission(
+            ws, "C-1", {"tool_input": {"prompt": _PROMPT}}) is None
+
+
+# ---------- the store read helper (#109 surface on hypothesis_store) ------
+
+class TestOpenCandidatesForQuestion:
+    def _hyps(self, *specs: dict) -> list:
+        from hypothesis_store import Hypothesis
+        return [Hypothesis(id=s["id"], claim_id=s.get("claim_id", "C-PENDING"),
+                           competitor_group=s.get("group", "pq-q1"),
+                           candidates=s.get("candidates", []),
+                           status=s.get("status", "open"),
+                           body=s.get("body", ""))
+                for s in specs]
+
+    def test_binds_by_marker_group_and_claim_map(self) -> None:
+        from hypothesis_store import open_candidates_for_question
+        hyps = self._hyps(
+            {"id": "H-1", "candidates": ["a"], "body": "pq:q1\nscaffold"},
+            {"id": "H-2", "candidates": ["b"], "group": "pq-q1"},
+            {"id": "H-3", "candidates": ["c"], "group": "pq:q1"},
+            {"id": "H-4", "candidates": ["d"], "claim_id": "C-1",
+             "group": "other"},
+        )
+        got = open_candidates_for_question(hyps, "q1", {"C-1": "q1"})
+        assert sorted(got) == ["a", "b", "c", "d"], f"got {got}"
+
+    def test_open_only_and_other_questions_excluded(self) -> None:
+        from hypothesis_store import open_candidates_for_question
+        hyps = self._hyps(
+            {"id": "H-1", "candidates": ["live"], "body": "pq:q1"},
+            {"id": "H-2", "candidates": ["dead"], "status": "refuted",
+             "body": "pq:q1"},
+            {"id": "H-3", "candidates": ["other-q"], "body": "pq:q2",
+             "group": "pq-q2"},
+        )
+        got = open_candidates_for_question(hyps, "q1", {})
+        assert got == ["live"], f"got {got}"
+
+    def test_no_map_and_no_marker_binds_nothing(self) -> None:
+        from hypothesis_store import open_candidates_for_question
+        hyps = self._hyps({"id": "H-1", "candidates": ["x"],
+                           "claim_id": "C-1", "group": "g"})
+        assert open_candidates_for_question(hyps, "q1", None) == []
+
+
+# ---------- vocabulary registration (#459 anchor sibling) -----------------
+
+@pytest.mark.parametrize("word", ["hypothesis_admission_reject",
+                                  "hypothesis_admission_fail_open"])
+def test_admission_words_are_registered_emit_actions(word: str) -> None:
+    """The gate's two new faces draw their event words from the controlled
+    vocabulary (an unregistered literal turns the CI anchor red)."""
+    import event_taxonomy as et
+    assert word in et.EMIT_ACTIONS


### PR DESCRIPTION
Closes #109

## Summary
Framework-rigidity predicate (protocol completeness — never a method judgment): the first dispatch whose claim answers primary_question qX requires >=2 non-adjudicated candidates for qX in the hypothesis layer. Anchoring risk is highest exactly when the system knows least; a single-hypothesis entry is how edge findings get chased as major ones.

## Design
- Trigger: claim `answers_question` -> task_spec PQ (canonical #77 parser) + first-dispatch detection via strategy-log (#120 read path) and roi-intents (#105 producer), claim-keyed
- Check: candidates >= 2, open-status only (adjudicated ones never count); falsifier check relaxed to #528's literal list contract with explicit TODO
- REJECT carries `<gate-verdict>` repair path per the #57 pattern: file >=2 competing candidates, each naming its falsifier
- Store read failure -> fail-open (WARN + `hypothesis_admission_fail_open` trace); non-PQ claims never trigger; second dispatch on the same PQ unrestricted
- Backward-compatible `_reject_with_guidance(issue=)` addition (#496 call sites byte-identical)

## Test plan
- [x] 21 new tests RED-first (12 failed before implementation)
- [x] Targeted: 206 passed (dispatch gates, roi_settlement_49); neighbor gate faces: 205 passed
- [x] Full suite: 5765 passed, 10 skipped, 1 known machine-local red (env_check python 3.14)
- [x] deploy-manifest regenerated (378 entries OK)