### PR TITLE
feat(#133): value-currency reconciliation — oracle-gated coverage credit + v_oracle gap projection

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -559,7 +559,7 @@ files:
   - src: scripts/mission_ledger.py
     dest: .claude/scripts/mission_ledger.py
     kind: scaffold
-    sha256: 8ba96b66b2ddc0f70db3ceb99f474c03dcb3677a54b5aeaf69173c905cfb488c
+    sha256: d49bb04b1506d7a9f76792b3ee27b226ba9177a87b602a29b7b2eb743082a643
   - src: scripts/mission_stall.py
     dest: .claude/scripts/mission_stall.py
     kind: scaffold

--- a/scripts/mission_ledger.py
+++ b/scripts/mission_ledger.py
@@ -297,6 +297,52 @@ def progress_face(ws, now=None) -> dict:
             "per_pq": rows}
 
 
+def _oracle_case_links(ws) -> list[tuple[str, str]]:
+    """#133: (case_id, target_pq) pairs over the workspace's ARMED oracle
+    case set. Single source: priority_ratio._load_oracle_cases — the SAME
+    reader the #107 Thompson case face consumes, so the value gate and the
+    ranker can never disagree about which cases belong to a PQ. Fail-open
+    contract inherited (no dir -> []; a broken case doc is skipped, not
+    signal)."""
+    from priority_ratio import _load_oracle_cases
+    return _load_oracle_cases(Path(ws))
+
+
+def _oracle_status_map(ws) -> dict[str, str] | None:
+    """#133: case_id -> runner status (pass|fail|pending) off the
+    oracle-status/1 verdict file, via the convergence DRAIN probe's own
+    reader (one schema face — no drift with the acceptance gate). None =
+    the file is PRESENT but unreadable: fail-closed, a corrupt verdict
+    never grants green (the contradiction-gate posture — unreadable
+    acceptance evidence cannot silently re-enable the value it checks)."""
+    from convergence_check import _load_oracle_status
+    face = _load_oracle_status(Path(ws))
+    if face.get("error"):
+        return None
+    return {c["id"]: c["status"] for c in face["cases"]}
+
+
+def oracle_credit_gate(pq_id, case_links: list[tuple[str, str]],
+                       status_map: dict[str, str] | None) -> bool | None:
+    """#133 coverage-credit gate (pure): may an answered PQ take full credit?
+
+    True  = every armed case bound to this PQ is green (runner pass).
+    False = armed but at least one case is NOT green — fail, pending (any
+            instrumentation state; "unknown" is never "pass", #108 A), a
+            case added after the last runner run, or an unreadable verdict
+            file. The PQ is "claimed but unproven", priced at the
+            blocked-tier credit.
+    None  = no armed case bound to this PQ — nothing to reconcile against
+            (Phase 0/1 tasks): keep current behavior.
+    """
+    armed = [cid for cid, tpq in case_links if tpq == str(pq_id)]
+    if not armed:
+        return None
+    if status_map is None:
+        return False
+    return all(status_map.get(cid) == "pass" for cid in armed)
+
+
 def value_m(ws, now=None) -> dict:
     """V_m + A_t。history 只由此函数追加（增量结算即时入账）。
 
@@ -315,6 +361,19 @@ def value_m(ws, now=None) -> dict:
     test_vm_normalization_10）——进度绝不写进 raw 面；V_m/A_t 数学原样
     不动——欠账结算仍是唯一权威；``now`` 仅参与 IN_PROGRESS 新鲜度
     分类，不入 V_m 单位。
+    #133 value-currency reconciliation（additive，raw 字段原样保留）：
+    v_m 的 PLAN 货币与 oracle 红/绿的 ACCEPTANCE 事实对账——answered PQ
+    的全额 coverage credit 需其 armed oracle cases 全绿（runner status
+    face: runs/oracle-status.json, oracle-status/1）。全绿 → 全额
+    w*coverage（原样）；任一 armed case 非绿（fail / pending / 未判 /
+    verdict 文件不可读——fail-closed）→ 阻断档信贷 β*w（"claimed but
+    unproven"）。无 armed case 的 PQ 保持原行为（Phase 0/1：无从对账）。
+    PQ→case 归链复用 #107 Thompson case face 的同一 reader（cases/
+    target_pq），价值闸门与排序层永不各自为政。新增对齐投影
+    v_oracle/v_oracle_norm：只给 oracle-green PQ（answered 且全绿）计
+    credit——v_norm 高 + v_oracle 低 = 叙事通胀的常设暴露面（#129 消费）。
+    history 行 ADDITIVE 携带 v_oracle/v_oracle_norm；raw v_m 数学、raw
+    返回键、raw history 字段全部原样。
     """
     led = load(ws)
     beta = float(led.get("mission", {}).get("beta", BETA))
@@ -329,18 +388,35 @@ def value_m(ws, now=None) -> dict:
         except yaml.YAMLError:
             claims = []
     v_m = 0.0
+    v_oracle = 0.0
     total_w = 0.0
     weighted_progress = 0.0
     pq_rows = []
     per_pq = {}
+    answered_ids = [str(p.get("id")) for p in pqs
+                    if p.get("state") == "answered"]
+    # #133: the acceptance face is read only when there is something to
+    # reconcile — no answered PQ (or no armed case set) touches oracle IO.
+    case_links = _oracle_case_links(ws) if answered_ids else []
+    status_map = (_oracle_status_map(ws)
+                  if (case_links and answered_ids) else {})
     for p in pqs:
         w = float(p.get("weight", 1.0))
         total_w += w
         cov = float(p.get("coverage", 0.0))
         st = p.get("state")
-        contrib = w * cov if st == "answered" else (
-            beta * w if st == "blocked" else 0.0)
+        oracle_green = None
+        if st == "answered":
+            oracle_green = oracle_credit_gate(p.get("id"), case_links,
+                                              status_map)
+            # None (no armed case) keeps the full credit; False (armed,
+            # not all green) damps to the blocked-tier credit.
+            contrib = w * cov if oracle_green is not False else beta * w
+        else:
+            contrib = beta * w if st == "blocked" else 0.0
         v_m += contrib
+        if oracle_green:
+            v_oracle += w * cov
         row = pq_progress(p, claims, now=now, tier=tier)
         weighted_progress += w * row["progress"]
         pq_rows.append(dict(id=p.get("id"), state=st, weight=w, **row))
@@ -349,6 +425,9 @@ def value_m(ws, now=None) -> dict:
     progress_fraction = (round(weighted_progress / total_w, 6)
                          if total_w > 0 else 0.0)
     v_norm = max(0.0, min(1.0, v_m / total_w)) if total_w > 0 else 0.0
+    # #133 aligned projection: only oracle-green PQs carry acceptance value.
+    v_oracle_norm = (max(0.0, min(1.0, v_oracle / total_w))
+                     if total_w > 0 else 0.0)
     hist = led.get("mission", {}).get("history") or []
     prev = float(hist[-1].get("v_m", 0.0)) if hist else 0.0
     if hist and "v_norm" in hist[-1]:
@@ -358,7 +437,9 @@ def value_m(ws, now=None) -> dict:
     a_t = v_m - prev
     a_t_norm = v_norm - prev_norm
     hist.append({"ts": _utc_now(), "v_m": round(v_m, 6),
-                 "v_norm": round(v_norm, 6)})
+                 "v_norm": round(v_norm, 6),
+                 "v_oracle": round(v_oracle, 6),
+                 "v_oracle_norm": round(v_oracle_norm, 6)})
     led["mission"]["history"] = hist
     _save(ws, led)
     n_answered = sum(1 for p in pqs if p.get("state") == "answered")
@@ -368,6 +449,10 @@ def value_m(ws, now=None) -> dict:
     return {"v_m": round(v_m, 6), "prev_v_m": prev, "a_t": round(a_t, 6),
             "v_norm": round(v_norm, 6), "a_t_norm": round(a_t_norm, 6),
             "total_weight": round(total_w, 6),
+            # #133 additive: acceptance currency + its normalized face —
+            # v_norm - v_oracle_norm is the standing inflation gap.
+            "v_oracle": round(v_oracle, 6),
+            "v_oracle_norm": round(v_oracle_norm, 6),
             "progress_fraction": progress_fraction,
             "per_pq_progress": pq_rows,
             "per_pq": per_pq, "answered": n_answered,
@@ -388,6 +473,9 @@ def emit_snapshot(ws, epoch: int | None = None, arm: str | None = None,
             # #10 additive: normalized value + per-round normalized delta
             "v_norm": val["v_norm"], "a_t_norm": val["a_t_norm"],
             "total_weight": val["total_weight"],
+            # #133 additive: acceptance currency + the inflation gap face
+            "v_oracle": val["v_oracle"],
+            "v_oracle_norm": val["v_oracle_norm"],
             # #14 additive: sub-PQ progress aggregate (see value_m)
             "progress_fraction": val["progress_fraction"],
         }, ensure_ascii=False)

--- a/tests/test_value_reconciliation_133.py
+++ b/tests/test_value_reconciliation_133.py
@@ -1,0 +1,291 @@
+# -*- coding: utf-8 -*-
+"""tests/test_value_reconciliation_133.py — #133 value-currency reconciliation.
+
+Two value currencies never reconciled. v_m (mission_ledger.value_m) measures
+PLAN progress: a PQ marked "answered" contributed full w*coverage regardless
+of acceptance. The oracle's red/green face (runs/oracle-status.json, schema
+oracle-status/1, written by oracle_runner.write_status) measures ACCEPTANCE
+fact. They could diverge: narrative-answered PQs maxed v_m while every armed
+oracle case was red — fake progress invisible to the value model, and
+mission_stall's reference frame (v_m history) agent-influenceable in exactly
+the way the drift audit flagged.
+
+#133 closes the value layer (the wiring layer closed in #108):
+
+1. Coverage credit gate: an answered PQ's contribution requires its armed
+   oracle cases green. The PQ->case linkage is the SAME one the #107
+   Thompson case face consumes (oracle/cases/*.yaml `target_pq`, read via
+   priority_ratio._load_oracle_cases), so the value gate and the ranker can
+   never disagree about which cases belong to a PQ. Green -> full w*coverage
+   (unchanged); any armed case not green (fail / pending / not yet judged /
+   unreadable verdict file) -> damped to the blocked-tier credit (beta*w) —
+   the PQ is "claimed but unproven", priced accordingly. Answered PQs with
+   NO armed cases keep current behavior (nothing to reconcile against —
+   Phase 0/1 tasks).
+2. Aligned projection: v_oracle / v_oracle_norm credit ONLY oracle-green
+   PQs (answered AND all-armed-cases-green). The v_norm - v_oracle gap is a
+   standing fake-progress indicator: v_norm high + v_oracle low = narrative
+   inflation. Additive everywhere: raw v_m math, raw return keys, and the
+   raw history fields are untouched (the module's #10/#14 additive
+   convention, byte-identical guards in test_vm_normalization_10).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import mission_ledger as ml  # noqa: E402
+import oracle_runner as orun  # noqa: E402  (real status-face producer)
+
+BETA = ml.BETA  # 0.3 — the blocked-tier credit the damped tier prices at
+
+
+# ------------------------------------------------------------------ fixtures
+
+def _pq(pid, state="answered", cov=1.0, weight=1.0):
+    return {"id": pid, "question": pid, "state": state, "coverage": cov,
+            "answered_by": [], "blocker": None, "wake": None,
+            "weight": weight}
+
+
+def _write_led(ws, pqs):
+    """Hand-seeded ledger (mirrors the live schema; direct write)."""
+    (Path(ws) / "runs" / "mission_ledger.yaml").write_text(
+        yaml.safe_dump({"mission": {"pqs": pqs, "beta": BETA,
+                                    "history": [], "feature_used": True}},
+                       allow_unicode=True), encoding="utf-8")
+
+
+def _write_case(ws, case_id, target_pq):
+    """One armed oracle case (oracle/cases/*.yaml `target_pq` linkage)."""
+    cdir = Path(ws) / "oracle" / "cases"
+    cdir.mkdir(parents=True, exist_ok=True)
+    (cdir / f"{case_id.lower()}.yaml").write_text(
+        yaml.safe_dump({"id": case_id, "target_pq": target_pq},
+                       allow_unicode=True), encoding="utf-8")
+
+
+def _write_status(ws, statuses):
+    """Write runs/oracle-status.json through the REAL producer face
+    (oracle_runner.write_status): statuses = {case_id: pass|fail|pending}."""
+    report = {
+        "cases": {cid: {"status": st, "pending_entries": 0,
+                        "instrumented": True}
+                  for cid, st in statuses.items()},
+        "counts": {"red": sum(1 for s in statuses.values() if s == "fail"),
+                   "green": sum(1 for s in statuses.values()
+                                if s == "pass"),
+                   "pending": sum(1 for s in statuses.values()
+                                  if s == "pending")},
+        "mutation": None,
+    }
+    orun.write_status(ws, report)
+
+
+def _mk_ws(tmp_path, name, pqs, cases=(), statuses=None):
+    """Workspace with a seeded ledger, optional armed cases, optional
+    runner verdicts. cases: [(case_id, target_pq)]; statuses: {cid: st}."""
+    ws = tmp_path / name
+    (ws / "runs").mkdir(parents=True)
+    _write_led(ws, pqs)
+    for case_id, target_pq in cases:
+        _write_case(ws, case_id, target_pq)
+    if statuses is not None:
+        _write_status(ws, statuses)
+    return ws
+
+
+# ------------------------------------- 1. the coverage credit gate (v_m)
+
+def test_answered_with_red_case_damps_to_blocked_tier(tmp_path):
+    """Narrative-answered + red armed case: full coverage credit DENIED,
+    the blocked-tier credit (beta*w) applies instead."""
+    ws = _mk_ws(tmp_path, "ws_red", [_pq("q1")],
+                cases=[("CASE-1", "q1")], statuses={"CASE-1": "fail"})
+    v = ml.value_m(ws)
+    assert v["v_m"] == pytest.approx(BETA)  # damped, NOT 1.0
+    assert v["per_pq"]["q1"]["contrib"] == pytest.approx(BETA)
+
+
+def test_answered_with_green_case_keeps_full_credit(tmp_path):
+    """Every armed case green: full w*coverage — unchanged."""
+    ws = _mk_ws(tmp_path, "ws_green", [_pq("q1")],
+                cases=[("CASE-1", "q1")], statuses={"CASE-1": "pass"})
+    v = ml.value_m(ws)
+    assert v["v_m"] == pytest.approx(1.0)
+    assert v["per_pq"]["q1"]["contrib"] == pytest.approx(1.0)
+
+
+def test_answered_with_no_armed_case_unchanged(tmp_path):
+    """No armed cases on the PQ -> nothing to reconcile against: current
+    behavior (full credit) preserved — the Phase 0/1 exemption."""
+    ws = _mk_ws(tmp_path, "ws_nocase", [_pq("q1")],
+                cases=[("CASE-OTHER", "q2")], statuses={"CASE-OTHER": "fail"})
+    v = ml.value_m(ws)
+    assert v["v_m"] == pytest.approx(1.0)  # CASE-OTHER targets q2, not q1
+
+
+def test_answered_with_pending_case_damps(tmp_path):
+    """Pending on live instrumentation is not green ("unknown" is never
+    "pass", #108 A) -> damped. An uninstrumented pending is damped too:
+    the gate requires green, and a runner that never observed anything
+    proved nothing."""
+    ws_pend = _mk_ws(tmp_path, "ws_pend", [_pq("q1")],
+                     cases=[("CASE-1", "q1")],
+                     statuses={"CASE-1": "pending"})
+    assert ml.value_m(ws_pend)["v_m"] == pytest.approx(BETA)
+
+    # uninstrumented pending: rewrite the verdict with instrumented=False
+    ws_raw = _mk_ws(tmp_path, "ws_pend_raw", [_pq("q1")],
+                    cases=[("CASE-1", "q1")])
+    (ws_raw / "runs" / "oracle-status.json").write_text(
+        '{"schema": "oracle-status/1", "cases": {"CASE-1": {"status": '
+        '"pending", "pending_entries": 2, "instrumented": false}}, '
+        '"counts": {"red": 0, "green": 0, "pending": 1}}\n',
+        encoding="utf-8")
+    assert ml.value_m(ws_raw)["v_m"] == pytest.approx(BETA)
+
+
+def test_answered_mixed_cases_any_non_green_damps(tmp_path):
+    """ALL armed cases must be green: one green + one red -> damped."""
+    ws = _mk_ws(tmp_path, "ws_mixed", [_pq("q1")],
+                cases=[("CASE-1", "q1"), ("CASE-2", "q1")],
+                statuses={"CASE-1": "pass", "CASE-2": "fail"})
+    assert ml.value_m(ws)["v_m"] == pytest.approx(BETA)
+
+
+def test_armed_case_missing_from_status_damps(tmp_path):
+    """A case in the armed set with no verdict yet (added after the last
+    runner run) is unproven, not green -> damped."""
+    ws = _mk_ws(tmp_path, "ws_unjudged", [_pq("q1")],
+                cases=[("CASE-1", "q1"), ("CASE-2", "q1")],
+                statuses={"CASE-1": "pass"})  # CASE-2 never judged
+    assert ml.value_m(ws)["v_m"] == pytest.approx(BETA)
+
+
+def test_unreadable_status_damps_fail_closed(tmp_path):
+    """A corrupt verdict file never grants full credit (the
+    contradiction-gate posture: corrupt acceptance evidence cannot silently
+    re-enable the value it is supposed to check)."""
+    ws = _mk_ws(tmp_path, "ws_corrupt", [_pq("q1")],
+                cases=[("CASE-1", "q1")])
+    (ws / "runs" / "oracle-status.json").write_text("{not json",)
+    assert ml.value_m(ws)["v_m"] == pytest.approx(BETA)
+
+
+def test_case_without_target_pq_belongs_to_no_pq(tmp_path):
+    """A case file with no target_pq is linked to nothing: the answered PQ
+    keeps current behavior (the Thompson reader skips empty target_pq)."""
+    ws = _mk_ws(tmp_path, "ws_unlinked", [_pq("q1")],
+                cases=[("CASE-1", "")], statuses={"CASE-1": "fail"})
+    assert ml.value_m(ws)["v_m"] == pytest.approx(1.0)
+
+
+# ------------------------------------- 2. the aligned v_oracle projection
+
+def test_v_oracle_credits_only_oracle_green_pqs(tmp_path):
+    """Inflation fixture: q1 answered+green-armed, q2 answered+red-armed.
+    v_m keeps the damped-plan currency (1.0 + beta), v_oracle credits only
+    the oracle-green PQ (1.0) — the gap surfaces the narrative half."""
+    ws = _mk_ws(tmp_path, "ws_gap",
+                [_pq("q1"), _pq("q2")],
+                cases=[("CASE-1", "q1"), ("CASE-2", "q2")],
+                statuses={"CASE-1": "pass", "CASE-2": "fail"})
+    v = ml.value_m(ws)
+    assert v["v_m"] == pytest.approx(1.0 + BETA)      # plan currency
+    assert v["v_norm"] == pytest.approx((1.0 + BETA) / 2.0)
+    assert "v_oracle" in v and "v_oracle_norm" in v
+    assert v["v_oracle"] == pytest.approx(1.0)        # green PQ only
+    assert v["v_oracle_norm"] == pytest.approx(0.5)
+    assert v["v_oracle"] < v["v_m"]                   # the gap exists
+    assert v["v_oracle_norm"] < v["v_norm"]
+
+
+def test_v_oracle_all_green_equals_v_m(tmp_path):
+    """Every answered PQ oracle-green: the two currencies coincide."""
+    ws = _mk_ws(tmp_path, "ws_allgreen",
+                [_pq("q1"), _pq("q2")],
+                cases=[("CASE-1", "q1"), ("CASE-2", "q2")],
+                statuses={"CASE-1": "pass", "CASE-2": "pass"})
+    v = ml.value_m(ws)
+    assert v["v_oracle"] == pytest.approx(v["v_m"])
+    assert v["v_oracle_norm"] == pytest.approx(v["v_norm"])
+
+
+def test_v_oracle_unarmed_answered_pq_not_credited(tmp_path):
+    """An answered PQ with NO armed cases keeps full v_m (nothing to
+    reconcile against) but earns NO oracle credit: v_norm full +
+    v_oracle zero IS the standing inflation marker."""
+    ws = _mk_ws(tmp_path, "ws_unarmed", [_pq("q1")])
+    v = ml.value_m(ws)
+    assert v["v_m"] == pytest.approx(1.0)    # plan face unchanged
+    assert v["v_oracle"] == pytest.approx(0.0)  # acceptance face: unproven
+    assert v["v_oracle_norm"] == pytest.approx(0.0)
+
+
+def test_v_oracle_blocked_and_unattempted_contribute_zero(tmp_path):
+    """Only answered-and-green PQs enter v_oracle; blocked keeps its
+    beta*w in v_m and nothing in v_oracle."""
+    ws = _mk_ws(tmp_path, "ws_tiers",
+                [_pq("q1", "blocked", 0.0), _pq("q2", "unattempted", 0.0),
+                 _pq("q3")],
+                cases=[("CASE-3", "q3")], statuses={"CASE-3": "pass"})
+    v = ml.value_m(ws)
+    assert v["v_m"] == pytest.approx(BETA + 1.0)
+    assert v["v_oracle"] == pytest.approx(1.0)  # only q3 is oracle-green
+
+
+# ------------------------------------- 3. additive history + raw preservation
+
+def test_history_rows_carry_v_oracle_additive_raw_intact(tmp_path):
+    """History rows gain v_oracle / v_oracle_norm ADDITIVELY: the raw
+    {ts, v_m, v_norm} shape is untouched (the #10 guard's intent)."""
+    ws = _mk_ws(tmp_path, "ws_hist",
+                [_pq("q1"), _pq("q2")],
+                cases=[("CASE-1", "q1"), ("CASE-2", "q2")],
+                statuses={"CASE-1": "pass", "CASE-2": "fail"})
+    ml.value_m(ws)
+    hist = ml.load(ws)["mission"]["history"]
+    assert len(hist) == 1
+    row = hist[-1]
+    assert "ts" in row and "v_m" in row and "v_norm" in row  # raw keys
+    assert row["v_m"] == pytest.approx(1.0 + BETA)
+    assert row["v_norm"] == pytest.approx((1.0 + BETA) / 2.0)
+    assert row["v_oracle"] == pytest.approx(1.0)             # additive
+    assert row["v_oracle_norm"] == pytest.approx(0.5)
+
+
+def test_no_oracle_artifacts_behavior_identical_to_pre_133(tmp_path):
+    """A workspace with no oracle/ dir and no status file: value_m output
+    is byte-identical to the pre-#133 contract (raw face preserved)."""
+    ws = _mk_ws(tmp_path, "ws_plain", [_pq("q1"), _pq("q2", "unattempted",
+                                                       0.0)])
+    v = ml.value_m(ws)
+    assert {k: v[k] for k in ("v_m", "prev_v_m", "a_t", "per_pq",
+                              "answered", "blocked", "unattempted")} == {
+        "v_m": 1.0, "prev_v_m": 0.0, "a_t": 1.0,
+        "per_pq": {"q1": {"state": "answered", "contrib": 1.0},
+                   "q2": {"state": "unattempted", "contrib": 0.0}},
+        "answered": 1, "blocked": 0, "unattempted": 1}
+    assert v["v_oracle"] == pytest.approx(0.0)
+    assert v["v_oracle_norm"] == pytest.approx(0.0)
+
+
+def test_weights_respected_in_both_currencies(tmp_path):
+    """The gate and the projection are weighted identically to the #10
+    normalization: damped and credited amounts scale with the PQ weight."""
+    ws = _mk_ws(tmp_path, "ws_weights",
+                [_pq("q1", weight=3.0), _pq("q2", weight=1.0)],
+                cases=[("CASE-1", "q1"), ("CASE-2", "q2")],
+                statuses={"CASE-1": "fail", "CASE-2": "pass"})
+    v = ml.value_m(ws)
+    assert v["v_m"] == pytest.approx(BETA * 3.0 + 1.0 * 1.0)
+    assert v["v_oracle"] == pytest.approx(1.0)  # only q2 (green) credited


### PR DESCRIPTION
Closes #133.

## What

Value-currency reconciliation: v_m's PLAN currency and the oracle's ACCEPTANCE fact now reconcile at `scripts/mission_ledger.py::value_m`.

1. **Coverage credit gate** — an answered PQ takes full `w*coverage` only when **every armed oracle case bound to it is green** on the runner status face (`runs/oracle-status.json`, `oracle-status/1`). Any armed case not green — `fail`, `pending` (any instrumentation state; "unknown" is never "pass", #108 A), added after the last runner run, or an unreadable verdict file (fail-closed) — damps the PQ to the **blocked-tier credit** `beta*w`: claimed but unproven. Answered PQs with **no armed cases keep current behavior** (Phase 0/1: nothing to reconcile against). Blocked/unattempted tiers untouched.
2. **Aligned projection** — `v_oracle` / `v_oracle_norm` credit **only** answered-and-all-green PQs, weighted and normalized exactly like `v_norm`. `v_norm` high + `v_oracle` low is the standing narrative-inflation marker (v0.2 #129 consumes the gap; this card only produces it).

## Additive by construction (the module's #10/#14 convention)

- Raw `v_m` math, raw return keys, the raw `per_pq` contrib face and the raw history fields (`ts`/`v_m`/`v_norm`) are **byte-identical**; `v_oracle`/`v_oracle_norm` ride alongside in the return dict, history rows, and the `emit_snapshot` detail.
- The byte-stability guards in `tests/test_vm_normalization_10.py` pass **unmodified** (their fixtures carry no armed cases — the gate's fast path).
- **mission_stall untouched** (including the #127 tolerance fix): it consumes history as-is; the new row fields are additive.
- `oracle_runner.py` untouched.

## Linkage (single source, no new schema)

- PQ -> armed cases: `priority_ratio._load_oracle_cases` (`oracle/cases/*.yaml` `target_pq`) — the **same reader** the #107 Thompson case face consumes, so the value gate and the ranker can never disagree about case ownership.
- Status face: `convergence_check._load_oracle_status` — the same fail-closed reader the DRAIN probe uses; no drift with the acceptance gate.
- Both imports are lazy: no import cycle, and zero oracle IO when there is nothing to reconcile (no answered PQ or no case set).

## Tests (TDD: RED committed first, then GREEN)

`tests/test_value_reconciliation_133.py` — 15 tests: answered+red damps; green keeps full credit; no-case PQ unchanged; pending (instrumented and not) damps; mixed cases damp; unjudged case damps; corrupt status file damps fail-closed; `target_pq`-less case links nothing; v_oracle credits only oracle-green PQs (inflation fixture shows the gap); all-green -> currencies coincide; unarmed answered PQ: full `v_m`, zero `v_oracle`; blocked/unattempted contribute zero to `v_oracle`; history rows additive; oracle-less workspace byte-identical to the pre-#133 contract; weights respected in both currencies.

Acceptance checks from the issue:
- [x] Narrative-answered + red-case fixture: full credit denied, damped credit applied, gap projection visible
- [x] Green fixture: full credit
- [x] mission_stall fixtures unaffected (producer change only; suite green)
- [x] #111 fixture path untouched (its driver never calls `value_m`; its known pre-existing base failures are unrelated to this change — see Deviations)

## Verification

- `env -u KUNGLAO_VALUE_ALGO python3 -m pytest tests/ -q` — green except the 6 pre-existing base failures documented below (none touch this change's path).
- `ruff check scripts/mission_ledger.py tests/test_value_reconciliation_133.py` — clean.
- `tests/test_decide_regression_anchor.py` — 32 passed, no drift (value_m-derived quantities stopped being ranking inputs in #107): no re-pin needed.
- `scripts/` touched -> `deploy_manifest.py --write && --verify` (389 entries OK), regen committed.
- Review gate: one independent all-PASS code-reviewer per commit slice (`r1/r2/r3-133-reconcile`), minted and hook-verified per commit; no `--no-verify`, no stash.

## Deviations / notes for reviewers

- Base `8e17741` carries 6 pre-existing test failures (verified on the pristine base before any change): `test_env_check::test_all_pass_exit_0`, 4x `test_hypothesis_loop_integration_111` (its fixture cases predate the #126 admission lint — `load_cases` refuses files without `hypothesis_ref`/`channel`/`update_map`), and `test_kunglao_upgrade_726::test_already_current_is_noop`. Left untouched, out of scope.
- 4 pre-existing ruff F401 findings in test files (919/102/589) — reported, not fixed.
