### PR TITLE
feat(#110): case_bank goes live — settlement write-side, cold-start prior injection, dedup

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -207,7 +207,7 @@ files:
   - src: scripts/case_bank.py
     dest: .claude/scripts/case_bank.py
     kind: scaffold
-    sha256: bcb2fdcdacbc7b2f78e400808e2f05159341bc41f37ab2faf1894ead42a2c5c0
+    sha256: ea836b3365ba235e62663b39cf55233e3cf12e3c9222a48476dd15ec54335cf5
   - src: scripts/challenge_ledger.py
     dest: .claude/scripts/challenge_ledger.py
     kind: scaffold
@@ -291,7 +291,7 @@ files:
   - src: scripts/digest_build.py
     dest: .claude/scripts/digest_build.py
     kind: scaffold
-    sha256: a20403338d912ecf76743f0237cd6ce12898b28a7ebf962a699f5daf914451bf
+    sha256: d65f1e79401152e112fb7335a2f2ef865af055b908e78fccd8663a5942c9ba29
   - src: scripts/dispatch_context.py
     dest: .claude/scripts/dispatch_context.py
     kind: scaffold
@@ -335,7 +335,7 @@ files:
   - src: scripts/event_taxonomy.py
     dest: .claude/scripts/event_taxonomy.py
     kind: scaffold
-    sha256: 5a83dddcee364d6cde0deaf304524bb4131aaf7792b4daddd41c7442d3bef8f4
+    sha256: 9bed1b1a5f9dc8abcae0e93bf901b5e8380c835db12ad19fb59eccd09f3488bc
   - src: scripts/explore_gate.py
     dest: .claude/scripts/explore_gate.py
     kind: scaffold
@@ -399,7 +399,7 @@ files:
   - src: scripts/hypothesis_seeder.py
     dest: .claude/scripts/hypothesis_seeder.py
     kind: scaffold
-    sha256: c8589ca9c2955f9b771bbbfaf942b2a87ba29085aeba3a9710de7162fe216456
+    sha256: 4867e369d6024a92504330a019ef2746d0820bf7de68090cd6ca667e84752e3e
   - src: scripts/hypothesis_store.py
     dest: .claude/scripts/hypothesis_store.py
     kind: scaffold
@@ -579,7 +579,7 @@ files:
   - src: scripts/outcome_capture.py
     dest: .claude/scripts/outcome_capture.py
     kind: scaffold
-    sha256: 139fb1b45a04e153dbde6d69c4bd8dd130bff475ca204a483faa1a12ebb88e4a
+    sha256: ec4ad9affe0d2d024e827268cf9fd271317b4432afa007a636779e22031567b7
   - src: scripts/pkg_detect.py
     dest: .claude/scripts/pkg_detect.py
     kind: scaffold

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -69,7 +69,7 @@ scripts (count in parens) · `tests` = exercised by tests/ only.
 | `infeasible_signal.py` | P3 doomed-trajectory signal (#823/#815): flat V × zero marginal discovery → infeasible_candidate event (shadow) | lib, tests |
 | `infeasible_proposal.py` | #815 早停接线 — gated INFEASIBLE 立案（阶梯 L1/L2/L3+清单+wake_condition 要件, REJECT 零变更）+ wake 复活面; DEFERRED 自动退出派发 | hooks, tests |
 | `zero_output_fingerprint.py` | P3 same-type action thrash circuit (#823/#634): (tool,target) hash streaks N=3 zero belief change → break + failure_analysis inject (shadow) | lib, tests |
-| `hypothesis_seeder.py` | PQ scaffold seeder (#662) + apkid candidate extension (#669): seeds `pq:<qid>` hypotheses, appends `apkid:<cat>:<rule>` / `taint:<cat>:<api>` candidates | lib(1: digest_build), CLI, tests |
+| `hypothesis_seeder.py` | PQ scaffold seeder (#662) + apkid candidate extension (#669) + #110 case-bank priors: seeds `pq:<qid>` hypotheses, appends `apkid:<cat>:<rule>` / `taint:<cat>:<api>` candidates; `seed_case_candidates` 按冷启动 (project_type+保护特征) 检索 runs/case-bank.jsonl 命中行注入 provenance 先验 (failure-first, 零行/零命中/零上下文静默跳过) | lib(1: digest_build), CLI, tests |
 | `apkid_scanner.py` | T1 apkid pre-scan wrapper (#669): fingerprints packer/compiler/obfuscator/anti-* into evidence/apkid.json (fail-open) | CLI, tests |
 | `provider_health.py` | runtime provider-failure memory (#692 WP4): record/query <ws>/provider_health.json, 24h window, fail-open; consumed by route_capability selection next round | CLI, lib(1: route_capability), tests |
 | `priority_ratio.py` | sanctioned v1.9.29 dispatch ranker (R4); #823 A3 feed-side terms always-on (#51) | lib(3), tests |
@@ -132,9 +132,9 @@ scripts (count in parens) · `tests` = exercised by tests/ only.
 | `dead_letter.py` | DEAD status + dead-letter quarantine | hooks, lib(1), tests |
 | `feedback.py` | feedback inbox processing | tests |
 | `obligation_discovery.py` | obligation discovery from claims | lib(1), tests |
-| `outcome_capture.py` | outcome ledger capture (R6) | lib(2), tests |
+| `outcome_capture.py` | outcome ledger capture (R6) + #110 结算落库: 每个 NEW settlement 经 `_bank_case`→case_bank.append_once 落一行案例 (NEGATIVE 无 attribution 机械合成 verdict/checker/signals, ruling 4); 落库失败 fail-open `case_bank_refused` 事件 | lib(2), tests |
 | `roi_settlement.py` | #49 dispatch intent contract + entropy-gain admission gate — record_intent (MISSING_UNCERTAINTY data-channel gate, ruling 3) + settle_intent outcome-vs-intent 归因 (POSITIVE/NEUTRAL/NEGATIVE/UNRESOLVED; fact count 永不作信号, ruling 2) → runs/roi-intents.jsonl + runs/roi-settlements.jsonl; dispatch_gate enforcement wiring 属后续 | outcome_capture (_settle_new wiring), tests |
-| `case_bank.py` | #49 案例库数据层 — 对称收录 (NEGATIVE 无 attribution 拒收 CaseBankError, 无声落库即违约, ruling 4) + failures-first 检索 (反例剪枝优先于正例复用, 类内 newest-first) + `<case-hints>` 生产面 (XML 注入标准保留名, 空匹配不产空标签); CLI: retrieve --tags --limit --json | tests, CLI |
+| `case_bank.py` | #49 案例库数据层 — 对称收录 (NEGATIVE 无 attribution 拒收 CaseBankError, 无声落库即违约, ruling 4) + failures-first 检索 (反例剪枝优先于正例复用, 类内 newest-first) + `<case-hints>` 生产面 (XML 注入标准保留名, 空匹配不产空标签); `append_once` (claim×method×roi_class 幂等去重, #110); CLI: retrieve --tags --limit --json | tests, CLI |
 | `reconcile_intents.py` | plan↔claims intent reconciliation | tests |
 | `reconcile_workers.py` | worker status reconciliation | lib(1), tests |
 | `refutation_propagate.py` | refutation propagation across facts | tests |

--- a/scripts/case_bank.py
+++ b/scripts/case_bank.py
@@ -117,6 +117,29 @@ def append(ws: Path, entry: dict) -> dict:
     return stored
 
 
+def append_once(ws: Path, entry: dict) -> dict:
+    """Idempotent append keyed on (claim_id, method, roi_class) — #110.
+
+    The settlement wiring fires per settled claim; a replayed settlement
+    (same claim, same method, same roi_class) must not grow the bank.
+    Validation is NOT bypassed: the ruling-4 lint (unattributed NEGATIVE)
+    and the required-field checks still raise CaseBankError — dedup only
+    short-circuits the WRITE, never the contract.
+
+    Returns {"ok": True, "duplicate": bool, "record": <stored or found>}.
+    """
+    e = entry or {}
+    key = (str(e.get("claim_id") or ""), str(e.get("method") or ""),
+           str(e.get("roi_class") or ""))
+    for existing in read_entries(ws):
+        if (str(existing.get("claim_id") or ""),
+                str(existing.get("method") or ""),
+                str(existing.get("roi_class") or "")) == key:
+            return {"ok": True, "duplicate": True, "record": existing}
+    record = append(ws, e)
+    return {"ok": True, "duplicate": False, "record": record}
+
+
 def retrieve(ws: Path, context_tags: list, limit: int = 5) -> list[dict]:
     """Matching entries, FAILURES FIRST then positives, newest first.
 

--- a/scripts/digest_build.py
+++ b/scripts/digest_build.py
@@ -283,6 +283,17 @@ def build_digest(ws: Path) -> str:
         seed_from_task_spec(ws)
     except Exception:  # noqa: BLE001 — seeding failure never blocks cold start
         pass
+    # ---- #110: case-bank priors -> hypothesis layer — FAIL-OPEN ----
+    # Same cold-start chain as PQ scaffolding: the per-workspace case bank
+    # (runs/case-bank.jsonl) is retrieved by (project_type + protection
+    # traits) and hits inject as provenance-carried prior candidates on one
+    # carrier hypothesis. Zero rows / zero hits -> silent (cold start
+    # unchanged — no fabricated priors); a failure never blocks the digest.
+    try:
+        from hypothesis_seeder import seed_case_candidates
+        seed_case_candidates(ws)
+    except Exception:  # noqa: BLE001 — priors never block cold start
+        pass
     # ---- sec_g: open hypotheses (#528) — FAIL-OPEN ----
     # A hypotheses-layer failure must never block cold start: the digest
     # degrades to the pre-#528 six-section shape instead of raising

--- a/scripts/event_taxonomy.py
+++ b/scripts/event_taxonomy.py
@@ -165,6 +165,8 @@ EMIT_ACTIONS = [
     "capability_reject",
     "capability_switch",
     "carrier_drift",      # #829 cross-carrier consistency gate: register/_INDEX/notes/facts drift face
+    "case_bank_refused",  # #110 settlement->case-bank append refused (fail-open WARN face)
+    "case_priors_seeded",  # #110 cold-start case-bank prior injection face
     "channel_default",    # #727 init channel degradation/guidance WARN
     "claim_migrate",
     "claim_revive",       # #634 PARK → OPEN revival (mission_stall.revive)

--- a/scripts/hypothesis_seeder.py
+++ b/scripts/hypothesis_seeder.py
@@ -29,6 +29,7 @@ except ImportError:  # pragma: no cover
 # Canonical PQ parse — same schema rules as convergence_check (issue #77);
 # a malformed schema is convergence's INVALID problem, not ours (D7).
 from convergence_check import _parse_primary_questions
+from init_state import STATE_FILE, read_project_type  # #110 init context
 from hypothesis_store import Hypothesis, HypothesisStore
 
 MARKER_FMT = "pq:{qid}"
@@ -345,6 +346,162 @@ def seed_taint_candidates(ws: Path) -> int:
                 except Exception:  # noqa: BLE001 - logging never breaks seeding
                     pass
     return appended
+
+
+# ---------------------------------------------------------------------------
+# #110 — case-bank priors -> hypothesis layer (cold-start injection)
+# ---------------------------------------------------------------------------
+# Storage reality: the case bank is PER-WORKSPACE (runs/case-bank.jsonl), so
+# the read side rides the cold-start chain (digest_build already fires
+# seed_from_task_spec there) instead of a cross-workspace lookup — the
+# initialized workspace's recurring cold start IS the replay face. Retrieval
+# is scoped by (project_type + protection traits from recon evidence on
+# disk); hits land as prior candidates with provenance on ONE carrier
+# hypothesis. Zero rows / zero hits / zero derivable context -> nothing is
+# written (cold start unchanged — no fabricated priors).
+CASE_BODY_MARKER = "case-bank-priors"
+_CASE_GROUP = "case-bank-priors"
+CASE_HINT_LIMIT = 5
+
+
+def _read_json_file(path: Path) -> dict:
+    """Tolerant JSON read: missing/corrupt -> {} (never raises)."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _case_query_tags(ws: Path) -> list[str]:
+    """(project_type + protection traits) query context for #110 retrieval.
+
+    project_type: init_state (analysis_state.txt, then the #625 state file).
+    Protection traits: recon evidence already on disk — evidence/die.json
+    (derived.detected_packer / high_entropy_sections) and evidence/apkid.json
+    (summary packer/obfuscator/anti_debug/anti_vm). Dedup, order-stable.
+    No derivable context -> [] (the caller skips: a context-free prior is a
+    fabricated prior).
+    """
+    tags: list[str] = []
+    ptype = read_project_type(ws)
+    if not ptype:
+        ptype = str(_read_json_file(ws / STATE_FILE).get("project_type") or "")
+    if ptype:
+        tags.append(str(ptype))
+    die = _read_json_file(ws / "evidence" / "die.json")
+    derived = die.get("derived") if isinstance(die.get("derived"), dict) else {}
+    packer = str(derived.get("detected_packer")
+                 or die.get("detected_packer") or "").strip()
+    if packer:
+        tags.extend(["packed", packer.lower()])
+    if derived.get("high_entropy_sections") or die.get("high_entropy_sections"):
+        tags.append("high-entropy")
+    apkid = _read_json_file(ws / "evidence" / "apkid.json")
+    summary = apkid.get("summary")
+    if not isinstance(summary, dict):
+        summary = {}
+    if summary.get("packer"):
+        tags.append("packed")
+    if summary.get("obfuscator"):
+        tags.append("obfuscated")
+    if summary.get("anti_debug") or summary.get("anti_vm"):
+        tags.append("anti-analysis")
+    out: list[str] = []
+    for t in tags:
+        if t and t not in out:
+            out.append(t)
+    return out
+
+
+def _case_text(value) -> str:
+    """Single-line, comma-free text (frontmatter list round-trip: the store
+    parses `candidates: [a, b]` by splitting on commas)."""
+    return " ".join(str(value or "").split()).replace(",", ";")
+
+
+def _case_candidate_line(entry: dict) -> str:
+    """One prior-candidate line with provenance (#110): failures carry
+    attribution (+ premise_correction) like the <case-hints> face."""
+    head = (f"case-bank prior: {entry.get('claim_id')} "
+            f"({entry.get('roi_class')} method={entry.get('method')})")
+    parts = [head]
+    if entry.get("attribution"):
+        parts.append(f"attribution: {_case_text(entry['attribution'])}")
+    if entry.get("premise_correction"):
+        parts.append(f"correction: {_case_text(entry['premise_correction'])}")
+    return " | ".join(parts)
+
+
+def _case_body() -> str:
+    return (
+        f"{CASE_BODY_MARKER}\n\n"
+        "Prior candidates from the case bank (runs/case-bank.jsonl),\n"
+        "retrieved at cold start by (project_type + protection traits).\n"
+        "Failures lead (counterexample pruning > positive reuse). These are\n"
+        "PROVENANCE-CARRIED hints — what was tried in a similar context,\n"
+        "what the signals looked like, what the attribution was — never hard\n"
+        "rules. Judgment stays with the orchestrator/worker; adjudicate per\n"
+        "#528 (refute / supersede).\n"
+    )
+
+
+def _emit_case(ws: Path, hyp_id: str, n: int) -> None:
+    """kunglao_log observability (#110) — guarded, never raises."""
+    try:
+        from kunglao_log import emit
+        emit(ws, actor="hypothesis_seeder", action="case_priors_seeded",
+             detail=f"{hyp_id} +{n} case prior(s)")
+    except Exception:  # noqa: BLE001 — logging must never break seeding
+        pass
+
+
+def seed_case_candidates(ws: Path, limit: int = CASE_HINT_LIMIT) -> int:
+    """Inject case-bank hits as prior candidates (cold-start face, #110).
+
+    case_bank.retrieve over the (project_type + protection traits) context —
+    FAILURES FIRST (the retrieve contract), newest first within a class.
+    Hits append to ONE carrier hypothesis (identified by the
+    case-bank-priors body marker — the #662 marker pattern, because the
+    store drops unknown frontmatter keys on rewrite); idempotent per exact
+    candidate string. Returns the count of NEW candidates appended.
+
+    Zero rows / zero hits / zero derivable context -> 0, nothing written.
+    Fail-open (D7): every failure degrades to 0, never raises.
+    """
+    ws = Path(ws)
+    try:
+        import case_bank
+        tags = _case_query_tags(ws)
+        if not tags:
+            return 0
+        entries = case_bank.retrieve(ws, tags, limit)
+        if not entries:
+            return 0
+        cands = [_case_candidate_line(e) for e in entries]
+        store = HypothesisStore(ws / "hypotheses")
+        carrier = next((h for h in store.list_all()
+                        if CASE_BODY_MARKER in h.body), None)
+        if carrier is None:
+            carrier = Hypothesis(
+                id=_next_free_id(store),
+                claim_id=PLACEHOLDER_CLAIM,
+                competitor_group=_CASE_GROUP,
+                candidates=[],
+                status="open",
+                body=_case_body(),
+            )
+            carrier.path = ws / "hypotheses" / f"{carrier.id}.md"
+            store._write(carrier)  # store has no public create-with-body path
+        existing = set(carrier.candidates)
+        new_candidates = [c for c in cands if c not in existing]
+        if new_candidates:
+            carrier.candidates = list(carrier.candidates) + new_candidates
+            store._write(carrier)
+            _emit_case(ws, carrier.id, len(new_candidates))
+        return len(new_candidates)
+    except Exception:  # noqa: BLE001 — priors never break cold start (D7)
+        return 0
 
 
 def main(argv=None) -> int:

--- a/scripts/outcome_capture.py
+++ b/scripts/outcome_capture.py
@@ -131,6 +131,11 @@ def _settle_new(workspace: Path, new_rows: list[dict]) -> None:
     breaks. Outcome payload today is verdict + checker (the fields an OUTCOME
     row carries); artifact-list enrichment from #77 result digests is a later
     change.
+
+    #110: each NEW settlement lands one case-bank row (case_bank.append_once,
+    idempotent on claim x method x roi_class) via _bank_case — equally
+    fail-open (a banking refusal is a `case_bank_refused` warn event, never
+    a capture failure).
     """
     try:
         import roi_settlement
@@ -141,12 +146,76 @@ def _settle_new(workspace: Path, new_rows: list[dict]) -> None:
             claim_id = entry.get("claim_id")
             if not claim_id or not roi_settlement.has_intent(workspace, claim_id):
                 continue
-            roi_settlement.settle_intent(workspace, claim_id, {
+            res = roi_settlement.settle_intent(workspace, claim_id, {
                 "verdict": entry.get("result"),
                 "checker": entry.get("checker"),
             })
+            # #110: every NEWLY settled claim banks one case row. A replayed
+            # settlement (duplicate settle_id) banks nothing — append_once is
+            # idempotent on (claim_id, method, roi_class) anyway.
+            if res.get("ok") and not res.get("duplicate"):
+                _bank_case(workspace, res.get("settlement") or {})
         except Exception:  # noqa: BLE001  (fail-open by contract)
             continue
+
+
+def _case_entry_from_settlement(settlement: dict) -> dict:
+    """#110: map a settlement row onto the #49 case-bank schema.
+
+    The scene/method/roi_class/outcome triple rides verbatim from the
+    settlement (ruling 1: value = method x context x outcome). attribution
+    defaults to a MECHANICAL synthesis from the settlement's own
+    verdict/checker/signals when the producer supplied none — ruling 4
+    refuses unattributed NEGATIVE rows, and the settlement row IS the
+    mechanical why-it-classified-NEGATIVE record (never invented analysis).
+    """
+    s = dict(settlement or {})
+    intent = s.get("intent") or {}
+    outcome = s.get("outcome") if isinstance(s.get("outcome"), dict) else {}
+    roi_class = str(s.get("roi_class") or "").strip()
+    attribution = str((outcome or {}).get("attribution") or "").strip()
+    if roi_class == "NEGATIVE" and not attribution:
+        # both modules freeze the same token: roi_settlement.ROI_NEGATIVE ==
+        # case_bank.ROI_NEGATIVE == "NEGATIVE" (ruling-4 lint target).
+        signals = ",".join(str(x) for x in (s.get("signals") or ())) or "none"
+        attribution = (f"verdict={(outcome or {}).get('verdict') or 'none'} "
+                       f"checker={(outcome or {}).get('checker') or 'none'} "
+                       f"signals={signals}")
+    return {
+        "claim_id": s.get("claim_id"),
+        "method": intent.get("method") or "dispatch",
+        "context_tags": [str(t) for t in (intent.get("context_tags") or [])],
+        "intent_uncertainty": intent.get("uncertainty") or "",
+        "outcome_observed": outcome or {},
+        "roi_class": roi_class,
+        "attribution": attribution or None,
+        "premise_correction":
+            str((outcome or {}).get("premise_correction") or "").strip()
+            or None,
+    }
+
+
+def _bank_case(ws: Path, settlement: dict) -> bool:
+    """#110: bank one settled claim (case_bank.append_once).
+
+    Fail-open by the same contract as settlement itself: a refusal
+    (CaseBankError — e.g. an unattributable NEGATIVE), a missing module or
+    any write failure emits a `case_bank_refused` warn event and returns
+    False. The settlement row is NEVER touched by banking.
+    """
+    try:
+        import case_bank
+        res = case_bank.append_once(ws, _case_entry_from_settlement(settlement))
+        return bool(res.get("ok")) and not res.get("duplicate")
+    except Exception as exc:  # noqa: BLE001  (banking must never break capture)
+        try:
+            from kunglao_log import emit
+            emit(ws, actor="outcome_capture", action="case_bank_refused",
+                 claim=(settlement or {}).get("claim_id"),
+                 detail=f"case-bank append refused ({exc!r})")
+        except Exception:  # noqa: BLE001  (telemetry never disturbs capture)
+            pass
+        return False
 
 
 def capture(workspace: Path) -> int:

--- a/tests/test_case_bank_110.py
+++ b/tests/test_case_bank_110.py
@@ -1,0 +1,369 @@
+# -*- coding: utf-8 -*-
+"""#110 case_bank goes live — write side (settlement -> bank) + read side
+(cold-start retrieval injection into the hypothesis layer) + dedup.
+
+RED-first tests pin the #110 contract:
+
+- Write side: every SUCCESSFULLY settled claim lands one case row
+  (scene/method/roi_class/outcome triple per ruling 1); NEGATIVE rows carry
+  attribution (synthesized from the settlement's verdict/checker/signals when
+  the producer supplied none — ruling 4 forbids unattributed failures).
+- Fail-open: a case-bank append failure NEVER breaks settlement — a
+  `case_bank_refused` warn event is the durable signal.
+- Dedup: idempotent on (claim_id, method, roi_class) — duplicate settlements
+  produce one row.
+- Read side: at cold start (digest_build seeding chain), the bank is queried
+  by (project_type + protection traits) and hits inject into the hypothesis
+  layer as prior candidates with provenance "case-bank prior: <claim_id>";
+  NEGATIVE rows lead (counterexample pruning); zero hits / zero rows /
+  zero derivable context -> silent skip (cold start unchanged, no fabricated
+  priors).
+
+Storage note (design): case_bank is PER-WORKSPACE (runs/case-bank.jsonl), so
+the issue's two-workspace cross-run face cannot read across workspaces — the
+read side rides the cold-start digest chain (the same chain that already
+fires seed_from_task_spec at every restart), which is the initialized
+workspace's recurring cold start.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+import case_bank as cb
+import digest_build
+import hypothesis_seeder as hs
+import outcome_capture as oc
+import roi_settlement as roi
+from event_taxonomy import EMIT_ACTIONS
+
+
+# ---------- fixtures ----------
+
+def _write_task_spec(ws: Path, qid: str = "pq1") -> None:
+    (ws / "task_spec.yaml").write_text(
+        "project_type: android\n"
+        "primary_questions:\n"
+        f"  - id: {qid}\n"
+        "    q: which unpack order restores the OEP\n",
+        encoding="utf-8")
+
+
+def _write_project_type(ws: Path, ptype: str = "android") -> None:
+    (ws / "analysis_state.txt").write_text(
+        f"project_type={ptype}\n", encoding="utf-8")
+
+
+def _write_die(ws: Path, packer: str = "UPX") -> None:
+    ev = ws / "evidence"
+    ev.mkdir(exist_ok=True)
+    (ev / "die.json").write_text(
+        json.dumps({"derived": {"detected_packer": packer,
+                                "high_entropy_sections": [".text"]}}),
+        encoding="utf-8")
+
+
+def _verify_note(ws: Path, name: str, claim_id: str, verdict: str) -> None:
+    runs = ws / "runs"
+    runs.mkdir(exist_ok=True)
+    (runs / name).write_text(
+        f"---\nclaim_id: {claim_id}\n---\n\n## Overall verdict\n{verdict}\n",
+        encoding="utf-8")
+
+
+def _record_intent(ws: Path, claim_id: str = "C-1", **kw) -> dict:
+    args = dict(method="upx-unpack", context_tags=["android", "packed"],
+                uncertainty="which unpack order restores the OEP",
+                expected_artifact="")
+    args.update(kw)
+    return roi.record_intent(ws, claim_id, **args)
+
+
+def _case_entry(claim_id: str, **kw) -> dict:
+    base = dict(claim_id=claim_id, method="upx-unpack",
+                context_tags=["android", "packed"],
+                intent_uncertainty="which unpack order restores the OEP",
+                outcome_observed={"verdict": "passes"},
+                roi_class="POSITIVE")
+    base.update(kw)
+    return base
+
+
+# ---------- write side: settlement -> case row ----------
+
+class TestSettlementBanking:
+    def test_negative_settlement_banks_attributed_case_row(self, tmp_path):
+        """fails verdict + recorded intent -> one NEGATIVE case row WITH
+        attribution (ruling 4) carrying the full scene/method/outcome triple."""
+        _record_intent(tmp_path)
+        _verify_note(tmp_path, "a-verify-01.md", "C-1", "fails")
+
+        added = oc.capture(tmp_path)
+
+        assert added == 1
+        rows = cb.read_entries(tmp_path)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["claim_id"] == "C-1"
+        assert row["method"] == "upx-unpack"
+        assert row["roi_class"] == "NEGATIVE"
+        assert row["context_tags"] == ["android", "packed"]
+        assert row["intent_uncertainty"] == \
+            "which unpack order restores the OEP"
+        assert row["outcome_observed"]["verdict"] == "fails"
+        assert row["attribution"], "NEGATIVE row must carry attribution"
+        assert "fails" in row["attribution"]
+
+    def test_positive_settlement_banks_row_without_attribution(self, tmp_path):
+        _record_intent(tmp_path)
+        _verify_note(tmp_path, "a-verify-01.md", "C-1", "passes")
+
+        oc.capture(tmp_path)
+
+        rows = cb.read_entries(tmp_path)
+        assert len(rows) == 1
+        assert rows[0]["roi_class"] == "POSITIVE"
+        assert rows[0]["attribution"] is None
+
+    def test_producer_supplied_attribution_and_correction_ride_along(
+            self, tmp_path):
+        """A producer may pass attribution/premise_correction inside the
+        settlement outcome; they land verbatim in the case row."""
+        _record_intent(tmp_path)
+        res = roi.settle_intent(tmp_path, "C-1", {
+            "verdict": "fails", "checker": "verify-note",
+            "attribution": "entrypoint guess skipped the real OEP",
+            "premise_correction": "entrypoint != OEP for UPX"})
+        assert res["ok"] is True
+        entry = oc._case_entry_from_settlement(res["settlement"])
+        assert entry["attribution"] == \
+            "entrypoint guess skipped the real OEP"
+        assert entry["premise_correction"] == "entrypoint != OEP for UPX"
+
+    def test_unsettled_claim_banks_nothing(self, tmp_path):
+        """No recorded intent -> no settlement -> no case row (unchanged)."""
+        _verify_note(tmp_path, "a-verify-01.md", "C-1", "fails")
+        oc.capture(tmp_path)
+        assert cb.read_entries(tmp_path) == []
+
+    def test_settlement_failure_still_fail_open(self, tmp_path, monkeypatch):
+        """Banking failure must not break capture — the settlement row exists
+        and a case_bank_refused warn event is emitted (fail-open contract)."""
+        import kunglao_log
+
+        _record_intent(tmp_path)
+        _verify_note(tmp_path, "a-verify-01.md", "C-1", "fails")
+        calls: list[dict] = []
+        real_emit = kunglao_log.emit
+
+        def _recorder(ws, actor, action, **kw):
+            calls.append({"actor": actor, "action": action})
+            return real_emit(ws, actor, action, **kw)
+
+        monkeypatch.setattr(kunglao_log, "emit", _recorder)
+
+        def _boom(ws, entry):
+            raise cb.CaseBankError("disk full")
+
+        monkeypatch.setattr(cb, "append_once", _boom)
+        added = oc.capture(tmp_path)
+
+        assert added == 1
+        assert len(roi.read_settlements(tmp_path)) == 1
+        assert cb.read_entries(tmp_path) == []
+        assert any(c["action"] == "case_bank_refused" for c in calls)
+
+    def test_case_bank_refused_is_registered_vocabulary(self):
+        """Emit-face words come from EMIT_ACTIONS (#459 discipline)."""
+        assert "case_bank_refused" in EMIT_ACTIONS
+        assert "case_priors_seeded" in EMIT_ACTIONS
+
+
+# ---------- dedup: (claim_id, method, roi_class) idempotent ----------
+
+class TestDedup:
+    def test_append_once_dedups_same_triple(self, tmp_path):
+        first = cb.append_once(tmp_path, _case_entry("C-1"))
+        second = cb.append_once(tmp_path, _case_entry("C-1"))
+        assert first["ok"] is True and first["duplicate"] is False
+        assert second["ok"] is True and second["duplicate"] is True
+        assert len(cb.read_entries(tmp_path)) == 1
+
+    def test_append_once_allows_different_roi_class(self, tmp_path):
+        """An evolving verdict (fails -> passes) banks a NEW row: the dedup
+        key is the (claim, method, roi_class) triple, not the claim alone."""
+        cb.append_once(tmp_path, _case_entry(
+            "C-1", roi_class="NEGATIVE",
+            attribution="wrong unpack order",
+            outcome_observed={"verdict": "fails"}))
+        cb.append_once(tmp_path, _case_entry("C-1"))
+        rows = cb.read_entries(tmp_path)
+        assert sorted(r["roi_class"] for r in rows) == ["NEGATIVE", "POSITIVE"]
+
+    def test_duplicate_settlement_produces_one_row(self, tmp_path):
+        """Same settlement re-fired (ledger replay) -> bank stays at one row."""
+        _record_intent(tmp_path)
+        _verify_note(tmp_path, "a-verify-01.md", "C-1", "fails")
+        oc.capture(tmp_path)
+        assert len(cb.read_entries(tmp_path)) == 1
+
+        ledger = tmp_path / oc.LEDGER_NAME
+        ledger.unlink()  # simulate a replay of the same verify file
+        oc.capture(tmp_path)
+        assert len(cb.read_entries(tmp_path)) == 1
+
+    def test_append_once_still_enforces_ruling4_lint(self, tmp_path):
+        """Dedup never bypasses validation: an unattributed NEGATIVE is
+        refused even on the once-face."""
+        with pytest.raises(cb.CaseBankError, match="attribution"):
+            cb.append_once(tmp_path, _case_entry("C-1", roi_class="NEGATIVE"))
+        assert not cb.bank_path(tmp_path).exists()
+
+
+# ---------- read side: cold-start retrieval injection ----------
+
+class TestCasePriorInjection:
+    def test_injects_failure_first_with_provenance(self, tmp_path):
+        """Hits inject as prior candidates, NEGATIVE leading (counterexample
+        pruning), each carrying "case-bank prior: <claim_id>" provenance."""
+        _write_task_spec(tmp_path)
+        _write_project_type(tmp_path)
+        _write_die(tmp_path)
+        cb.append(tmp_path, _case_entry("C-1"))  # POSITIVE, oldest
+        cb.append(tmp_path, _case_entry("C-2", roi_class="NEGATIVE",
+                                        attribution="wrong unpack order",
+                                        premise_correction="entrypoint != OEP",
+                                        outcome_observed={"verdict": "fails"}))
+        cb.append(tmp_path, _case_entry("C-3"))  # POSITIVE, newest
+
+        n = hs.seed_case_candidates(tmp_path)
+
+        assert n == 3
+        store = hs.HypothesisStore(tmp_path / "hypotheses")
+        carrier = [h for h in store.list_all()
+                   if hs.CASE_BODY_MARKER in h.body]
+        assert len(carrier) == 1
+        cands = carrier[0].candidates
+        assert cands[0].startswith("case-bank prior: C-2")
+        assert "NEGATIVE" in cands[0]
+        assert "wrong unpack order" in cands[0]
+        assert "entrypoint != OEP" in cands[0]
+        assert [c.split(": ")[1].split(" ")[0] for c in cands] == \
+            ["C-2", "C-3", "C-1"]
+
+    def test_tag_intersection_scopes_injection(self, tmp_path):
+        """A row whose context shares no tag with the derived context
+        (project_type + protection traits) is NOT injected."""
+        _write_task_spec(tmp_path)
+        _write_project_type(tmp_path)
+        cb.append(tmp_path, _case_entry("C-1"))
+        cb.append(tmp_path, _case_entry("C-9", context_tags=["osint"],
+                                        method="osint-query"))
+
+        n = hs.seed_case_candidates(tmp_path)
+
+        assert n == 1
+        store = hs.HypothesisStore(tmp_path / "hypotheses")
+        carrier = [h for h in store.list_all()
+                   if hs.CASE_BODY_MARKER in h.body][0]
+        assert len(carrier.candidates) == 1
+        assert "case-bank prior: C-1" in carrier.candidates[0]
+        assert all("C-9" not in c for c in carrier.candidates)
+
+    def test_idempotent_rerun_adds_nothing(self, tmp_path):
+        _write_task_spec(tmp_path)
+        _write_project_type(tmp_path)
+        cb.append(tmp_path, _case_entry("C-1"))
+
+        assert hs.seed_case_candidates(tmp_path) == 1
+        assert hs.seed_case_candidates(tmp_path) == 0
+
+        store = hs.HypothesisStore(tmp_path / "hypotheses")
+        carrier = [h for h in store.list_all()
+                   if hs.CASE_BODY_MARKER in h.body][0]
+        assert len(carrier.candidates) == 1
+
+    def test_new_case_joins_existing_carrier(self, tmp_path):
+        _write_task_spec(tmp_path)
+        _write_project_type(tmp_path)
+        cb.append(tmp_path, _case_entry("C-1"))
+        hs.seed_case_candidates(tmp_path)
+        cb.append(tmp_path, _case_entry("C-2", roi_class="NEGATIVE",
+                                        attribution="packed entrypoint guess"))
+
+        assert hs.seed_case_candidates(tmp_path) == 1
+
+        store = hs.HypothesisStore(tmp_path / "hypotheses")
+        carrier = [h for h in store.list_all()
+                   if hs.CASE_BODY_MARKER in h.body]
+        assert len(carrier) == 1  # no second carrier file
+        assert len(carrier[0].candidates) == 2
+
+    def test_zero_rows_silent(self, tmp_path):
+        """Empty bank -> nothing injected, cold start unchanged (#110
+        acceptance: no fabricated priors)."""
+        _write_task_spec(tmp_path)
+        _write_project_type(tmp_path)
+
+        assert hs.seed_case_candidates(tmp_path) == 0
+        store = hs.HypothesisStore(tmp_path / "hypotheses")
+        assert [h for h in store.list_all()
+                if hs.CASE_BODY_MARKER in h.body] == []
+
+    def test_no_derivable_context_silent(self, tmp_path):
+        """No project_type + no protection evidence -> no query context ->
+        no injection (never a context-free 'match everything' prior)."""
+        _write_task_spec(tmp_path)
+        cb.append(tmp_path, _case_entry("C-1"))
+
+        assert hs.seed_case_candidates(tmp_path) == 0
+        store = hs.HypothesisStore(tmp_path / "hypotheses")
+        assert [h for h in store.list_all()
+                if hs.CASE_BODY_MARKER in h.body] == []
+
+    def test_protection_traits_derive_query_tags(self, tmp_path):
+        """DIE packer evidence widens the query context beyond project_type:
+        a row tagged only with the trait token still matches."""
+        _write_project_type(tmp_path)
+        _write_die(tmp_path, packer="VMProtect")
+        tags = hs._case_query_tags(tmp_path)
+        assert "android" in tags
+        assert "packed" in tags
+        assert "vmprotect" in tags
+        assert "high-entropy" in tags
+
+    def test_cold_start_digest_chain_injects(self, tmp_path):
+        """The injection rides the cold-start digest chain (the same chain
+        that fires seed_from_task_spec) and is visible in sec_g — the
+        initialized workspace's recurring cold start."""
+        _write_task_spec(tmp_path)
+        _write_project_type(tmp_path)
+        cb.append(tmp_path, _case_entry("C-1"))
+        cb.append(tmp_path, _case_entry("C-2", roi_class="NEGATIVE",
+                                        attribution="wrong unpack order",
+                                        outcome_observed={"verdict": "fails"}))
+
+        md = digest_build.build_digest(tmp_path)
+
+        store = hs.HypothesisStore(tmp_path / "hypotheses")
+        assert any("pq:pq1" in h.body for h in store.list_all()), \
+            "pq scaffolds still seeded (unchanged face)"
+        assert "case-bank prior: C-2" in md  # sec_g carries the priors
+        assert md.index("case-bank prior: C-2") < md.index("case-bank prior: C-1")
+
+    def test_case_priors_seeded_event(self, tmp_path, monkeypatch):
+        """Injection emits its telemetry face (like apkid/taint seeders)."""
+        import kunglao_log
+        _write_task_spec(tmp_path)
+        _write_project_type(tmp_path)
+        cb.append(tmp_path, _case_entry("C-1"))
+        calls: list[dict] = []
+        real_emit = kunglao_log.emit
+
+        def _recorder(ws, actor, action, **kw):
+            calls.append({"actor": actor, "action": action})
+            return real_emit(ws, actor, action, **kw)
+
+        monkeypatch.setattr(kunglao_log, "emit", _recorder)
+        hs.seed_case_candidates(tmp_path)
+        assert any(c["action"] == "case_priors_seeded" for c in calls)


### PR DESCRIPTION
Closes #110

## Summary
The experience bank starts receiving data. Write-side: settled claims land as case rows ((scene, method, roi_class) per ruling 1; NEGATIVE rows carry mechanically-synthesized attribution + premise_correction when the producer omits them — a ruling-4 row that can't be banked is a lost lesson). Read-side: cold-start digest chain retrieves by (project_type + protection traits) and injects hits as prior candidates on the same carrier hypothesis, failure-first, with provenance. Zero rows -> init behavior byte-identical (no fabricated priors).

## Design decisions
- `append_once` idempotency on (claim_id, method, roi_class) — dedup without weakening ruling-4 lint (attribution-missing NEGATIVE still raises)
- Bank hooked at outcome_capture._settle_new (settlement data layer stays pure); failures fail-open with `case_bank_refused` warn event
- Injection hooked in the cold-start digest chain after seed_from_task_spec (#662 marker pattern; body-marker because the store drops unknown frontmatter on rewrite)
- Per-workspace bank (runs/case-bank.jsonl) per the issue's fallback: cross-workspace read defers to the #50 experience-banking card; injection tested via repeated cold-start of the same workspace

## Test plan
- [x] 19 tests RED-first (18 red): settlement banking POSITIVE/NEGATIVE/synthesized-attribution/no-op/fail-open/dedup/lint-retain; injection failure-first/ordering/idempotent/re-tagging/zero-row-silent/telemetry
- [x] Targeted neighbors: 126 passed
- [x] Full suite: 1 failed / 5762 passed (machine-local env_check; pre-existing proven via temp-worktree baseline)
- [x] ruff clean; deploy-manifest regenerated (378 entries OK)