### PR TITLE
feat(#143): upgrade purges legacy global kunglao hooks — project-scope migration completed

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -343,7 +343,7 @@ files:
   - src: scripts/event_taxonomy.py
     dest: .claude/scripts/event_taxonomy.py
     kind: scaffold
-    sha256: a5a7c2ecd9b0aa1c510c096f32ed982331f0dfb085678970816f04b6bf8be823
+    sha256: f14ebff87900d6e58d9dc7bb0e430b0509be92e4b041dee8d42d4d037a7b181c
   - src: scripts/external_kicker.py
     dest: .claude/scripts/external_kicker.py
     kind: scaffold
@@ -403,7 +403,7 @@ files:
   - src: scripts/hooks_selfcheck.py
     dest: .claude/scripts/hooks_selfcheck.py
     kind: scaffold
-    sha256: 048aa15248109b199efd423626add964543c99ca909aebeddfc216f68196978f
+    sha256: 9b335b3cbb673e18aac2b065480dc14997d4badba2b36378d26499e7627266bf
   - src: scripts/hypothesis_seeder.py
     dest: .claude/scripts/hypothesis_seeder.py
     kind: scaffold
@@ -503,7 +503,7 @@ files:
   - src: scripts/kunglao_upgrade.py
     dest: .claude/scripts/kunglao_upgrade.py
     kind: scaffold
-    sha256: 7f6adf34da41c41a870f5740176882b656ee00f704854d165d72a99c7555bb44
+    sha256: 1bb0750f0bb37e095d10fcf39455ee83f8a4f160a33e0e17f29ce5f28fa139d5
   - src: scripts/kunglao_verify.py
     dest: .claude/scripts/kunglao_verify.py
     kind: scaffold

--- a/scripts/event_taxonomy.py
+++ b/scripts/event_taxonomy.py
@@ -186,6 +186,7 @@ EMIT_ACTIONS = [
     "failure_blocked",
     "git_anchor_skipped",  # #753 pre-migration rollback anchor untakeable (git missing/failed) — kunglao_upgrade
     "git_snapshot_skipped",  # #739 WARN faces — kunglao_upgrade (snapshot untakeable: git missing/failed) + kunglao-init (workspace snapshot skip)
+    "global_hook_purge",  # #143 upgrade purge of legacy global kunglao hooks (backup/skip/noop faces)
     "heartbeat_gap",      # #618 dead-window alarm: durable sidecar newest tick over threshold
     "hypothesis_admission_fail_open",  # #109 store-read failure WARN face — admission not enforced, dispatch proceeds
     "hypothesis_admission_reject",  # #109 PQ first-dispatch admission REJECT face (empty competitor field)

--- a/scripts/hooks_selfcheck.py
+++ b/scripts/hooks_selfcheck.py
@@ -74,6 +74,8 @@ wire_up_settings.derive_hook_subset(
 KONG_HOOK_FILES = list(_KONG_CHAIN_FILES)
 # User-global settings: NOT a deployment target since #258. Checked only to warn
 # about leftover kunglao hooks that should be migrated to the project level.
+# #143: /kunglao-agent:upgrade now PURGES those leftovers (backup + WARN rails);
+# this check stays as the between-upgrades tripwire and is behaviorally unchanged.
 USER_SETTINGS = Path.home() / ".claude" / "settings.json"
 
 

--- a/scripts/kunglao_upgrade.py
+++ b/scripts/kunglao_upgrade.py
@@ -74,6 +74,7 @@ from hook_activation import (  # noqa: E402
     canonical_install_root,
     register_hooks,
 )
+from wire_up_settings import WIRE_UP_HOOK_FILES, hook_deployment_targets  # noqa: E402  (#143 purge matches the #372 registry single source)
 from _hooks_path import load_module_by_path  # noqa: E402  # #863 Family B: loader delegation (#671 authority)
 
 USER_DATA_DIRS: tuple[str, ...] = (
@@ -128,6 +129,141 @@ def _item_hooks_rewire(ws: Path, dry: bool) -> str:
     if not dry:
         register_hooks(ws)
     return "hooks_rewire"
+
+
+def _global_settings_path() -> Path:
+    """#143 — the user-global settings file. Reads Path.home() (never env
+    vars) so test fake-homes bind through the established monkeypatch seam
+    (hook_activation.canonical_install_root precedent)."""
+    return Path.home() / ".claude" / "settings.json"
+
+
+def _is_kunglao_hook_command(command: str) -> bool:
+    """#143 matcher: a hook command references a kunglao hook file iff a
+    WIRE_UP_HOOK_FILES registry basename appears in the command string — the
+    same basename-substring convention hooks_selfcheck.check_settings uses
+    for its present/missing scan. The registry import keeps ONE source
+    (#372): a hook file added to the registry is purged from the global
+    file without a second list to forget."""
+    cmd = command or ""
+    return any(name in cmd for name in WIRE_UP_HOOK_FILES)
+
+
+def _settings_has_live_hooks(path: Path) -> bool:
+    """True iff <path> parses and carries a non-empty hooks segment. Any
+    read/parse failure answers False — callers only use this to decide
+    whether the project layer deserves a missing-registration WARN."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    return bool(isinstance(data, dict) and data.get("hooks"))
+
+
+def _item_global_hook_purge(ws: Path, dry: bool) -> str:
+    """#143: purge legacy pre-#258 kunglao hooks from the user-global
+    ~/.claude/settings.json — the upgrade-side completion of #258's
+    project-scope migration (owner ruling 2026-09-07: ships in v0.1.5).
+
+    Scope contract:
+      - ONLY the `hooks` segment is walked; env/statusLine/enabledPlugins
+        and every other top-level key are never touched.
+      - A hook entry is purged iff its command references a
+        WIRE_UP_HOOK_FILES registry basename. Non-kunglao entries survive
+        in place; containers the purge empties (matcher rows, event keys)
+        carried kunglao-only content by construction.
+      - Safety rails: the ORIGINAL file bytes are backed up to
+        <ws>/runs/global-settings-backup-<utc-ts>.json before the first
+        write (iron-rule-exempt, D4 class); a parse failure skips with a
+        WARN and leaves the file byte-untouched (never repair a corrupted
+        global file by truncation — v1.9.37 lesson); no kunglao entries ->
+        idempotent noop line, no backup, no write.
+      - Ordering: registered AFTER _item_hooks_rewire so project-level
+        registration is confirmed earlier in the SAME run (#258: no window
+        where neither layer is active). If the project layer still reads
+        hook-less, the purge proceeds but draws the missing-layer WARN —
+        stale global hooks are live pollution either way.
+      - Write-back is atomic (same-dir temp + rename) and preserves the
+        file mode. A dry run only reports what would be removed.
+    """
+    gp = _global_settings_path()
+    if not gp.is_file():
+        return "global_hook_purge(noop: absent)"
+    try:
+        original = gp.read_bytes()
+        data = json.loads(original.decode("utf-8"))
+    except (OSError, ValueError) as exc:
+        why = f"{type(exc).__name__}: {exc}"
+        _warn(f"kunglao-upgrade: WARN — global settings purge skipped: "
+              f"{gp} is unreadable/unparseable ({why}); file left "
+              f"untouched — never repair a corrupted global file",
+              why, "global_hook_purge", ws)
+        return "global_hook_purge(warn: parse-failed)"
+    hooks = data.get("hooks") if isinstance(data, dict) else None
+    if not isinstance(hooks, dict):
+        return "global_hook_purge(noop)"
+    removed: list[str] = []
+    for event in list(hooks):
+        entries = hooks.get(event)
+        if not isinstance(entries, list):
+            continue
+        kept_entries: list = []
+        for entry in entries:
+            if not isinstance(entry, dict) \
+                    or not isinstance(entry.get("hooks"), list):
+                kept_entries.append(entry)
+                continue
+            kept_hooks = []
+            for h in entry["hooks"]:
+                cmd = h.get("command", "") if isinstance(h, dict) else ""
+                if isinstance(h, dict) and _is_kunglao_hook_command(cmd):
+                    removed.append(cmd)
+                else:
+                    kept_hooks.append(h)
+            if len(kept_hooks) == len(entry["hooks"]):
+                kept_entries.append(entry)          # nothing kunglao here
+            elif kept_hooks:
+                kept_entries.append({**entry, "hooks": kept_hooks})
+        if kept_entries:
+            hooks[event] = kept_entries
+        else:
+            del hooks[event]                        # event rode only kunglao
+    if not removed:
+        return "global_hook_purge(noop)"
+    matched = ",".join(sorted(name for name in WIRE_UP_HOOK_FILES
+                              if any(name in c for c in removed)))
+    if dry:
+        return (f"global_hook_purge(dry: would remove {len(removed)}: "
+                f"{matched})")
+    # #258 ordering contract: the rewire item ran earlier in this same run;
+    # a still-hook-less project layer draws the WARN but never blocks the
+    # purge (the stale global hooks keep firing outside any workspace).
+    if not any(_settings_has_live_hooks(t)
+               for t in hook_deployment_targets(ws)):
+        _warn("kunglao-upgrade: WARN — project-level hook registration not "
+              "detected before global purge (contract: hooks rewire runs "
+              "earlier in this upgrade); purging global kunglao hooks "
+              "anyway", "project-layer-missing", "global_hook_purge", ws)
+    ts = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    backup = ws / "runs" / f"global-settings-backup-{ts}.json"
+    try:
+        backup.parent.mkdir(parents=True, exist_ok=True)
+        backup.write_bytes(original)
+    except OSError as exc:
+        why = f"{type(exc).__name__}: {exc}"
+        _warn(f"kunglao-upgrade: WARN — global settings purge skipped: "
+              f"backup {backup} unwritable ({why}); global file left "
+              f"untouched — never purge without a backup",
+              why, "global_hook_purge", ws)
+        return "global_hook_purge(warn: backup-failed)"
+    tmp = gp.with_name(gp.name + ".tmp143")
+    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+                   encoding="utf-8")
+    os.chmod(tmp, gp.stat().st_mode & 0o777)
+    os.replace(tmp, gp)
+    detail = f"removed={len(removed)} files={matched}"
+    _emit(ws, "global_hook_purge", detail)
+    return f"global_hook_purge(removed={len(removed)}: {matched})"
 
 
 def _item_deployed_refresh(ws: Path, dry: bool) -> str:
@@ -599,6 +735,7 @@ def migrate_to_0_1_3(ws: Path, dry: bool) -> list[str]:
     init-report upgrade record, .agent seed. All items idempotent."""
     return [
         _item_hooks_rewire(ws, dry),
+        _item_global_hook_purge(ws, dry),  # #143 AFTER rewire (#258 completion)
         _item_always_armed_repair(ws, dry),
         _item_template_stamp_refresh(ws, dry),
         _item_init_report_note(ws, dry),
@@ -674,6 +811,13 @@ def _is_exempt(rel: str) -> bool:
     # #791 refresh item — same D4 exemption class as upgrade-snapshot.
     # Analysis data under runs/ stays byte-protected.
     if rel.startswith("runs/deploy-backup-"):
+        return True
+    # #143: the global-settings purge backup — framework-owned write of the
+    # upgrade's own #143 item (same D4 exemption class as deploy-backup);
+    # it mirrors the USER-GLOBAL settings, which the iron rule never hashed
+    # in the first place.
+    if rel.startswith("runs/global-settings-backup-") \
+            and rel.endswith(".json"):
         return True
     return False
 

--- a/tests/test_canonical_chain_752.py
+++ b/tests/test_canonical_chain_752.py
@@ -55,6 +55,25 @@ WIRE_UP_ENTRIES = len(WIRE_UP_HOOK_FILES) + len(
 
 # ---------------------------------------------------------------- helpers
 
+
+# ---------------------------------------------------------------- #143 home isolation
+# The upgrade now purges the user-global ~/.claude/settings.json (#143 item).
+# Every real-run upgrade test in this file binds Path.home to a bare tmp home
+# (the established monkeypatch seam, canonical_install_root precedent) plus
+# HOME/USERPROFILE for subprocess children, so a pytest run can never purge
+# the production global file — same protection class as conftest.isolated_home.
+
+
+@pytest.fixture(autouse=True)
+def _isolated_upgrade_home(tmp_path, monkeypatch):
+    home = tmp_path / "fake-home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
 @pytest.fixture
 def fake_home(tmp_path, monkeypatch):
     """Path.home() -> tmp home with an empty ~/.claude/skills tree."""

--- a/tests/test_claudemd_pending_merge_5.py
+++ b/tests/test_claudemd_pending_merge_5.py
@@ -55,6 +55,24 @@ PAYLOAD = b"MZ\x90\x00" + b"\x00" * 64
 SAMPLE_SHA = hashlib.sha256(PAYLOAD).hexdigest()
 
 
+# ---------------------------------------------------------------- #143 home isolation
+# The upgrade now purges the user-global ~/.claude/settings.json (#143 item).
+# Every real-run upgrade test in this file binds Path.home to a bare tmp home
+# (the established monkeypatch seam, canonical_install_root precedent) plus
+# HOME/USERPROFILE for subprocess children, so a pytest run can never purge
+# the production global file — same protection class as conftest.isolated_home.
+
+
+@pytest.fixture(autouse=True)
+def _isolated_upgrade_home(tmp_path, monkeypatch):
+    home = tmp_path / "fake-home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
 def _load_upgrade():
     spec = importlib.util.spec_from_file_location(
         "kunglao_upgrade", SCRIPTS / "kunglao_upgrade.py")

--- a/tests/test_deploy_lifecycle_783.py
+++ b/tests/test_deploy_lifecycle_783.py
@@ -34,10 +34,30 @@ if str(SCRIPTS) not in sys.path:
 import template_version as tv  # noqa: E402
 from _factories import seed_bins
 
+import pytest  # noqa: E402
+
 # #794 lesson: behavioral env vars must never leak into CLI children.
 _BEHAVIORAL_ENV_VARS = ("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS",)
 
 GIT_IDENTITY = ("-c", "user.name=t", "-c", "user.email=t@localhost")
+
+
+# ---------------------------------------------------------------- #143 home isolation
+# The upgrade now purges the user-global ~/.claude/settings.json (#143 item).
+# Every real-run upgrade test in this file binds Path.home to a bare tmp home
+# (the established monkeypatch seam, canonical_install_root precedent) plus
+# HOME/USERPROFILE for subprocess children, so a pytest run can never purge
+# the production global file — same protection class as conftest.isolated_home.
+
+
+@pytest.fixture(autouse=True)
+def _isolated_upgrade_home(tmp_path, monkeypatch):
+    home = tmp_path / "fake-home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
 
 
 def _run_cli(args: list[str], *, env: dict | None = None,

--- a/tests/test_deploy_surface_755.py
+++ b/tests/test_deploy_surface_755.py
@@ -34,6 +34,24 @@ from event_taxonomy import EMIT_ACTIONS  # noqa: E402
 from _factories import seed_bins
 
 
+# ---------------------------------------------------------------- #143 home isolation
+# The upgrade now purges the user-global ~/.claude/settings.json (#143 item).
+# Every real-run upgrade test in this file binds Path.home to a bare tmp home
+# (the established monkeypatch seam, canonical_install_root precedent) plus
+# HOME/USERPROFILE for subprocess children, so a pytest run can never purge
+# the production global file — same protection class as conftest.isolated_home.
+
+
+@pytest.fixture(autouse=True)
+def _isolated_upgrade_home(tmp_path, monkeypatch):
+    home = tmp_path / "fake-home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
 def _load_upgrade():
     import importlib.util
     spec = importlib.util.spec_from_file_location(

--- a/tests/test_global_hook_purge_143.py
+++ b/tests/test_global_hook_purge_143.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""tests/test_global_hook_purge_143.py — upgrade purges legacy global kunglao
+hooks (#143).
+
+Contract (issue #143, owner ruling 2026-09-07: ships in v0.1.5): hook
+deployment has been PROJECT-scoped since #258, but machines that ran
+pre-#258 versions still carry kunglao hooks in the user-global
+~/.claude/settings.json. The upgrade item _item_global_hook_purge:
+
+  - removes ONLY hook entries whose command references a WIRE_UP_HOOK_FILES
+    registry basename (#372 single source); non-kunglao entries and every
+    non-hooks top-level key (env/statusLine/enabledPlugins/...) survive;
+  - backs up the ORIGINAL file bytes to
+    <ws>/runs/global-settings-backup-<utc-ts>.json before the first write
+    (iron-rule-exempt, D4 class);
+  - skips with a WARN on a corrupted file, leaving it byte-untouched (never
+    repair a corrupted global file by truncation);
+  - is idempotent: no kunglao entries -> noop, no backup, no write;
+  - is registered AFTER _item_hooks_rewire so project-level registration is
+    confirmed earlier in the SAME upgrade run (#258: no window where neither
+    layer is active); a project layer that still reads hook-less draws a
+    WARN but the purge proceeds.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+UGRADE_PATH = SCRIPTS / "kunglao_upgrade.py"
+
+KUNGLAO_CMD_1 = "python /legacy/install/kunglao-agent/hooks/heartbeat_touch.py"
+KUNGLAO_CMD_2 = ("PYTHONUTF8=1 uv run --project /legacy/kunglao-agent "
+                 "/legacy/kunglao-agent/hooks/worker_budget.py")
+FOREIGN_CMD = "/usr/local/bin/prettier --stdin-filepath x.ts"
+
+
+def _load_upgrade():
+    spec = importlib.util.spec_from_file_location("kunglao_upgrade_143",
+                                                  UGRADE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _global_settings() -> dict:
+    """Mixed global settings: 2 kunglao hook entries + 1 foreign hook +
+    env + statusLine. The kunglao commands reference registry basenames via
+    paths from a DEAD pre-#258 install (the exact legacy shape #143 purges)."""
+    return {
+        "env": {"KUNGLAO_VALUE_ALGO": "keep-me"},
+        "hooks": {
+            "PreToolUse": [
+                {"matcher": "Agent", "hooks": [
+                    {"type": "command", "command": KUNGLAO_CMD_1},
+                    {"type": "command", "command": FOREIGN_CMD},
+                ]},
+            ],
+            "Stop": [
+                {"hooks": [{"type": "command", "command": KUNGLAO_CMD_2}]},
+            ],
+        },
+        "statusLine": {"type": "command", "command": "starship prompt"},
+    }
+
+
+def _write_global(gp: Path, payload: dict) -> bytes:
+    gp.parent.mkdir(parents=True, exist_ok=True)
+    gp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return gp.read_bytes()
+
+
+@pytest.fixture
+def purge_env(tmp_path, monkeypatch):
+    """Fixture home (the established Path.home monkeypatch seam —
+    hook_activation.canonical_install_root precedent) + a workspace whose
+    project-level settings carry live hooks (the post-rewire state)."""
+    home = tmp_path / "home"
+    gp = home / ".claude" / "settings.json"
+    original = _write_global(gp, _global_settings())
+    monkeypatch.setattr(Path, "home", lambda: home)
+    ws = tmp_path / "ws"
+    _write_global(ws / ".claude" / "settings.json", {
+        "hooks": {"Stop": [{"hooks": [
+            {"type": "command", "command": "uv run completion_gate.py"}]}]},
+    })
+    return home, gp, ws, original
+
+
+# ------------------------------------------------------------- purge core
+
+def test_purge_removes_exactly_the_kunglao_entries(purge_env):
+    home, gp, ws, original = purge_env
+    up = _load_upgrade()
+    line = up._item_global_hook_purge(ws, False)
+    assert "removed=2" in line, line
+    post = json.loads(gp.read_text(encoding="utf-8"))
+    pre = json.loads(original)
+    # non-hooks top-level keys untouched (parsed equality of whole subtrees)
+    assert post["env"] == pre["env"]
+    assert post["statusLine"] == pre["statusLine"]
+    # the foreign hook entry survives IN PLACE; Stop emptied -> key dropped
+    assert [h["command"] for h in post["hooks"]["PreToolUse"][0]["hooks"]] \
+        == [FOREIGN_CMD]
+    assert "Stop" not in post["hooks"]
+    blob = gp.read_text(encoding="utf-8")
+    assert KUNGLAO_CMD_1 not in blob and KUNGLAO_CMD_2 not in blob
+    assert FOREIGN_CMD in blob
+
+
+def test_purge_keeps_foreign_entries_in_original_shape(purge_env):
+    """A matcher entry that also carried foreign hooks is KEPT (with the
+    kunglao rows removed), not dropped wholesale."""
+    home, gp, ws, original = purge_env
+    up = _load_upgrade()
+    up._item_global_hook_purge(ws, False)
+    post = json.loads(gp.read_text(encoding="utf-8"))
+    entry = post["hooks"]["PreToolUse"][0]
+    assert entry["matcher"] == "Agent"
+    assert len(entry["hooks"]) == 1
+
+
+def test_backup_written_before_first_write(purge_env):
+    home, gp, ws, original = purge_env
+    up = _load_upgrade()
+    up._item_global_hook_purge(ws, False)
+    backups = list((ws / "runs").glob("global-settings-backup-*.json"))
+    assert len(backups) == 1, backups
+    assert backups[0].read_bytes() == original, \
+        "backup must carry the ORIGINAL bytes"
+
+
+def test_second_run_is_idempotent_noop(purge_env):
+    home, gp, ws, original = purge_env
+    up = _load_upgrade()
+    up._item_global_hook_purge(ws, False)
+    after_first = gp.read_bytes()
+    line2 = up._item_global_hook_purge(ws, False)
+    assert "noop" in line2, line2
+    assert gp.read_bytes() == after_first, "second run must not rewrite"
+    assert len(list((ws / "runs").glob("global-settings-backup-*.json"))) == 1
+
+
+def test_atomic_write_preserves_file_mode(purge_env):
+    home, gp, ws, original = purge_env
+    gp.chmod(0o600)
+    up = _load_upgrade()
+    up._item_global_hook_purge(ws, False)
+    assert gp.stat().st_mode & 0o777 == 0o600
+    assert not gp.with_name(gp.name + ".tmp143").exists(), \
+        "temp file must not survive the rename"
+
+
+def test_missing_global_file_is_noop(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    up = _load_upgrade()
+    line = up._item_global_hook_purge(tmp_path / "ws", False)
+    assert "noop" in line, line
+
+
+def test_no_hooks_segment_is_noop(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    gp = home / ".claude" / "settings.json"
+    original = _write_global(gp, {"env": {"A": "1"},
+                                  "statusLine": {"type": "command"}})
+    monkeypatch.setattr(Path, "home", lambda: home)
+    up = _load_upgrade()
+    line = up._item_global_hook_purge(tmp_path / "ws", False)
+    assert "noop" in line, line
+    assert gp.read_bytes() == original
+
+
+# ------------------------------------------------------------- safety rails
+
+def test_corrupted_global_file_skips_with_warn_untouched(purge_env, capsys):
+    home, gp, ws, original = purge_env
+    corrupted = b'{"hooks": {"PreToolUse": [TRUNCATED'
+    gp.write_bytes(corrupted)
+    up = _load_upgrade()
+    line = up._item_global_hook_purge(ws, False)
+    assert "warn" in line.lower(), line
+    assert gp.read_bytes() == corrupted, "corrupted file must stay untouched"
+    err = capsys.readouterr().err
+    assert "WARN" in err and "global" in err.lower()
+    assert not list((ws / "runs").glob("global-settings-backup-*.json")), \
+        "a skipped purge must not write a backup"
+
+
+def test_dry_run_reports_removal_writes_nothing(purge_env):
+    home, gp, ws, original = purge_env
+    up = _load_upgrade()
+    line = up._item_global_hook_purge(ws, True)
+    assert "dry" in line and "2" in line, line
+    assert gp.read_bytes() == original, "dry run must not write"
+    assert not list((ws / "runs").glob("global-settings-backup-*.json")), \
+        "dry run must not write a backup"
+
+
+def test_project_layer_missing_still_purges_but_warns(tmp_path, monkeypatch,
+                                                       capsys):
+    """Order contract: project rewire runs EARLIER in the same upgrade run.
+    If the project layer still reads hook-less, the purge proceeds (stale
+    global hooks are live pollution either way) but logs the WARN."""
+    home = tmp_path / "home"
+    gp = home / ".claude" / "settings.json"
+    _write_global(gp, _global_settings())
+    monkeypatch.setattr(Path, "home", lambda: home)
+    ws = tmp_path / "ws"
+    ws.mkdir()  # no ws/.claude/settings.json at all
+    up = _load_upgrade()
+    line = up._item_global_hook_purge(ws, False)
+    assert "removed=2" in line, line
+    err = capsys.readouterr().err
+    assert "WARN" in err and "project" in err.lower()
+
+
+def test_project_layer_present_no_warn(purge_env, capsys):
+    home, gp, ws, original = purge_env
+    up = _load_upgrade()
+    up._item_global_hook_purge(ws, False)
+    assert "WARN" not in capsys.readouterr().err
+
+
+# ------------------------------------------------------------- registration
+
+def test_registered_after_hooks_rewire_in_the_items_list(tmp_path):
+    """The purge item must ride the 0.1.3 migration plan AFTER
+    _item_hooks_rewire (#258: project registration confirmed before global
+    removal — no window where neither layer is active)."""
+    up = _load_upgrade()
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    plan = up.migrate_to_0_1_3(ws, dry=True)
+    assert "hooks_rewire" in plan
+    purge_rows = [i for i in plan if i.startswith("global_hook_purge")]
+    assert len(purge_rows) == 1, plan
+    assert plan.index("hooks_rewire") < plan.index(purge_rows[0])
+
+
+def test_purge_event_word_registered():
+    """The ledger emit face is a controlled-vocabulary word (#459)."""
+    sys.path.insert(0, str(SCRIPTS))
+    import event_taxonomy
+    assert "global_hook_purge" in event_taxonomy.EMIT_ACTIONS
+
+
+# ------------------------------------------------------------- iron rule
+
+def test_purge_backup_is_iron_rule_exempt(tmp_path):
+    """<ws>/runs/global-settings-backup-*.json is framework-owned telemetry
+    of the upgrade's own item — same D4 exemption class as deploy-backup;
+    the file mirrors the USER-GLOBAL settings the iron rule never hashed."""
+    up = _load_upgrade()
+    ws = tmp_path / "ws"
+    (ws / "facts").mkdir(parents=True)
+    (ws / "facts" / "F001.md").write_text("body", encoding="utf-8")
+    pre = up.user_data_digest(ws)
+    backup = ws / "runs" / "global-settings-backup-20260907T000000Z.json"
+    backup.parent.mkdir(parents=True)
+    backup.write_text("{}", encoding="utf-8")
+    assert up.user_data_digest(ws) == pre, \
+        "the purge backup must not trip the iron rule"

--- a/tests/test_kunglao_upgrade_726.py
+++ b/tests/test_kunglao_upgrade_726.py
@@ -30,6 +30,24 @@ from _factories import write_hook_state
 UGRADE_PATH = SCRIPTS / "kunglao_upgrade.py"
 
 
+# ---------------------------------------------------------------- #143 home isolation
+# The upgrade now purges the user-global ~/.claude/settings.json (#143 item).
+# Every real-run upgrade test in this file binds Path.home to a bare tmp home
+# (the established monkeypatch seam, canonical_install_root precedent) plus
+# HOME/USERPROFILE for subprocess children, so a pytest run can never purge
+# the production global file — same protection class as conftest.isolated_home.
+
+
+@pytest.fixture(autouse=True)
+def _isolated_upgrade_home(tmp_path, monkeypatch):
+    home = tmp_path / "fake-home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
 def _load_upgrade():
     spec = importlib.util.spec_from_file_location("kunglao_upgrade", UGRADE_PATH)
     mod = importlib.util.module_from_spec(spec)

--- a/tests/test_runtime_version_758.py
+++ b/tests/test_runtime_version_758.py
@@ -30,6 +30,25 @@ CUR_VERSION = tv.read_skill_version()
 
 # =============================================================== G1a: pin
 
+
+# ---------------------------------------------------------------- #143 home isolation
+# The upgrade now purges the user-global ~/.claude/settings.json (#143 item).
+# Every real-run upgrade test in this file binds Path.home to a bare tmp home
+# (the established monkeypatch seam, canonical_install_root precedent) plus
+# HOME/USERPROFILE for subprocess children, so a pytest run can never purge
+# the production global file — same protection class as conftest.isolated_home.
+
+
+@pytest.fixture(autouse=True)
+def _isolated_upgrade_home(tmp_path, monkeypatch):
+    home = tmp_path / "fake-home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
 class TestG1aPin:
     def test_python_version_file_pins_311(self):
         p = REPO / ".python-version"

--- a/tests/test_upgrade_safety_753.py
+++ b/tests/test_upgrade_safety_753.py
@@ -44,6 +44,24 @@ EVENT_RE = re.compile(
 IDENTITY = ("-c", "user.name=t", "-c", "user.email=t@localhost")
 
 
+# ---------------------------------------------------------------- #143 home isolation
+# The upgrade now purges the user-global ~/.claude/settings.json (#143 item).
+# Every real-run upgrade test in this file binds Path.home to a bare tmp home
+# (the established monkeypatch seam, canonical_install_root precedent) plus
+# HOME/USERPROFILE for subprocess children, so a pytest run can never purge
+# the production global file — same protection class as conftest.isolated_home.
+
+
+@pytest.fixture(autouse=True)
+def _isolated_upgrade_home(tmp_path, monkeypatch):
+    home = tmp_path / "fake-home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
 def _load_upgrade():
     spec = importlib.util.spec_from_file_location(
         "kunglao_upgrade_753", UPGRADE_PATH)


### PR DESCRIPTION
## What

Closes #143. `/kunglao-agent:upgrade` now PURGES legacy pre-#258 kunglao hooks from the user-global `~/.claude/settings.json` — the upgrade-side completion of #258's project-scope deployment migration (owner ruling 2026-09-07: ships in v0.1.5). Until now the tooling only WARNED about them (hooks_selfcheck), while stale global hooks bound to dead install paths kept firing outside any workspace.

## How

- **New upgrade item** `_item_global_hook_purge(ws, dry)` in `scripts/kunglao_upgrade.py` (follows the `\_item\_\*` pattern: one-line status string, honors dry mode). Registered in `migrate_to_0_1_3`'s items list **directly after** `_item_hooks_rewire` — project-level registration is confirmed earlier in the SAME run, so there is no window where neither layer is active (#258).
- **Purge scope**: walks ONLY the `hooks` segment; removes hook entries whose command strings reference a `wire_up_settings.WIRE_UP_HOOK_FILES` basename (imported — single source, #372; same basename-substring convention as hooks_selfcheck's present/missing scan). Never touches non-kunglao entries; never touches env/statusLine/enabledPlugins or any other top-level key. Containers the purge empties carried kunglao-only content by construction.
- **Safety rails**: original bytes backed up to `<ws>/runs/global-settings-backup-<utc-ts>.json` before the first write (exempted from the iron-rule digest — D4 class, mirrors the user-global file the rule never hashed); parse failure → skip + WARN, file byte-untouched (never repair a corrupted global file by truncation — v1.9.37 lesson); no kunglao entries → idempotent noop (no backup, no write); backup-unwritable → skip + WARN. Write-back is atomic (same-dir temp + `os.replace`) and preserves the file mode. If the project layer still reads hook-less, the purge proceeds but logs the project-missing WARN.
- **Telemetry**: `global_hook_purge` registered in `event_taxonomy.EMIT_ACTIONS` (#459 controlled vocabulary, sorted position); ledger emit on applied purges.
- **hooks_selfcheck.py**: comment updated to note upgrade now purges; the check itself stays as the between-upgrades tripwire, behavior unchanged.
- **Test hygiene**: the 7 test files that execute real upgrade runs now bind `Path.home` + `HOME`/`USERPROFILE` to a bare tmp home (autouse fixture, established monkeypatch seam) — a pytest run can never purge the production global file.

## Test plan

- [x] New `tests/test_global_hook_purge_143.py` (RED-first, 14 tests): mixed global settings (2 kunglao + 1 foreign hook + env + statusLine) → exactly the 2 removed, others preserved; backup carries original bytes; second run noop; corrupted JSON → skip+WARN untouched; dry-run writes nothing; plan order `hooks_rewire` < `global_hook_purge`; project-missing WARN; mode preservation; iron-rule exemption; EMIT_ACTIONS word.
- [x] Full suite: `env -u KUNGLAO_VALUE_ALGO python3 -m pytest tests/ -q` — branch: 5901 passed / 5 failed / 10 skipped; bare-dev baseline (8e17741): 5886 passed / **identical 5 failures** / 11 skipped. Collection diff: +14 tests, all from the new file, zero other changes.
- [x] Pre-existing reds on bare dev (reported, not fixed here): `test_env_check.py::test_all_pass_exit_0` + `test_hypothesis_loop_integration_111.py` (4 tests — reproduce on bare 8e17741 in isolation).
- [x] `ruff check .`: identical 5 pre-existing findings on both trees (dispatch_gate F841; unused imports in test_claudemd_conditional_919 / test_contracts_drift_102 x2 / test_docsync_589_563). Touched files clean.
- [x] `deploy_manifest.py --write && --verify`: 389 entries verified (regen committed).
- [x] Decide anchors: `test_decide_regression_anchor.py` + `test_decision_surface_anchor.py` — 40 passed.
- [x] Review gate: one code-reviewer subagent (`r1-143-purge`) on the staged diff — verdict PASS; per-commit evidence minted via `review_gate.py mint`.

## Notes

- End-to-end smoke (fixture HOME): dry plan prints `global_hook_purge(dry: would remove 2: ...)`; real run removes exactly the kunglao entries, foreign hook/env/statusLine intact, backup written, re-runs noop.
- Known non-blocking reviewer notes: `os.replace` turns a symlinked global settings file into a regular file (content preserved via backup; dotfile-manager edge); plan-order test reads the real home in dry mode (write-free by construction).
- Parallel-branch coordination: feat/142-statusline-v2 may touch hooks_selfcheck.py; this branch's hooks_selfcheck change is a comment block only — trivial rebase if both land.