### PR TITLE
feat(#126): oracle case admission integrity — ref resolution, hypothesis_ref, signature dedup, load-time mutation

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -207,7 +207,7 @@ files:
   - src: scripts/case_bank.py
     dest: .claude/scripts/case_bank.py
     kind: scaffold
-    sha256: 2da508665c50e92207762688f6842616f4223b4d3cfaa75e25eb92547c9519a8
+    sha256: 39221df879fa1e7ade6d9c6628ddde01dd1092e825f77bb87d646d2a003e6471
   - src: scripts/challenge_ledger.py
     dest: .claude/scripts/challenge_ledger.py
     kind: scaffold
@@ -579,7 +579,7 @@ files:
   - src: scripts/oracle_runner.py
     dest: .claude/scripts/oracle_runner.py
     kind: scaffold
-    sha256: a63fb2d1319855294af3a7f4f4c1e70c1ed2265fdd9e2749b74862982a5ca6d1
+    sha256: 3f390170a677f731eaa4c39ec4e6bc0912ef4655a70e239749dc0ce7c326c27b
   - src: scripts/outcome_capture.py
     dest: .claude/scripts/outcome_capture.py
     kind: scaffold

--- a/scripts/case_bank.py
+++ b/scripts/case_bank.py
@@ -123,10 +123,16 @@ def append(ws: Path, entry: dict) -> dict:
 
 
 def append_once(ws: Path, entry: dict) -> dict:
-    """Idempotent append keyed on (claim_id, method, roi_class) — #110.
+    """Idempotent append keyed on (claim_id, action signature, roi_class).
 
-    The settlement wiring fires per settled claim; a replayed settlement
-    (same claim, same method, same roi_class) must not grow the bank.
+    #110 keyed the middle axis on the free-text method; #126 upgrades it to
+    the action signature (oracle_runner.action_channel): the same action
+    under two tool names (device-trace via frida-stalker vs ida-server —
+    one observation channel) banks ONCE, so a tool-name variant can no
+    longer displace other failures-first lessons from the top-5 retrieval
+    window. A DIFFERENT observation channel (emulator vs device) still
+    banks separately: cross-channel divergence is itself an observation.
+
     Validation is NOT bypassed: the ruling-4 lint (unattributed NEGATIVE)
     and the required-field checks still raise CaseBankError — dedup only
     short-circuits the WRITE, never the contract.
@@ -134,11 +140,13 @@ def append_once(ws: Path, entry: dict) -> dict:
     Returns {"ok": True, "duplicate": bool, "record": <stored or found>}.
     """
     e = entry or {}
-    key = (str(e.get("claim_id") or ""), str(e.get("method") or ""),
+    from oracle_runner import action_channel  # #126 signature axis (lazy:
+    # keeps case_bank's import graph unchanged for its read/CLI faces)
+    key = (str(e.get("claim_id") or ""), action_channel(e.get("method")),
            str(e.get("roi_class") or ""))
     for existing in read_entries(ws):
         if (str(existing.get("claim_id") or ""),
-                str(existing.get("method") or ""),
+                action_channel(existing.get("method")),
                 str(existing.get("roi_class") or "")) == key:
             return {"ok": True, "duplicate": True, "record": existing}
     record = append(ws, e)

--- a/scripts/oracle_runner.py
+++ b/scripts/oracle_runner.py
@@ -44,15 +44,54 @@ is not an observation and never touches the posterior.
 Case YAML shape::
 
     id: auth-fields            # required (file stem as fallback)
+    channel: device-trace      # required (#126): declared observation channel
+    hypothesis_ref: H-001      # required (#126): the live bet this case realizes
+    update_map:                # required (#126): cross-candidate separation —
+      green_up: [H-001]        #   who RISES on green / on red; ids must be
+      red_up: [H-002]          #   OPEN hypotheses in hypothesis_ref's group
     params: {user: alice, nonce: 10}
     expected:                  # required, non-empty
       - field: auth_algo       # required per entry
         value: hmac-sha256     # required per entry
-        evidence_refs: [F001]  # byte anchor (fact id(s)) — OR the marker below
-        pending-observation: true   # scaffold entry: owed, not compared
-    mutations:                 # optional; what distinguishes this case from
-      - field: auth_algo       #   near-miss implementations (half B)
-        kind: swap             #   swap | omit | change (default change)
+        evidence_refs: [F001]  # byte anchor — must RESOLVE (#126) …
+        pending-observation: true   # …or this marker: scaffold entry, owed
+    mutations:                 # REQUIRED non-empty (#126; was optional):
+      - field: auth_algo       #   what distinguishes this case from
+        kind: swap             #   near-miss implementations (half B)
+
+#126 — admission-time integrity beyond the #108 half C presence lint (the
+case set is blessed as a whole or not at all, before any IO):
+  - every non-pending evidence_ref RESOLVES to an existing fact-pipeline
+    artifact under the workspace — facts/F*.md or an evidence/ file
+    (an invented fact id is refused: refs are declarations, not
+    resolutions);
+  - refs into the oracle's own output (runs/ | oracle/ — the status file,
+    the case file itself) are refused: self-anchoring is circular
+    verification, the machine channel for a 100% pass rate;
+  - hypothesis_ref must name an existing <ws>/hypotheses/H*.md — a case
+    that discriminates nothing in the live competitor field is
+    indistinguishable from a real experiment at load time (the
+    trivial-oracle class);
+  - the action signature (declared channel, competitor_group of the linked
+    hypothesis) is the dedup axis: a second case with an identical
+    signature in one load is refused — marginal discriminative power, not
+    text. A different channel (emulator vs device) is a different
+    signature: cross-channel divergence is itself an observation;
+  - mutations non-empty at load: the --mutation flag becomes an admission
+    requirement — a case that cannot go red under a deliberately wrong
+    implementation is a rubber stamp;
+  - update_map is required and non-vacuous (cross-candidate separation):
+    green_up non-empty, at least one direction populated, every id an OPEN
+    hypothesis in the linked hypothesis's competitor_group. A case whose
+    outcome is invariant across the hypothesis space cannot write a valid
+    update_map — the HTTP-200 specimen: "HTTP 200 + body non-empty" is a
+    property of the ENVIRONMENT (server liveness), not of the unknown
+    being reversed; every candidate client greens it and
+    mutation-can-redden does not catch it (a mutation perturbing that
+    client reddens it too). Refused at admission;
+  - the linked hypothesis's competitor_group must hold >=2 OPEN members —
+    a live competition to discriminate; a self-filed singleton vacuous
+    hypothesis fails admission.
 
 Exit codes: 0 = no red case; 1 = at least one red case; 2 = lint refusal.
 Usage:
@@ -64,6 +103,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import sys
 import tempfile
 from pathlib import Path
@@ -84,9 +124,102 @@ class OracleCaseError(ValueError):
     """Case-set lint refusal (#108 half C) — loud, never silently blessed."""
 
 
+# ------------------------------------------------- #126 admission lints
+
+# E3 (issue #126 pre-experiment): the observation channel is DECLARED, not
+# inferred from tool names — priority_ratio.py's tool-family vocabulary is
+# per-TOOL (frida != ida) and carries no emulator tokens, so it cannot
+# produce the canonical verdict table ("frida stalker trace" == "ida server
+# trace" -> SAME device-trace channel; "unidbg codehook trace" != "frida
+# hook trace"). The case doc therefore declares `channel:` outright. The
+# case bank's entries carry only a free-text `method`, so the bank face
+# reads the channel through this DECLARED token vocabulary (word-bounded,
+# mechanical — the tool_families_from_text posture, channel semantics).
+# An unrecognized method maps to `adhoc:<normalized text>`: unknown actions
+# keep per-method keys and can never falsely dedup.
+_ACTION_CHANNEL_BY_TOKEN: dict[str, str] = {
+    "frida": "device-trace", "ida": "device-trace",
+    "x64dbg": "device-trace", "gdb": "device-trace",
+    "unidbg": "emulator-trace", "qiling": "emulator-trace",
+    "ghidra": "static",
+}
+
+
+def action_channel(method: str) -> str:
+    """Declared observation channel of an action's method text (pure).
+
+    Word-bounded, case-insensitive token match ('ida-server' -> ida; a
+    token inside a longer word never matches). Unrecognized text maps to
+    an ``adhoc:`` per-method channel so unknown actions stay distinct."""
+    text = str(method or "").lower()
+    for token, channel in _ACTION_CHANNEL_BY_TOKEN.items():
+        if re.search(r"(?<![a-z0-9])" + re.escape(token) + r"(?![a-z0-9])",
+                     text):
+            return channel
+    return "adhoc:" + " ".join(text.split())
+
+
+def action_signature(channel: str, competitor_group: str) -> tuple[str, str]:
+    """The #126 dedup axis: (declared observation channel, competitor
+    group served). Pure — same inputs, same signature, no hidden state."""
+    return (str(channel or "").strip(), str(competitor_group or "").strip())
+
+
+_EVIDENCE_ROOTS = ("facts", "evidence")
+
+
+def _resolve_evidence_ref(ws: Path, case_path: Path, cid: str,
+                          field: str, ref: str) -> Path:
+    """#126: an evidence ref RESOLVES or the case is refused.
+
+    Valid targets are fact-pipeline artifacts under the workspace:
+    ``facts/F*.md`` or any file under ``evidence/``. Refs pointing into
+    the oracle's own output (``runs/`` | ``oracle/`` — the status file,
+    the case file itself) are refused outright: self-anchoring is
+    circular verification. Path escapes are neutralized by containment —
+    a ref that resolves outside facts/ | evidence/ is refused, never
+    followed."""
+    text = str(ref).strip()
+    if not text:
+        raise OracleCaseError(
+            f"{case_path.name}: case {cid!r}: expected entry {field!r} "
+            f"carries an empty evidence_ref")
+    norm = text.replace("\\", "/").lower()
+    if norm.startswith(("runs/", "oracle/")) or "oracle-status" in norm:
+        raise OracleCaseError(
+            f"{case_path.name}: case {cid!r}: expected entry {field!r}: "
+            f"evidence ref {text!r} points into the oracle's own output "
+            f"(runs/ | oracle/) — self-anchor refused (#126: circular "
+            f"verification is the machine channel for a 100% pass rate)")
+    if "/" in text:
+        candidates = [ws / Path(text)]
+    else:
+        candidates = [ws / "facts" / f"{text}.md", ws / "facts" / text,
+                      ws / "evidence" / text]
+    for cand in candidates:
+        if not cand.is_file():
+            continue
+        resolved = cand.resolve()
+        for root in _EVIDENCE_ROOTS:
+            try:
+                resolved.relative_to((ws / root).resolve())
+            except ValueError:
+                continue
+            if root == "evidence" or (resolved.suffix == ".md"
+                                      and resolved.stem.startswith("F")):
+                return resolved
+            break  # under facts/ but not an F*.md — refused below
+        break  # exists, but outside facts/ | evidence/ — refused below
+    raise OracleCaseError(
+        f"{case_path.name}: case {cid!r}: expected entry {field!r}: evidence "
+        f"ref {text!r} does not resolve to an existing fact-pipeline "
+        f"artifact (facts/F*.md or an evidence/ file) under the workspace — "
+        f"refs are declarations, not resolutions (#126)")
+
+
 # ------------------------------------------------------------ case loading
 
-def _parse_expected(case_path: Path, cid: str, raw) -> list[dict]:
+def _parse_expected(ws: Path, case_path: Path, cid: str, raw) -> list[dict]:
     if not isinstance(raw, list) or not raw:
         raise OracleCaseError(
             f"{case_path.name}: case {cid!r} needs a non-empty `expected` list")
@@ -119,8 +252,13 @@ def _parse_expected(case_path: Path, cid: str, raw) -> list[dict]:
                 f"to bless an invented value (#108 half C: every expected "
                 f"entry carries a byte-anchored fact reference or an "
                 f"explicit pending-observation marker)")
+        str_refs = [str(r) for r in refs]
+        # #126: presence is not resolution — every non-pending ref must
+        # name an existing fact-pipeline artifact, or the case is refused.
+        for r in str_refs:
+            _resolve_evidence_ref(ws, case_path, cid, field, r)
         out.append({"field": field, "value": e["value"],
-                    "evidence_refs": [str(r) for r in refs], "pending": False})
+                    "evidence_refs": str_refs, "pending": False})
     return out
 
 
@@ -148,22 +286,163 @@ def _parse_mutations(case_path: Path, cid: str, raw) -> list[dict]:
     return out
 
 
+def _parse_update_map(case_path: Path, cid: str, group: str, raw,
+                      open_groups: dict[str, str]) -> dict:
+    """#126 amendment: cross-candidate separation, mechanical, fail-closed.
+
+    A valid case's outcome must functionally depend on the referenced
+    hypothesis's model: ``green_up`` names the OPEN hypotheses (same
+    competitor group) whose probability RISES if the case greens, ``red_up``
+    the ones that rise on red. ``green_up`` empty — or both directions
+    empty — means nothing rises if green: the case discriminates nothing
+    upward (the HTTP-200 class, refused at admission). Ids must be OPEN
+    hypotheses inside ``hypothesis_ref``'s own competitor group — an update
+    outside the discriminated competition moves nobody's posterior."""
+    if not isinstance(raw, dict):
+        raise OracleCaseError(
+            f"{case_path.name}: case {cid!r}: `update_map` is required — a "
+            f"mapping {repr({'green_up': ['H-xxx'], 'red_up': ['H-yyy']})} "
+            f"of hypothesis ids (#126: cross-candidate separation — the "
+            f"case's outcome must functionally depend on the referenced "
+            f"hypothesis's model)")
+    green = raw.get("green_up")
+    red = raw.get("red_up") or []
+    if not isinstance(green, list) or not green:
+        raise OracleCaseError(
+            f"{case_path.name}: case {cid!r}: update_map.green_up must be a "
+            f"non-empty list of hypothesis ids — nothing rises if green "
+            f"(#126: an outcome invariant across the hypothesis space — "
+            f"the HTTP-200 'environment predicate' class — discriminates "
+            f"nothing upward)")
+    if not isinstance(red, list):
+        raise OracleCaseError(
+            f"{case_path.name}: case {cid!r}: update_map.red_up must be a "
+            f"list of hypothesis ids")
+    for direction, ids in (("green_up", green), ("red_up", red)):
+        for h in ids:
+            hid = str(h).strip()
+            if hid not in open_groups:
+                raise OracleCaseError(
+                    f"{case_path.name}: case {cid!r}: update_map."
+                    f"{direction}: {hid!r} is not an OPEN hypothesis in the "
+                    f"store (missing, terminal, or malformed) — update_map "
+                    f"moves live candidates only (#126)")
+            if open_groups[hid] != group:
+                raise OracleCaseError(
+                    f"{case_path.name}: case {cid!r}: update_map."
+                    f"{direction}: {hid!r} competes in "
+                    f"{open_groups[hid]!r}, not the linked competitor group "
+                    f"{group!r} — update_map ids must sit inside "
+                    f"hypothesis_ref's own competitor group (#126)")
+    return {"green_up": [str(h).strip() for h in green],
+            "red_up": [str(h).strip() for h in red]}
+
+
 def load_cases(cases_dir) -> list[dict]:
-    """Load + lint every ``*.yaml`` case. Raises OracleCaseError on the first
-    refusal (#108 half C) — the case set is blessed as a whole or not at all."""
+    """Load + lint every ``*.yaml`` case. Raises OracleCaseError on the
+    first refusal (#108 half C presence lint + #126 admission integrity:
+    refs resolve, hypothesis_ref linked and existing, action-signature
+    dedup, mutations required, cross-candidate separation — a non-vacuous
+    update_map over OPEN hypotheses inside a live >=2-OPEN competitor
+    group) — the case set is blessed as a whole or not at all."""
+    cases_dir = Path(cases_dir)
+    ws = cases_dir.parent.parent  # <ws>/oracle/cases -> ws root (#126)
+    from hypothesis_store import HypothesisStore
+    hypotheses = HypothesisStore(ws / "hypotheses")
+    # #126 amendment: OPEN-hypothesis faces for the update_map + live-group
+    # lints (id -> competitor_group, and the per-group OPEN census).
+    open_groups: dict[str, str] = {h.id: h.competitor_group
+                                   for h in hypotheses.list_open()}
+    open_in_group: dict[str, int] = {}
+    for g in open_groups.values():
+        open_in_group[g] = open_in_group.get(g, 0) + 1
     cases: list[dict] = []
-    for p in sorted(Path(cases_dir).glob("*.yaml")):
+    seen_signatures: dict[tuple[str, str], str] = {}
+    for p in sorted(cases_dir.glob("*.yaml")):
         doc = yaml.safe_load(p.read_text(encoding="utf-8"))
         if not isinstance(doc, dict):
             raise OracleCaseError(f"{p.name}: case file is not a mapping")
         cid = str(doc.get("id") or p.stem).strip()
         if not cid:
             raise OracleCaseError(f"{p.name}: case id is empty")
+        expected = _parse_expected(ws, p, cid, doc.get("expected"))
+        mutations = _parse_mutations(p, cid, doc.get("mutations"))
+        # #126: mutations are an admission requirement now — a case that
+        # cannot go red under a deliberately wrong implementation is a
+        # rubber stamp (the --mutation flag made mandatory at load).
+        if not mutations:
+            raise OracleCaseError(
+                f"{p.name}: case {cid!r}: `mutations` is required non-empty "
+                f"at admission (#126) — a case that cannot go red under a "
+                f"deliberately wrong implementation is a rubber stamp")
+        # #126: case -> hypothesis linkage. A case that discriminates
+        # nothing in the live competitor field is indistinguishable from a
+        # real experiment at load time (the trivial-oracle class).
+        hyp_ref = str(doc.get("hypothesis_ref") or "").strip()
+        if not hyp_ref or "/" in hyp_ref or "\\" in hyp_ref \
+                or hyp_ref in (".", ".."):
+            raise OracleCaseError(
+                f"{p.name}: case {cid!r}: `hypothesis_ref` is required and "
+                f"must name a hypothesis id in the store (#126: without the "
+                f"linkage a case that discriminates nothing in the live "
+                f"competitor field passes for a real experiment)")
+        try:
+            hyp = hypotheses.get(hyp_ref)
+        except (KeyError, OSError, ValueError) as exc:  # InvalidTransition
+            # is a ValueError; the store's fail-open parse never invents a
+            # hypothesis, so ANY read failure is a refused link.
+            raise OracleCaseError(
+                f"{p.name}: case {cid!r}: hypothesis_ref {hyp_ref!r} does "
+                f"not resolve to a readable hypothesis in "
+                f"{hypotheses.root} ({exc}) — a link to nothing links "
+                f"nothing (#126)") from None
+        # #126 amendment: cross-candidate separation. The HTTP-200 specimen
+        # ("success" = server liveness — a property of the ENVIRONMENT,
+        # invariant across the hypothesis space) cannot write a valid
+        # update_map and is refused here.
+        update_map = _parse_update_map(p, cid, hyp.competitor_group,
+                                       doc.get("update_map"), open_groups)
+        # #126 amendment: a live competition to discriminate. A group with
+        # <2 OPEN members is a self-filed singleton — vacuous by width.
+        n_live = open_in_group.get(hyp.competitor_group, 0)
+        if n_live < 2:
+            raise OracleCaseError(
+                f"{p.name}: case {cid!r}: competitor group "
+                f"{hyp.competitor_group!r} holds {n_live} OPEN "
+                f"hypotheses — a live competition needs >=2 candidates to "
+                f"discriminate; a self-filed singleton vacuous hypothesis "
+                f"is refused (#126)")
+        # #126 (E3): the observation channel is declared, never inferred
+        # from tool names — the tool-family vocabulary cannot classify
+        # "frida stalker trace" and "ida server trace" as one channel.
+        channel = str(doc.get("channel") or "").strip()
+        if not channel:
+            raise OracleCaseError(
+                f"{p.name}: case {cid!r}: `channel` is required (#126: the "
+                f"observation channel is declared, not inferred)")
+        # #126: action-signature dedup. Same signature = one case; a second
+        # case with an identical signature adds no marginal discriminative
+        # power and is refused. Different channel or different
+        # competitor_group = different signature (cross-channel divergence
+        # is itself an observation).
+        sig = action_signature(channel, hyp.competitor_group)
+        if sig in seen_signatures:
+            raise OracleCaseError(
+                f"{p.name}: case {cid!r}: duplicate action signature "
+                f"{sig} — already covered by case "
+                f"{seen_signatures[sig]!r} (same declared channel + same "
+                f"competitor_group); the dedup axis is marginal "
+                f"discriminative power, not text (#126)")
+        seen_signatures[sig] = cid
         cases.append({
             "id": cid,
+            "channel": channel,
+            "hypothesis_ref": hyp_ref,
+            "competitor_group": hyp.competitor_group,
+            "update_map": update_map,
             "params": doc.get("params") or {},
-            "expected": _parse_expected(p, cid, doc.get("expected")),
-            "mutations": _parse_mutations(p, cid, doc.get("mutations")),
+            "expected": expected,
+            "mutations": mutations,
         })
     return cases
 

--- a/tests/test_case_admission_126.py
+++ b/tests/test_case_admission_126.py
@@ -1,0 +1,346 @@
+# -*- coding: utf-8 -*-
+"""tests/test_case_admission_126.py — #126 oracle case admission integrity.
+
+#108 half C made byte anchors MANDATORY, but they stayed DECLARATIONS, not
+RESOLUTIONS: ``evidence_refs: [F999]`` with an invented fact id passes the
+lint, nothing ties a case to the hypothesis whose predicted_observation it
+realizes, dedup is absent on the case side and textual on the bank side, and
+a case can be admitted without any mutation at all. This file pins the
+admission-time contract that closes those four openings:
+
+  1. every non-pending evidence_ref RESOLVES to an existing fact-pipeline
+     artifact (facts/F*.md or an evidence/ file) under the workspace;
+  2. refs pointing into the oracle's own output (runs/ | oracle/, the case
+     file itself) are REFUSED — self-anchoring is circular verification;
+  3. ``hypothesis_ref`` is required and must exist in the hypothesis store
+     (the case names the live competitor-group question it discriminates);
+  4. the action signature (declared observation channel, competitor_group
+     of the linked hypothesis) is the dedup axis — a second case with an
+     identical signature is refused at load;
+  5. ``mutations`` must be non-empty at load (the mutation-must-fail flag
+     becomes an admission requirement);
+  6. case_bank.append_once keys on the action signature, not the free-text
+     method: the same action under two tool names banks once and can no
+     longer displace other failures-first lessons from the top-5 window.
+
+E3 pre-experiment verdict (scripts/priority_ratio.py reuse check): the
+tool-family vocabulary is per-TOOL (frida != ida) and carries no unidbg/
+qiling emulator tokens, so it cannot classify
+("frida stalker trace", "ida server trace") as the SAME channel. The
+observation channel is therefore DECLARED (`channel:` on the case doc);
+the bank face reads the channel from the method text through a declared
+word-bounded token vocabulary with an ``adhoc:`` fallback so unknown
+actions never falsely dedup. Both faces are pure functions.
+"""
+from __future__ import annotations
+
+import copy
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import case_bank as cb  # noqa: E402  (RED: imports resolve, contract absent)
+import oracle_runner as orun  # noqa: E402
+
+
+# ---------------------------------------------------------------- fixtures
+
+HYP_AUTH = "H-101"    # competitor_group: grp-auth
+HYP_MAGIC = "H-102"   # competitor_group: grp-magic
+
+
+def _write_hypothesis(ws: Path, hyp_id: str, group: str) -> None:
+    p = ws / "hypotheses" / f"{hyp_id}.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        "---\n"
+        f"id: {hyp_id}\n"
+        "claim_id: C-1\n"
+        f"competitor_group: {group}\n"
+        "candidates: [AES, ChaCha20]\n"
+        "status: open\n"
+        "schema_rev: 1\n"
+        "---\n"
+        "\npq:q1\n\nSeeded scaffold — the case realizes this bet's "
+        "predicted_observation.\n",
+        encoding="utf-8")
+
+
+def _mk_ws(tmp_path: Path) -> Path:
+    """Workspace whose fact pipeline can answer resolvable refs: facts/F001,
+    facts/F002, evidence/die.json, and two live hypotheses."""
+    ws = tmp_path / "ws"
+    (ws / "oracle" / "cases").mkdir(parents=True)
+    (ws / "facts").mkdir()
+    (ws / "facts" / "F001.md").write_text(
+        "# F001\n\nauth_algo pins hmac-sha256 (byte-anchored).\n",
+        encoding="utf-8")
+    (ws / "facts" / "F002.md").write_text(
+        "# F002\n\nmagic pins MZ (byte-anchored).\n", encoding="utf-8")
+    (ws / "evidence").mkdir()
+    (ws / "evidence" / "die.json").write_text("{}\n", encoding="utf-8")
+    _write_hypothesis(ws, HYP_AUTH, "grp-auth")
+    _write_hypothesis(ws, HYP_MAGIC, "grp-magic")
+    return ws
+
+
+BASE_CASE = {
+    "id": "auth-fields",
+    "channel": "device-trace",
+    "hypothesis_ref": HYP_AUTH,
+    "params": {"user": "alice", "nonce": 10},
+    "expected": [
+        {"field": "auth_algo", "value": "hmac-sha256",
+         "evidence_refs": ["F001"]},
+    ],
+    "mutations": [{"field": "auth_algo", "kind": "swap"}],
+}
+
+
+def _write_case(ws: Path, case: dict, name: str = "case-00.yaml") -> Path:
+    p = ws / "oracle" / "cases" / name
+    p.write_text(
+        yaml.safe_dump(case, allow_unicode=True, sort_keys=False),
+        encoding="utf-8")
+    return p
+
+
+# --------------------------------------------------- 1. invented refs
+
+def test_invented_evidence_ref_refused(tmp_path: Path) -> None:
+    """evidence_refs: [F999] where facts/F999.md does not exist -> REFUSED
+    (#126: refs are declarations, not resolutions)."""
+    ws = _mk_ws(tmp_path)
+    case = copy.deepcopy(BASE_CASE)
+    case["expected"][0]["evidence_refs"] = ["F999"]
+    _write_case(ws, case)
+    with pytest.raises(orun.OracleCaseError, match="F999"):
+        orun.load_cases(ws / "oracle" / "cases")
+
+
+def test_invented_evidence_ref_refused_in_second_case_too(tmp_path: Path) -> None:
+    """The resolution lint is per-case, not first-case-only."""
+    ws = _mk_ws(tmp_path)
+    good = copy.deepcopy(BASE_CASE)
+    bad = copy.deepcopy(BASE_CASE)
+    bad["id"] = "other-fields"
+    bad["channel"] = "emulator-trace"
+    bad["expected"][0]["evidence_refs"] = ["F888"]
+    _write_case(ws, good, "case-00.yaml")
+    _write_case(ws, bad, "case-01.yaml")
+    with pytest.raises(orun.OracleCaseError, match="F888"):
+        orun.load_cases(ws / "oracle" / "cases")
+
+
+# --------------------------------------------------- 2. self-anchoring
+
+@pytest.mark.parametrize("ref", [
+    "runs/oracle-status.json",        # the run's own verdict file
+    "oracle/cases/case-00.yaml",      # the case file itself
+])
+def test_self_anchoring_ref_refused(tmp_path: Path, ref: str) -> None:
+    """A ref pointing at oracle status/output (runs/... or the case file
+    itself) is refused — circular verification is the machine channel for a
+    100% pass rate (#126)."""
+    ws = _mk_ws(tmp_path)
+    (ws / "runs").mkdir()
+    (ws / "runs" / "oracle-status.json").write_text("{}\n", encoding="utf-8")
+    case = copy.deepcopy(BASE_CASE)
+    case["expected"][0]["evidence_refs"] = [ref]
+    _write_case(ws, case)
+    with pytest.raises(orun.OracleCaseError, match="self-anchor"):
+        orun.load_cases(ws / "oracle" / "cases")
+
+
+# --------------------------------------------------- 3. hypothesis_ref
+
+def test_case_without_hypothesis_ref_refused(tmp_path: Path) -> None:
+    """No case->hypothesis linkage -> the case discriminates nothing in the
+    live competitor field (the trivial-oracle class) -> REFUSED."""
+    ws = _mk_ws(tmp_path)
+    case = copy.deepcopy(BASE_CASE)
+    case.pop("hypothesis_ref")
+    _write_case(ws, case)
+    with pytest.raises(orun.OracleCaseError, match="hypothesis_ref"):
+        orun.load_cases(ws / "oracle" / "cases")
+
+
+def test_hypothesis_ref_must_exist_in_store(tmp_path: Path) -> None:
+    """hypothesis_ref naming a hypothesis the store has never heard of ->
+    REFUSED (a link to nothing links nothing)."""
+    ws = _mk_ws(tmp_path)
+    case = copy.deepcopy(BASE_CASE)
+    case["hypothesis_ref"] = "H-999"
+    _write_case(ws, case)
+    with pytest.raises(orun.OracleCaseError, match="H-999"):
+        orun.load_cases(ws / "oracle" / "cases")
+
+
+# ------------------------------------- 4. action-signature dedup (E3)
+
+def test_e3_channel_verdict_table() -> None:
+    """E3 canonical verdict table, bank face:
+    ("frida stalker trace", "ida server trace")     -> SAME  (device-trace)
+    ("unidbg codehook trace", "frida hook trace")   -> DIFFERENT (emu/dev)
+    priority_ratio's tool families are per-TOOL and cannot produce this —
+    the channel comes from the declared vocabulary instead."""
+    assert orun.action_channel("frida stalker trace") == \
+        orun.action_channel("ida server trace")
+    assert orun.action_channel("unidbg codehook trace") != \
+        orun.action_channel("frida hook trace")
+
+
+def test_action_signature_is_pure() -> None:
+    """The signature is a pure function: same input -> same output, no
+    hidden state, and unknown methods never collapse into one bucket."""
+    assert orun.action_signature("device-trace", "grp-auth") == \
+        orun.action_signature("device-trace", "grp-auth")
+    assert orun.action_signature("device-trace", "grp-auth") != \
+        orun.action_signature("device-trace", "grp-magic")
+    for m in ("device-trace via frida-stalker", "upx-unpack", ""):
+        assert orun.action_channel(m) == orun.action_channel(m)
+    assert orun.action_channel("upx-unpack") != \
+        orun.action_channel("osint-query")
+
+
+def test_duplicate_signature_second_case_refused(tmp_path: Path) -> None:
+    """Two cases in one load with the identical signature (same declared
+    channel + same competitor_group) -> the SECOND is refused: marginal
+    discriminative power, not text, is the dedup axis."""
+    ws = _mk_ws(tmp_path)
+    twin = copy.deepcopy(BASE_CASE)
+    twin["id"] = "auth-fields-again"
+    _write_case(ws, copy.deepcopy(BASE_CASE), "case-00.yaml")
+    _write_case(ws, twin, "case-01.yaml")
+    with pytest.raises(orun.OracleCaseError, match="auth-fields-again"):
+        orun.load_cases(ws / "oracle" / "cases")
+
+
+def test_distinct_channel_or_group_admits_both(tmp_path: Path) -> None:
+    """Different channel (emulator vs device) = NOT a duplicate —
+    cross-channel divergence is itself an observation. Same channel with a
+    different competitor_group is equally distinct."""
+    ws = _mk_ws(tmp_path)
+    device = copy.deepcopy(BASE_CASE)
+    emulator = copy.deepcopy(BASE_CASE)
+    emulator["id"] = "emu-fields"
+    emulator["channel"] = "emulator-trace"
+    other_group = copy.deepcopy(BASE_CASE)
+    other_group["id"] = "magic-fields"
+    other_group["hypothesis_ref"] = HYP_MAGIC
+    _write_case(ws, device, "case-00.yaml")
+    _write_case(ws, emulator, "case-01.yaml")
+    _write_case(ws, other_group, "case-02.yaml")
+    cases = orun.load_cases(ws / "oracle" / "cases")
+    assert [c["id"] for c in cases] == \
+        ["auth-fields", "emu-fields", "magic-fields"]
+
+
+# ---------------------------------------------- 5. mutations at load
+
+@pytest.mark.parametrize("mutations", [None, []])
+def test_case_without_mutations_refused(tmp_path: Path,
+                                        mutations) -> None:
+    """A case that cannot go red under a deliberately wrong implementation
+    is a rubber stamp: missing OR empty `mutations` -> REFUSED at load
+    (the --mutation flag becomes an admission requirement)."""
+    ws = _mk_ws(tmp_path)
+    case = copy.deepcopy(BASE_CASE)
+    if mutations is None:
+        case.pop("mutations")
+    else:
+        case["mutations"] = mutations
+    _write_case(ws, case)
+    with pytest.raises(orun.OracleCaseError, match="mutation"):
+        orun.load_cases(ws / "oracle" / "cases")
+
+
+# ------------------------------------------------------ 7. acceptance
+
+def test_fully_armed_case_loads_clean(tmp_path: Path) -> None:
+    """Acceptance: resolvable fact refs + a resolvable evidence/ file ref +
+    existing hypothesis_ref + >=1 mutation -> loads clean."""
+    ws = _mk_ws(tmp_path)
+    case = copy.deepcopy(BASE_CASE)
+    case["expected"].append(
+        {"field": "packer", "value": "UPX", "evidence_refs": ["die.json"]})
+    _write_case(ws, case)
+    cases = orun.load_cases(ws / "oracle" / "cases")
+    assert [c["id"] for c in cases] == ["auth-fields"]
+    assert cases[0]["expected"][1]["evidence_refs"] == ["die.json"]
+    assert cases[0]["mutations"][0]["field"] == "auth_algo"
+
+
+# ------------------------------------------ 8. bank-side signature dedup
+
+def _bank_entry(claim_id: str, method: str, roi_class: str = "POSITIVE",
+                **kw) -> dict:
+    e = {"claim_id": claim_id, "method": method, "roi_class": roi_class,
+         "context_tags": ["android"]}
+    e.update(kw)
+    return e
+
+
+def test_append_once_dedups_same_signature_different_tool_name(
+        tmp_path: Path) -> None:
+    """Two entries differing only in the free-text method, SAME signature
+    (device-trace via frida-stalker vs ida-server) -> one banked row."""
+    first = cb.append_once(tmp_path, _bank_entry(
+        "C-1", "device-trace via frida-stalker"))
+    second = cb.append_once(tmp_path, _bank_entry(
+        "C-1", "device-trace via ida-server"))
+    assert first["ok"] is True and first["duplicate"] is False
+    assert second["ok"] is True and second["duplicate"] is True
+    assert len(cb.read_entries(tmp_path)) == 1
+
+
+def test_cross_channel_divergence_banks_separately(tmp_path: Path) -> None:
+    """emulator vs device channels are DIFFERENT signatures — cross-channel
+    divergence is itself an observation, so both rows bank."""
+    cb.append_once(tmp_path, _bank_entry(
+        "C-1", "device-trace via frida-stalker"))
+    res = cb.append_once(tmp_path, _bank_entry(
+        "C-1", "emulator-trace via unidbg"))
+    assert res["duplicate"] is False
+    assert len(cb.read_entries(tmp_path)) == 2
+
+
+def test_roi_class_still_axes_the_bank_key(tmp_path: Path) -> None:
+    """The dedup key stays (claim_id, signature, roi_class): an evolving
+    verdict (fails -> passes) still banks a NEW row (#110 face kept)."""
+    cb.append_once(tmp_path, _bank_entry(
+        "C-1", "device-trace via frida-stalker", "NEGATIVE",
+        attribution="wrong trace pass"))
+    res = cb.append_once(tmp_path, _bank_entry(
+        "C-1", "device-trace via ida-server"))
+    assert res["duplicate"] is False
+    assert sorted(r["roi_class"] for r in cb.read_entries(tmp_path)) == \
+        ["NEGATIVE", "POSITIVE"]
+
+
+def test_top5_failures_window_not_displaced_by_tool_name_variants(
+        tmp_path: Path) -> None:
+    """The reason #126 exists: retrieve() is positional, limit=5. A tool-name
+    variant of an already-banked action must NOT append a new row — the
+    oldest failure stays inside the top-5 failures-first window."""
+    methods = ["static-derive via ghidra", "adhoc-scan via apkid",
+               "adhoc-hook via xposed", "adhoc-unpack via binwalk",
+               "device-trace via frida-stalker"]
+    for i, m in enumerate(methods):
+        cb.append_once(tmp_path, _bank_entry(
+            f"C-{i + 1}", m, "NEGATIVE", attribution=f"why C-{i + 1} failed"))
+    res = cb.append_once(tmp_path, _bank_entry(
+        "C-5", "device-trace via ida-server", "NEGATIVE",
+        attribution="same trace channel, second tool name"))
+    assert res["duplicate"] is True
+    assert len(cb.read_entries(tmp_path)) == 5
+    window = [e["claim_id"] for e in cb.retrieve(tmp_path, [], 5)]
+    assert window == ["C-5", "C-4", "C-3", "C-2", "C-1"], \
+        "the oldest failure was displaced by a tool-name variant"

--- a/tests/test_case_admission_126.py
+++ b/tests/test_case_admission_126.py
@@ -22,6 +22,15 @@ admission-time contract that closes those four openings:
   6. case_bank.append_once keys on the action signature, not the free-text
      method: the same action under two tool names banks once and can no
      longer displace other failures-first lessons from the top-5 window.
+Plus the #126 amendment's cross-candidate separation teeth (the lost tooth
+from the v0.1.4 user bug specimen — "HTTP 200 + response body non-empty"
+predicates success on the ENVIRONMENT, not on the unknown being reversed):
+  7. ``update_map`` required and non-vacuous — green_up non-empty, at
+     least one direction populated, every id an OPEN hypothesis inside
+     hypothesis_ref's own competitor group (no candidate's probability
+     should move on an HTTP status -> the specimen cannot write one);
+  8. live-group: hypothesis_ref's competitor group must hold >=2 OPEN
+     members — a self-filed singleton vacuous hypothesis is refused.
 
 E3 pre-experiment verdict (scripts/priority_ratio.py reuse check): the
 tool-family vocabulary is per-TOOL (frida != ida) and carries no unidbg/
@@ -52,21 +61,30 @@ import oracle_runner as orun  # noqa: E402
 
 # ---------------------------------------------------------------- fixtures
 
-HYP_AUTH = "H-101"    # competitor_group: grp-auth
-HYP_MAGIC = "H-102"   # competitor_group: grp-magic
+HYP_AUTH = "H-101"      # competitor_group: grp-auth (open)
+HYP_MAGIC = "H-102"     # competitor_group: grp-magic (open)
+HYP_AUTH2 = "H-103"     # grp-auth's second OPEN member (live-group census)
+HYP_MAGIC2 = "H-104"    # grp-magic's second OPEN member
+HYP_DEAD = "H-105"      # grp-auth but REFUTED — not an update_map target
+HYP_LONELY = "H-106"    # grp-lonely's ONLY member — dead (singleton) group
 
 
-def _write_hypothesis(ws: Path, hyp_id: str, group: str) -> None:
+def _write_hypothesis(ws: Path, hyp_id: str, group: str,
+                      status: str = "open") -> None:
     p = ws / "hypotheses" / f"{hyp_id}.md"
     p.parent.mkdir(parents=True, exist_ok=True)
+    refuting = ""
+    if status == "refuted":
+        refuting = "\nrefuting_fact_id: F002\n"
     p.write_text(
         "---\n"
         f"id: {hyp_id}\n"
         "claim_id: C-1\n"
         f"competitor_group: {group}\n"
         "candidates: [AES, ChaCha20]\n"
-        "status: open\n"
+        f"status: {status}\n"
         "schema_rev: 1\n"
+        f"{refuting}"
         "---\n"
         "\npq:q1\n\nSeeded scaffold — the case realizes this bet's "
         "predicted_observation.\n",
@@ -75,7 +93,8 @@ def _write_hypothesis(ws: Path, hyp_id: str, group: str) -> None:
 
 def _mk_ws(tmp_path: Path) -> Path:
     """Workspace whose fact pipeline can answer resolvable refs: facts/F001,
-    facts/F002, evidence/die.json, and two live hypotheses."""
+    facts/F002, evidence/die.json, and live competitor groups (each group
+    that admission touches holds >=2 OPEN hypotheses)."""
     ws = tmp_path / "ws"
     (ws / "oracle" / "cases").mkdir(parents=True)
     (ws / "facts").mkdir()
@@ -88,6 +107,10 @@ def _mk_ws(tmp_path: Path) -> Path:
     (ws / "evidence" / "die.json").write_text("{}\n", encoding="utf-8")
     _write_hypothesis(ws, HYP_AUTH, "grp-auth")
     _write_hypothesis(ws, HYP_MAGIC, "grp-magic")
+    _write_hypothesis(ws, HYP_AUTH2, "grp-auth")
+    _write_hypothesis(ws, HYP_MAGIC2, "grp-magic")
+    _write_hypothesis(ws, HYP_DEAD, "grp-auth", status="refuted")
+    _write_hypothesis(ws, HYP_LONELY, "grp-lonely")
     return ws
 
 
@@ -95,12 +118,33 @@ BASE_CASE = {
     "id": "auth-fields",
     "channel": "device-trace",
     "hypothesis_ref": HYP_AUTH,
+    "update_map": {"green_up": [HYP_AUTH, HYP_AUTH2], "red_up": [HYP_AUTH2]},
     "params": {"user": "alice", "nonce": 10},
     "expected": [
         {"field": "auth_algo", "value": "hmac-sha256",
          "evidence_refs": ["F001"]},
     ],
     "mutations": [{"field": "auth_algo", "kind": "swap"}],
+}
+
+# The v0.1.4 user-bug specimen (issue #126 amendment): "HTTP 200 + response
+# body non-empty" predicates success on the ENVIRONMENT (server liveness) —
+# its truth is invariant across the hypothesis space. Every candidate client
+# greens it; mutation-can-redden does NOT catch it (a mutation perturbing
+# that client reddens it too). No valid update_map exists: no candidate's
+# probability should move on an HTTP status code. Refused at admission.
+HTTP_200_SPECIMEN = {
+    "id": "http-200-env-predicate",
+    "description": "success predicated on server liveness, not on the "
+                   "unknown being reversed (v0.1.4 specimen)",
+    "channel": "device-trace",
+    "hypothesis_ref": HYP_AUTH,
+    "update_map": {"green_up": [], "red_up": []},  # cannot be made valid
+    "params": {"host": "crypto.example"},
+    "expected": [
+        {"field": "http_status", "value": 200, "evidence_refs": ["F001"]},
+    ],
+    "mutations": [{"field": "http_status", "kind": "change"}],
 }
 
 
@@ -226,18 +270,27 @@ def test_duplicate_signature_second_case_refused(tmp_path: Path) -> None:
 def test_distinct_channel_or_group_admits_both(tmp_path: Path) -> None:
     """Different channel (emulator vs device) = NOT a duplicate —
     cross-channel divergence is itself an observation. Same channel with a
-    different competitor_group is equally distinct."""
+    different (live) competitor_group is equally distinct."""
     ws = _mk_ws(tmp_path)
     device = copy.deepcopy(BASE_CASE)
     emulator = copy.deepcopy(BASE_CASE)
     emulator["id"] = "emu-fields"
     emulator["channel"] = "emulator-trace"
-    other_group = copy.deepcopy(BASE_CASE)
-    other_group["id"] = "magic-fields"
-    other_group["hypothesis_ref"] = HYP_MAGIC
+    other_group = {
+        "id": "magic-fields",
+        "channel": "device-trace",
+        "hypothesis_ref": HYP_MAGIC,
+        # red_up empty is fine: green_up alone proves upward discrimination
+        "update_map": {"green_up": [HYP_MAGIC, HYP_MAGIC2], "red_up": []},
+        "params": {},
+        "expected": [
+            {"field": "magic", "value": "MZ", "evidence_refs": ["F002"]},
+        ],
+        "mutations": [{"field": "magic", "kind": "change"}],
+    }
     _write_case(ws, device, "case-00.yaml")
-    _write_case(ws, emulator, "case-01.yaml")
-    _write_case(ws, other_group, "case-02.yaml")
+    _write_case(ws, emulator, "case-one.yaml")
+    _write_case(ws, other_group, "case-two.yaml")
     cases = orun.load_cases(ws / "oracle" / "cases")
     assert [c["id"] for c in cases] == \
         ["auth-fields", "emu-fields", "magic-fields"]
@@ -262,6 +315,98 @@ def test_case_without_mutations_refused(tmp_path: Path,
         orun.load_cases(ws / "oracle" / "cases")
 
 
+# ------------------------- 5b. cross-candidate separation (#126 amendment)
+
+def test_missing_update_map_refused(tmp_path: Path) -> None:
+    """No update_map -> the case's outcome is not tied to any candidate's
+    posterior -> REFUSED (cross-candidate separation is admission-level)."""
+    ws = _mk_ws(tmp_path)
+    case = copy.deepcopy(BASE_CASE)
+    case.pop("update_map")
+    _write_case(ws, case)
+    with pytest.raises(orun.OracleCaseError, match="update_map"):
+        orun.load_cases(ws / "oracle" / "cases")
+
+
+def test_empty_update_map_refused(tmp_path: Path) -> None:
+    """green_up empty — nothing rises if green — is the vacuous map; the
+    both-directions-empty form refuses on the same green_up rule."""
+    ws = _mk_ws(tmp_path)
+    vacuous = copy.deepcopy(BASE_CASE)
+    vacuous["id"] = "vacuous-green"
+    vacuous["update_map"] = {"green_up": [], "red_up": []}
+    _write_case(ws, vacuous)
+    with pytest.raises(orun.OracleCaseError, match="green_up"):
+        orun.load_cases(ws / "oracle" / "cases")
+
+
+@pytest.mark.parametrize("bad_id", ["H-999"])  # nonexistent in the store
+def test_update_map_id_must_exist(tmp_path: Path, bad_id: str) -> None:
+    ws = _mk_ws(tmp_path)
+    case = copy.deepcopy(BASE_CASE)
+    case["update_map"] = {"green_up": [bad_id], "red_up": []}
+    _write_case(ws, case)
+    with pytest.raises(orun.OracleCaseError, match="not an OPEN hypothesis"):
+        orun.load_cases(ws / "oracle" / "cases")
+
+
+def test_update_map_id_must_be_open(tmp_path: Path) -> None:
+    """A REFUTED hypothesis is history, not a live candidate — it cannot
+    rise. update_map moves live candidates only."""
+    ws = _mk_ws(tmp_path)
+    case = copy.deepcopy(BASE_CASE)
+    case["update_map"] = {"green_up": [HYP_DEAD], "red_up": []}
+    _write_case(ws, case)
+    with pytest.raises(orun.OracleCaseError, match="not an OPEN hypothesis"):
+        orun.load_cases(ws / "oracle" / "cases")
+
+
+def test_update_map_cross_group_id_refused(tmp_path: Path) -> None:
+    """An id from ANOTHER competitor group moves nobody's posterior in the
+    discriminated competition -> REFUSED."""
+    ws = _mk_ws(tmp_path)
+    case = copy.deepcopy(BASE_CASE)
+    case["update_map"] = {"green_up": [HYP_MAGIC], "red_up": []}
+    _write_case(ws, case)
+    with pytest.raises(orun.OracleCaseError,
+                       match="own competitor group|competes in"):
+        orun.load_cases(ws / "oracle" / "cases")
+
+
+def test_dead_group_refused(tmp_path: Path) -> None:
+    """hypothesis_ref's group holds a single OPEN hypothesis — a self-filed
+    singleton is a vacuous competition (nothing to discriminate) -> the
+    case is REFUSED even though its update_map ids are technically valid."""
+    ws = _mk_ws(tmp_path)
+    case = {
+        "id": "lonely-fields",
+        "channel": "device-trace",
+        "hypothesis_ref": HYP_LONELY,
+        "update_map": {"green_up": [HYP_LONELY], "red_up": []},
+        "params": {},
+        "expected": [
+            {"field": "auth_algo", "value": "hmac-sha256",
+             "evidence_refs": ["F001"]},
+        ],
+        "mutations": [{"field": "auth_algo", "kind": "swap"}],
+    }
+    _write_case(ws, case)
+    with pytest.raises(orun.OracleCaseError, match="live competition"):
+        orun.load_cases(ws / "oracle" / "cases")
+
+
+def test_http_200_specimen_refused(tmp_path: Path) -> None:
+    """The named v0.1.4 specimen: "HTTP 200 + response body non-empty" is a
+    property of the ENVIRONMENT (server liveness), not of the unknown being
+    reversed — its truth is invariant across the hypothesis space, every
+    candidate client greens it, and mutation-can-redden does not catch it.
+    No valid update_map exists -> REFUSED at admission."""
+    ws = _mk_ws(tmp_path)
+    _write_case(ws, copy.deepcopy(HTTP_200_SPECIMEN))
+    with pytest.raises(orun.OracleCaseError, match="green_up"):
+        orun.load_cases(ws / "oracle" / "cases")
+
+
 # ------------------------------------------------------ 7. acceptance
 
 def test_fully_armed_case_loads_clean(tmp_path: Path) -> None:
@@ -276,6 +421,8 @@ def test_fully_armed_case_loads_clean(tmp_path: Path) -> None:
     assert [c["id"] for c in cases] == ["auth-fields"]
     assert cases[0]["expected"][1]["evidence_refs"] == ["die.json"]
     assert cases[0]["mutations"][0]["field"] == "auth_algo"
+    assert cases[0]["update_map"] == {"green_up": [HYP_AUTH, HYP_AUTH2],
+                                      "red_up": [HYP_AUTH2]}
 
 
 # ------------------------------------------ 8. bank-side signature dedup

--- a/tests/test_oracle_runner_108.py
+++ b/tests/test_oracle_runner_108.py
@@ -60,6 +60,9 @@ CRASH_CLIENT = '''def compute(params):
 CASE_GOOD = {
     "id": "auth-fields",
     "description": "signed auth field ordering discriminator",
+    "channel": "device-trace",     # #126: declared observation channel
+    "hypothesis_ref": "H-001",     # #126: the live bet this case realizes
+    "update_map": {"green_up": ["H-001"], "red_up": ["H-002"]},
     "params": {"user": "alice", "nonce": 10},
     "expected": [
         {"field": "auth_algo", "value": "hmac-sha256",
@@ -74,6 +77,9 @@ CASE_GOOD = {
 CASE_BLIND = {
     "id": "blind-spot",
     "description": "declares a mutation on an unobserved field",
+    "channel": "static",           # distinct signature from CASE_GOOD (#126)
+    "hypothesis_ref": "H-002",
+    "update_map": {"green_up": ["H-002"], "red_up": ["H-001"]},
     "params": {"blob": "cafe"},
     "expected": [
         {"field": "magic", "value": "MZ", "evidence_refs": ["F002"]},
@@ -94,9 +100,35 @@ UNIVERSAL_CLIENT = '''def compute(params):
 '''
 
 
+def _write_hypothesis(ws: Path, hyp_id: str, group: str) -> None:
+    """#126 fixture support: one hypotheses/<id>.md in the #528 frontmatter
+    shape, so case fixtures can name a hypothesis_ref that resolves."""
+    p = ws / "hypotheses" / f"{hyp_id}.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        "---\n"
+        f"id: {hyp_id}\n"
+        "claim_id: C-001\n"
+        f"competitor_group: {group}\n"
+        "candidates: [AES, ChaCha20]\n"
+        "status: open\n"
+        "schema_rev: 1\n"
+        "---\n\npq:q1\n",
+        encoding="utf-8")
+
+
 def _mk_ws(tmp_path: Path, cases: list[dict], client_src: str | None) -> Path:
     ws = tmp_path / "ws"
     (ws / "oracle" / "cases").mkdir(parents=True)
+    # #126: refs must RESOLVE now — the fixture fact pipeline + hypothesis
+    # store back the case fixtures' evidence_refs / hypothesis_ref.
+    (ws / "facts").mkdir()
+    (ws / "facts" / "F001.md").write_text(
+        "# F001\n\nauth fields pinned (byte-anchored).\n", encoding="utf-8")
+    (ws / "facts" / "F002.md").write_text(
+        "# F002\n\nmagic bytes pinned (byte-anchored).\n", encoding="utf-8")
+    _write_hypothesis(ws, "H-001", "grp-live")
+    _write_hypothesis(ws, "H-002", "grp-live")
     for i, case in enumerate(cases):
         (ws / "oracle" / "cases" / f"case-{i:02d}.yaml").write_text(
             yaml.safe_dump(case, allow_unicode=True, sort_keys=False),
@@ -164,12 +196,16 @@ def test_client_crash_is_pending_not_green(tmp_path: Path) -> None:
 def test_pending_observation_entries_count_not_compare(tmp_path: Path) -> None:
     case = {
         "id": "scaffold",
+        "channel": "device-trace",
+        "hypothesis_ref": "H-001",
+        "update_map": {"green_up": ["H-001", "H-002"], "red_up": []},
         "params": {},
         "expected": [
             {"field": "auth_algo", "value": "hmac-sha256",
              "pending-observation": True},
             {"field": "nonce_len", "value": 2, "evidence_refs": ["F001"]},
         ],
+        "mutations": [{"field": "nonce_len", "kind": "change"}],
     }
     ws = _mk_ws(tmp_path, [case], None)
     (ws / "oracle" / "client.py").write_text(GOOD_CLIENT, encoding="utf-8")
@@ -232,10 +268,14 @@ def test_mutation_all_green_case_flagged_low_discriminativity(tmp_path: Path) ->
 
 
 def test_mutation_without_declarations_never_flags(tmp_path: Path) -> None:
+    """#126: a mutation-less case is now REFUSED at load, so this face is
+    exercised on the raw dict (mutation_pass itself, not load_cases): no
+    declared mutations -> no flags, empty mutations map."""
     case = {k: v for k, v in CASE_GOOD.items() if k != "mutations"}
-    ws = _mk_ws(tmp_path, [case], None)
+    case["mutations"] = []
+    ws = _mk_ws(tmp_path, [], None)
     compute = _load_client(_write_client(ws, GOOD_CLIENT))
-    mp = orun.mutation_pass(orun.load_cases(ws / "oracle" / "cases"), compute)
+    mp = orun.mutation_pass([case], compute)
     assert mp["low_discriminativity"] == []
     assert mp["mutations"] == {}
 


### PR DESCRIPTION
Closes #126. Branch base: origin/dev @ 1ad1654, rebased onto d3cac05 (#127 merged first; case_bank.py regions were disjoint — append_once vs emit_case_hints removal — and merged cleanly).

## E3 pre-experiment — signature function verdict table

Checked `scripts/priority_ratio.py` reuse first, empirically (scratch run in /tmp, never committed):

| method strings | required verdict | tool_families_from_text result | action_channel result |
|---|---|---|---|
| `"frida stalker trace"` vs `"ida server trace"` | SAME (both device-trace channel) | `{frida}` vs `{ida}` -> DIFFERENT — WRONG | `device-trace` == `device-trace` -> SAME — OK |
| `"unidbg codehook trace"` vs `"frida hook trace"` | DIFFERENT (emulator vs device) | `∅` vs `{frida}` -> DIFFERENT — right only by accident (unidbg/qiling absent from `_TOOL_FAMILY_BY_TOKEN`) | `emulator-trace` != `device-trace` -> DIFFERENT — OK |

Decision: the tool-family vocabulary is per-TOOL and cannot classify channel semantics, so the observation channel is **DECLARED, not inferred** (the issue's declaration-over-inference doctrine): `channel:` on the case doc; the bank face reads a declared word-bounded channel-token vocabulary (`frida/ida/x64dbg/gdb` -> device-trace, `unidbg/qiling` -> emulator-trace, `ghidra` -> static) with an `adhoc:<normalized text>` fallback so unknown methods never falsely dedup. Signature = (channel, competitor_group) — pure functions `action_channel` / `action_signature` in scripts/oracle_runner.py.

## What each refusal closes (all OracleCaseError from load_cases, fail-closed, no status write)

| refusal (test) | closes |
|---|---|
| invented ref `evidence_refs: [F999]` (facts/F999.md missing) | refs are declarations-not-resolutions: an expected value can no longer be anchored on a fact that does not exist |
| ref into `runs/` or `oracle/` (oracle-status / the case file itself) | self-anchoring = circular verification, the machine channel for a 100% pass rate; containment also neutralizes absolute/`../`/symlink escapes |
| case without `hypothesis_ref` / naming a nonexistent hypothesis | case->hypothesis linkage: a case discriminating nothing in the live competitor field (the trivial-oracle class) no longer passes for a real experiment |
| two cases, one load, identical signature (same channel + same competitor_group) | supply-side dedup on marginal discriminative power: the ranker has no submodular decay (#107), so admission is the only line of defense; different channel = NOT a duplicate (cross-channel divergence is itself an observation) |
| missing/empty `mutations` | mutation-must-fail becomes an admission requirement: a case that cannot go red under a deliberately wrong implementation is a rubber stamp |
| missing/empty `update_map` (`green_up` empty, or both directions empty) — #126 amendment | cross-candidate separation: the case's outcome must functionally depend on the referenced hypothesis's model; every id must be an OPEN hypothesis inside hypothesis_ref's own competitor group |
| hypothesis_ref's group holds <2 OPEN hypotheses — #126 amendment | live-group: a self-filed singleton vacuous competition is refused |

Named fixture class for the v0.1.4 user-bug specimen (`HTTP_200_SPECIMEN` in tests/test_case_admission_126.py): "HTTP 200 + response body non-empty" predicates success on the ENVIRONMENT (server liveness), not on the unknown being reversed — invariant across the hypothesis space, every candidate client greens it, mutation-can-redden does not catch it. No valid update_map exists -> refused at admission.

## Bank side

`case_bank.append_once` key `(claim_id, method, roi_class)` -> `(claim_id, action_channel(method), roi_class)`: tool-name variants of one action (device-trace via frida-stalker vs ida-server) bank once (`duplicate=True`) and can no longer displace other failures-first lessons from the positional top-5 retrieval window (test: 5 distinct failures, a variant of C-5 -> `duplicate=True`, window stays C-5..C-1). Emulator vs device still bank separately. The ruling-4 attribution lint is untouched. `tests/test_case_bank_110.py` needed no changes (verified green as-is).

## Tests

- tests/test_case_admission_126.py: 24 tests (one per refusal path + acceptance + E3 verdict-table/purity pins + the specimen), RED-first (13 failing before GREEN, per TDD).
- tests/test_oracle_runner_108.py: fixtures lifted to the new contract, all original assertions untouched; `test_mutation_without_declarations_never_flags` now exercises mutation_pass on the raw dict (a mutation-less case is refused at load now).
- Anchor: tests/test_decide_regression_anchor.py 32 passed, no drift, no re-pin.

## Gates

- `env -u KUNGLAO_VALUE_ALGO python3 -m pytest tests/ -q` on the rebased tree: **5861 passed, 10 skipped, 1 failed** — the one failure is `tests/test_env_check.py::test_all_pass_exit_0`, byte-identical on bare origin/dev (verified on a detached 1ad1654 worktree; also re-verified solo). Pre-existing red, not fixed here per instructions. An earlier `test_load_lock` failure was machine-lock contention from two concurrent suite runs and passes solo.
- `python3 -m ruff check .`: clean on all touched/added files; repo-wide 5 pre-existing errors identical on bare origin/dev (dispatch_gate F841 + 4 unused imports) — reported, not fixed.
- Per-commit review gate: one independent code-reviewer pass per commit (reviewer r1-126-admission), all PASS, review-gate minted per staged diff; deploy-manifest regen verified (`--verify` OK, 387 entries post-rebase).
- Commit note (cosmetic): the feat commit message lost one word ("channel") to shell backtick substitution in one bullet; the message still reads unambiguously ("the observation channel is DECLARED, not inferred").

## Deviations

- Coordinator amendment (cross-candidate separation: update_map + live-group + the HTTP-200 specimen) rode the feat commit as directed; the 108 fixture lift + manifest regen form the chore commit.
- #111 (tests/test_hypothesis_loop_integration_111.py) had NOT merged when this branch rebased (#127 merged instead); no #111 fixture lift was needed. scripts/case_bank.py vs feat/127 merged cleanly per the stated preference order.
- Intermediate shas are red-by-design (TDD split: the RED commit fails until feat lands; the feat sha still carries pre-lift 108 fixtures until the chore lands). Final tree is fully green modulo the pre-existing env_check red.
