### PR TITLE
feat(#142): statusline v2 — sparkline, entropy badge, health dots, task chip; project-scoped deployment

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -27,7 +27,7 @@ files:
   - src: hooks/heartbeat_touch.py
     dest: .claude/hooks/heartbeat_touch.py
     kind: hook
-    sha256: 995d0da90fbc029c8b38ed214c778e18d6a2d0eaaebb82dc6eeb7ffae85c4992
+    sha256: a212e9607c15df4b80e5a61451d6bb2b57c783e8da508369638f9a5441119701
   - src: hooks/lib_kunglao.py
     dest: .claude/hooks/lib_kunglao.py
     kind: hook
@@ -271,7 +271,7 @@ files:
   - src: scripts/deploy_manifest.py
     dest: .claude/scripts/deploy_manifest.py
     kind: scaffold
-    sha256: b7c3ee455d532e3e8a5131c8e7dce4e759073681f93144804f38a12a31d07cc8
+    sha256: 158f3b76380582dfd2ae7cfe20e0ad5ad9fd5c9fc93ef2bfac0ab09cf6d7fa1b
   - src: scripts/deploy_shim.py
     dest: .claude/scripts/deploy_shim.py
     kind: scaffold
@@ -391,7 +391,7 @@ files:
   - src: scripts/hook_activation.py
     dest: .claude/scripts/hook_activation.py
     kind: scaffold
-    sha256: b8118f3baef15418e8128f45eff4606da2e512c6e854928943d2bfba8d982daf
+    sha256: b053449390ac2446d180de0ff31e0171f8a0927b5cac62c2db949ec4606e0d79
   - src: scripts/hook_exit_codes.py
     dest: .claude/scripts/hook_exit_codes.py
     kind: scaffold
@@ -399,7 +399,7 @@ files:
   - src: scripts/hooks_selfcheck.py
     dest: .claude/scripts/hooks_selfcheck.py
     kind: scaffold
-    sha256: 2d27373ad3a736657e9d574ee746df11c52b6e9a2f013a708843f4901b02b6fd
+    sha256: 048aa15248109b199efd423626add964543c99ca909aebeddfc216f68196978f
   - src: scripts/hypothesis_seeder.py
     dest: .claude/scripts/hypothesis_seeder.py
     kind: scaffold
@@ -739,7 +739,7 @@ files:
   - src: scripts/statusline_snapshot.py
     dest: .claude/scripts/statusline_snapshot.py
     kind: scaffold
-    sha256: 811bdcc221f2117e3ada35c71f9b3ca4b4428a444ea8525d8b888c74fba16b86
+    sha256: e156d3f5a199755455ebdd3d595c1411cdf69c8b1aca9434d8cfbe6df27a5b09
   - src: scripts/strategy_metrics.py
     dest: .claude/scripts/strategy_metrics.py
     kind: scaffold
@@ -852,6 +852,10 @@ files:
     dest: .claude/scripts/zero_output_fingerprint.py
     kind: scaffold
     sha256: e189a0f71e3f09131f2d33f7586b3e222771fff36b4f3f69825729decb001660
+  - src: scripts/statusline_render.mjs
+    dest: .claude/scripts/statusline_render.mjs
+    kind: scaffold
+    sha256: eee1a7c81a78ef300aa161ea9e9880cc1b19e39f8fe8d7db07670292ab93a319
   - src: references/_INDEX.md
     dest: .claude/references/_INDEX.md
     kind: asset

--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -312,6 +312,10 @@ files:
     dest: .claude/scripts/encoding_lint.py
     kind: scaffold
     sha256: ddd56a84030f29bbd00a661d2c06d7108510e8196fa96f7dcb4c5f2a92c76007
+  - src: scripts/entropy_face.py
+    dest: .claude/scripts/entropy_face.py
+    kind: scaffold
+    sha256: 5e71725ce19814511aad020482df863f1527e05ccc76bd023f3484f78425ed69
   - src: scripts/env_check.py
     dest: .claude/scripts/env_check.py
     kind: scaffold
@@ -339,7 +343,7 @@ files:
   - src: scripts/event_taxonomy.py
     dest: .claude/scripts/event_taxonomy.py
     kind: scaffold
-    sha256: d09e0ef3a8b46a51197ac06bae40753e9c66b755630549ce8151f238111145e2
+    sha256: a5a7c2ecd9b0aa1c510c096f32ed982331f0dfb085678970816f04b6bf8be823
   - src: scripts/external_kicker.py
     dest: .claude/scripts/external_kicker.py
     kind: scaffold
@@ -383,7 +387,7 @@ files:
   - src: scripts/heartbeat_tick.py
     dest: .claude/scripts/heartbeat_tick.py
     kind: scaffold
-    sha256: e5d38a53d547b0b235c855f6b36aecea039d8272b7dafc9f5ca9cbd8cadf48d4
+    sha256: a4727f44d813f33d1af4db49088b5040beabe2978a7323cd9c6b4d54b7342a49
   - src: scripts/heartbeat_touch.py
     dest: .claude/scripts/heartbeat_touch.py
     kind: scaffold
@@ -483,7 +487,7 @@ files:
   - src: scripts/kunglao_log.py
     dest: .claude/scripts/kunglao_log.py
     kind: scaffold
-    sha256: 860ee9b60e35ca9f9fccc99f3dd1dcf09d5671fb7c9e53851e9da9459dba9045
+    sha256: 180f17bb70eb51d7d46459fa1ecec4d365da9ee865e685255087f14852727429
   - src: scripts/kunglao_record.py
     dest: .claude/scripts/kunglao_record.py
     kind: scaffold
@@ -739,7 +743,7 @@ files:
   - src: scripts/statusline_snapshot.py
     dest: .claude/scripts/statusline_snapshot.py
     kind: scaffold
-    sha256: e156d3f5a199755455ebdd3d595c1411cdf69c8b1aca9434d8cfbe6df27a5b09
+    sha256: 9a8e8b2bc9122dfb8c23b7f6fd38b8be43fdb4c9223f7e3fa8c5341ac624e400
   - src: scripts/strategy_metrics.py
     dest: .claude/scripts/strategy_metrics.py
     kind: scaffold
@@ -855,7 +859,7 @@ files:
   - src: scripts/statusline_render.mjs
     dest: .claude/scripts/statusline_render.mjs
     kind: scaffold
-    sha256: eee1a7c81a78ef300aa161ea9e9880cc1b19e39f8fe8d7db07670292ab93a319
+    sha256: 285f75f6eae4f2c019a92d4071b451d5e19fd2c0059779356528a3a51dfbe626
   - src: references/_INDEX.md
     dest: .claude/references/_INDEX.md
     kind: asset

--- a/hooks/heartbeat_touch.py
+++ b/hooks/heartbeat_touch.py
@@ -80,6 +80,16 @@ def main() -> int:
                     hbmod.append_tick_log(ws, actor="hook")
             except Exception:  # noqa: BLE001 — liveness substrate best-effort
                 pass
+            # #142: per-tool-use statusline snapshot refresh — the v2
+            # freshness contract rides the existing touch path so the
+            # working-period snapshot mtime advances ~= per tool call,
+            # without waiting for the 5-min tick. Fail-open: the statusline
+            # is cosmetic and must never block or fail a tool call.
+            try:
+                import statusline_snapshot  # scripts/ on path via #671 boot
+                statusline_snapshot.write_snapshot(ws)
+            except Exception:  # noqa: BLE001 — statusline never blocks tools
+                pass
             return 0
         except Exception as exc:  # noqa: BLE001 — never break the tool call
             print(f"heartbeat_touch: heartbeat refresh failed ({exc})",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -81,6 +81,7 @@ scripts (count in parens) · `tests` = exercised by tests/ only.
 | `env_manifest.py` | env-facts.yaml single source (issue #450): five fact families + LayoutConventions, priority chain yaml > task-spec > defaults; --render/--probe | CLI, lib(3), tests |
 | `env_state_probe.py` | env-state liveness snapshot writer → runs/env-state.json (tick step 9; #475) | lib(2), tests |
 | `env_repair_l1.py` | L1 deterministic env repair (adb-reconnect/vm-rediscover/mcp-rehandshake; idempotent, safe no-op; #475) | CLI, tests |
+| `entropy_face.py` | #142 follow-up entropy-honesty face, SINGLE SOURCE — frontier PQ categorical entropy (posteriors.PQCategorical; frontier = first non-answered PQ, deterministic max-entropy fallback) + trend vs the previous stored snapshot value (falling/flat/rising/unknown, TREND_EPS); dual-use display (owner principle): statusline_snapshot renders it AND heartbeat_tick report carries the same h_bits/h_pq/h_trend (decision-side gear-shift signal); fail-open (empty/unreadable ledger → h_bits=None / unknown) | heartbeat_tick, statusline_snapshot, tests |
 | `heartbeat.py` | convergence-gated heartbeat bookkeeping (lib for hook_activation) | lib(1), tests |
 | `heartbeat_tick.py` | heartbeat tick runner (hook-invoked + kunglao.py) | hooks, lib(1), tests |
 | `heartbeat_loop_prompt.py` | loop-prompt generator for the tick loop | hooks, tests |

--- a/scripts/deploy_manifest.py
+++ b/scripts/deploy_manifest.py
@@ -132,6 +132,11 @@ def build_entries() -> list[dict]:
         ents.append({"src": f"agents/{p.name}", "kind": "agent"})
     for p in sorted(SKILL_SCRIPTS.glob("*.py")):
         ents.append({"src": f"scripts/{p.name}", "kind": "scaffold"})
+    # #142: the statusline renderer rides the deployed scaffold like the
+    # scripts it reads — statusLine commands point at the workspace-local
+    # copy (<ws>/.claude/scripts/), so the workspace stays self-contained.
+    for p in sorted(SKILL_SCRIPTS.glob("*.mjs")):
+        ents.append({"src": f"scripts/{p.name}", "kind": "scaffold"})
     for d, p in _iter_asset_files():
         ents.append({"src": f"{d}/{p.relative_to(ROOT / d).as_posix()}",
                      "kind": "asset"})

--- a/scripts/entropy_face.py
+++ b/scripts/entropy_face.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+"""entropy_face.py — THE entropy-honesty face, single-source (#142 follow-up).
+
+Owner design principle (dual-use display): every displayed metric must be
+consumed by agent decisions AND informative to humans — a display-only
+metric is decoration. This module owns the frontier PQ categorical entropy
+and its trend so the two faces read THE SAME computed values:
+
+  - display face   — scripts/statusline_snapshot.py renders ``H1.3b`` from
+    ``face(ws)`` inside the snapshot (the renderer stays a dumb view);
+  - decision face  — scripts/heartbeat_tick.py carries ``h_bits``/``h_pq``/
+    ``h_trend`` in the tick report (runs/.heartbeat-tick.json); the future
+    policy/strategy arbiter reads the same module, never a re-computation.
+
+The trend baseline is the PREVIOUS STORED snapshot value
+(``runs/.kunglao-statusline.json`` → ``h_bits``): one stored history, no
+second trend ledger. Frontier = the mission ledger's first non-answered
+PQ; a frontier without a posterior falls back to the deterministic
+max-entropy PQ. Fail-open everywhere: an empty/unreadable posterior ledger
+is ``h_bits=None`` / ``trend="unknown"``, never an exception.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+SNAPSHOT_REL = Path("runs") / ".kunglao-statusline.json"
+
+# |ΔH| below this is flat — entropy only moves on posterior updates, so
+# float noise must never flip the gear-shift signal.
+TREND_EPS = 1e-6
+
+TREND_FALLING = "falling"   # learning (green face)
+TREND_RISING = "rising"     # luck/fake-progress alert (red face)
+TREND_FLAT = "flat"         # stall-suspect (amber face)
+TREND_UNKNOWN = "unknown"
+
+
+def prev_h_bits(ws: Path) -> float | None:
+    """The trend baseline: h_bits from the previous stored snapshot. None on
+    missing/corrupt file (first observation — nothing to compare yet)."""
+    try:
+        prev = json.loads((Path(ws) / SNAPSHOT_REL).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    h = prev.get("h_bits") if isinstance(prev, dict) else None
+    return float(h) if isinstance(h, (int, float)) else None
+
+
+def frontier_pq_id(ws: Path) -> str | None:
+    """任务前沿 = mission_ledger PQ 序里第一个未 answered 的 PQ id。
+    读失败/全答 -> None（调用方回退 max-entropy 或缺省）。"""
+    try:
+        led = yaml.safe_load((Path(ws) / "runs" / "mission_ledger.yaml")
+                             .read_text(encoding="utf-8")) or {}
+        for p in (led.get("mission", {}) or {}).get("pqs") or []:
+            if not isinstance(p, dict):
+                continue
+            if str(p.get("state") or "") != "answered":
+                return str(p.get("id")) if p.get("id") is not None else None
+    except (OSError, yaml.YAMLError, TypeError):
+        pass
+    return None
+
+
+def frontier_entropy(ws: Path) -> tuple[float | None, str | None]:
+    """Frontier PQ categorical entropy in bits (posteriors.PQCategorical).
+    Frontier without a posterior -> deterministic max-entropy PQ fallback;
+    empty/unreadable ledger -> (None, None)."""
+    try:
+        from posteriors import PosteriorLedger
+        led = PosteriorLedger.load(ws)
+        if not led.pqs:
+            return None, None
+        frontier_id = frontier_pq_id(ws)
+        pq = led.pqs.get(frontier_id) if frontier_id is not None else None
+        if pq is None:
+            pq = max(led.pqs.values(), key=lambda p: p.entropy())
+        return round(pq.entropy(), 4), pq.pq_id
+    except Exception:  # noqa: BLE001 — a face never breaks its caller
+        return None, None
+
+
+def trend(h_bits: float | None, prev_h: float | None) -> str:
+    """Entropy trend vs the previous stored value:
+    falling / flat / rising / unknown."""
+    if not isinstance(h_bits, (int, float)):
+        return TREND_UNKNOWN
+    if not isinstance(prev_h, (int, float)):
+        return TREND_UNKNOWN
+    delta = float(h_bits) - float(prev_h)
+    if delta < -TREND_EPS:
+        return TREND_FALLING
+    if delta > TREND_EPS:
+        return TREND_RISING
+    return TREND_FLAT
+
+
+def face(ws: Path, prev: dict | None = None) -> dict:
+    """THE single-source face: ``{"h_bits", "h_pq", "h_trend"}``.
+
+    ``prev`` is the previous snapshot dict when the caller already read it
+    (the snapshot writer has); otherwise the stored snapshot is read here
+    (the tick report face). Both routes share this one computation.
+    """
+    h_bits, h_pq = frontier_entropy(ws)
+    if prev is None:
+        prev_h = prev_h_bits(ws)
+    else:
+        prev_h = prev.get("h_bits") if isinstance(prev, dict) else None
+        prev_h = float(prev_h) if isinstance(prev_h, (int, float)) else None
+    return {"h_bits": h_bits, "h_pq": h_pq,
+            "h_trend": trend(h_bits, prev_h)}

--- a/scripts/event_taxonomy.py
+++ b/scripts/event_taxonomy.py
@@ -241,7 +241,7 @@ EMIT_ACTIONS = [
     "signal_gate_reject",    # #868 dual-gate rejection w/ disclosure mode
     "skill_install_staleness",  # #755 A1 executing-install git-lag face
     "stale_plan_on_new_evidence",
-    "statusline_snapshot",  # #883 per-tick statusline health-snapshot write face
+    "statusline_snapshot",  # #883 statusline health-snapshot write face (event-driven, #142)
     "taint_candidates",   # #692 WP5 hypothesis_seeder dexdc-taint->competitor extension
     "tool_call",          # #880 real emitter: Agent PostToolUse claim-granularity tool rows (worker_budget_sinks.post_check)
     "toolchain_manifest_check",  # #755 A6 toolchain-manifest face (code reality)

--- a/scripts/heartbeat_tick.py
+++ b/scripts/heartbeat_tick.py
@@ -450,8 +450,10 @@ def main(argv: list[str] | None = None) -> int:
     # claims' answers_question -> PQ answered (idempotent, every tick);
     # value_m() appends the V_m history point that feeds V_m/d_slope, gated
     # by _mission_history_due so the trajectory samples once per window.
+    settlement_hosted = False
     try:
         if (ws / "runs" / "mission_ledger.yaml").exists():
+            settlement_hosted = True
             import mission_ledger as _ml
             _ml.update(ws)
             if _mission_history_due(ws):
@@ -465,14 +467,42 @@ def main(argv: list[str] | None = None) -> int:
     except Exception:  # noqa: BLE001 — cockpit 采样永不打断 tick
         pass
 
-    # #883: pre-write the statusline health snapshot (O(1) atomic; the user's
-    # combined-statusline.mjs only reads this file — zero spawn). Fail-open
-    # like the cockpit sample above: a snapshot crash must never fail the tick.
+    # step 11b (#142 follow-up, dual-use display): the SAME entropy-honesty
+    # values the statusline renders ride the tick report. Computed AFTER the
+    # settlement/cockpit block, so the frontier reflects this tick's
+    # settlements, with the PREVIOUS STORED snapshot as the trend baseline
+    # (the snapshot below is not written yet — both faces trend against the
+    # same baseline). Decision-side consumers (policy/strategy arbiter)
+    # read the display's numbers from the single-source module, never a
+    # second computation. The report was serialized early (rc summary,
+    # :416) — re-serialize here so the face lands in
+    # runs/.heartbeat-tick.json, the same re-write pattern the #634
+    # breaker uses. Fail-open like every report field.
     try:
-        import statusline_snapshot as _sls
-        _sls.write_snapshot(ws)
-    except Exception:  # noqa: BLE001 — 快照永不打断 tick
+        import entropy_face
+        _h = entropy_face.face(ws)
+        report["h_bits"] = _h["h_bits"]
+        report["h_pq"] = _h["h_pq"]
+        report["h_trend"] = _h["h_trend"]
+        out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    except Exception:  # noqa: BLE001 — a report face never fails the tick
         pass
+
+    # step 11c (#142 refinement, event-driven): when this tick HOSTED a
+    # settlement/rollup (mission ledger present), that IS a semantic event
+    # — it moved the frontier, and the display would otherwise lag it
+    # indefinitely during LLM-idle. Write the snapshot here, AFTER the
+    # report face above (same computed values, same stored baseline) and
+    # with NO tool-use flow required. A ledger-less workspace hosts no
+    # settlement event and writes nothing; beyond this, writes stay
+    # event-only (tool use via heartbeat_touch) — stale is truthful.
+    # Fail-open like every display dependency.
+    if settlement_hosted:
+        try:
+            import statusline_snapshot as _sls
+            _sls.write_snapshot(ws)
+        except Exception:  # noqa: BLE001 — 快照永不打断 tick
+            pass
 
     action = report["action_taken"] or "(EMPTY — must be filled: what was dispatched/verified/resolved/reactivated)"
     print(f"heartbeat_tick: {sc} | selfcheck_rc={rc_sc} | renew_rc={rc_renew} | heartbeat_rc={rc_hb} | {hb}")

--- a/scripts/hook_activation.py
+++ b/scripts/hook_activation.py
@@ -790,6 +790,89 @@ def deploy_workspace_copy(ws: Path) -> dict:
 ORCHESTRATOR_MCP_MATCHER = (
     "mcp__ghidra__.*|mcp__x64dbg__.*|mcp__frida__.*")
 
+# #142: the statusline registration — NOT a hook. It rides the top-level
+# `statusLine` settings key: same #258 PROJECT-scoped file
+# (<workspace>/.claude/settings.json), different key, so it lives and dies
+# with the workspace like the hooks do. It stays in THIS module (THE
+# registration entry, #445) and must never enter WIRE_UP_HOOK_FILES — that
+# registry is hooks-only (event-keyed) and tests pin its set + shape.
+STATUSLINE_RENDER_FILE = "statusline_render.mjs"
+STATUSLINE_SETTINGS_KEY = "statusLine"
+
+
+def statusline_render_command(workspace: Path | None) -> str:
+    """The statusLine command: absolute `node <statusline_render.mjs>`.
+
+    Path resolution mirrors the hook deployment (#783/#752): the
+    workspace-local deployed copy (<ws>/.claude/scripts/, materialized by
+    deploy_workspace_copy) wins when present — the workspace stays
+    self-contained against skill-package upgrades; otherwise the executing
+    install's copy (canonical_install_root, durable-vs-ephemeral ruling).
+    POSIX slashes: the command runs via `sh -c`.
+    """
+    if workspace is not None:
+        local = (Path(workspace).resolve() / ".claude" / "scripts"
+                 / STATUSLINE_RENDER_FILE)
+        if local.exists():
+            return f"node {local.as_posix()}"
+    canonical = canonical_install_root() / "scripts" / STATUSLINE_RENDER_FILE
+    return f"node {canonical.as_posix()}"
+
+
+def register_statusline(workspace: Path) -> dict:
+    """#142 PROJECT-scoped statusLine registration (keep-alive repair face).
+
+    Writes ONLY <workspace>/.claude/settings.json — the #258 project target,
+    different key (`statusLine`, not `hooks`). There is deliberately NO
+    global_opt_in escape hatch: the user-global ~/.claude/settings.json is
+    never a statusline deployment target (the #258 lesson applies verbatim —
+    a global entry would outlive the workspace and render a dead snapshot).
+    Idempotent: overwrites our key in place, preserves every other key.
+    Maker-checker: re-reads the written file and only reports ok when the
+    re-read entry matches what was written.
+    """
+    ws = Path(workspace).resolve()
+    target = ws / ".claude" / "settings.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    existing: dict = {}
+    if target.exists():
+        try:
+            existing = json.loads(target.read_text(encoding="utf-8"))
+        except Exception:  # unparseable settings — rebuild our key alone
+            existing = {}
+    if not isinstance(existing, dict):
+        existing = {}
+    entry = {"type": "command", "command": statusline_render_command(ws)}
+    existing[STATUSLINE_SETTINGS_KEY] = entry
+    target.write_text(
+        json.dumps(existing, indent=2, ensure_ascii=False), encoding="utf-8")
+    # maker-checker: re-read from disk, never trust the in-memory dict.
+    try:
+        reread = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        reread = {}
+    ok = reread.get(STATUSLINE_SETTINGS_KEY) == entry
+    return {"ok": ok, "target": str(target), "command": entry["command"]}
+
+
+def _register_statusline_warn(ws: Path | None) -> None:
+    """Best-effort statusline registration for the wire-up flows: a failed
+    cosmetic registration must never fail hook wiring (hooks_selfcheck's
+    keep-alive face repairs it next tick)."""
+    if ws is None:
+        return
+    try:
+        res = register_statusline(ws)
+        if res.get("ok"):
+            print(f"OK: statusline registered -> {res['command']}")
+        else:
+            print(f"WARN: statusline registration self-check failed "
+                  f"({res.get('target')})", file=sys.stderr)
+    except Exception as exc:  # noqa: BLE001 — cosmetic, never blocks wiring
+        print(f"WARN: statusline registration failed ({exc})", file=sys.stderr)
+
+
+
 _DEPLOYED_WIRING = (
     # (event, matcher, hook_file) — mirrors register_hooks exactly.
     ("PreToolUse", "Agent", "env_check_gate.py"),
@@ -882,6 +965,9 @@ def register_hooks_deployed(ws: Path) -> int:
         raise HookWiringSelfcheckError(
             f"{settings_path} failed the deployed-mode self-check "
             f"({', '.join(check['mismatches'])})")
+    # #142: the statusline rides the same #258 project file (different key)
+    # so it lives and dies with the workspace — best-effort (cosmetic face).
+    _register_statusline_warn(ws)
     print(f"OK: registered {added} deployed hook entries")
     return 0
 
@@ -1072,6 +1158,11 @@ def register_hooks(workspace: Path | None = None,
             f"{settings_path} failed the post-registration self-check "
             f"({', '.join(check['mismatches'])}) — the hooks are NOT "
             f"verifiably registered on a layer that fires (#445)")
+    # #142: PROJECT-scoped statusline rides the same wire-up (different
+    # settings key). NEVER on the global_opt_in path — the user-global
+    # settings file is not a statusline deployment target (no opt-in hatch).
+    if not global_opt_in:
+        _register_statusline_warn(workspace)
     return count
 
 

--- a/scripts/hooks_selfcheck.py
+++ b/scripts/hooks_selfcheck.py
@@ -127,6 +127,40 @@ def rebuild_project_level(workspace: Path) -> dict:
         return {"rebuilt": False, "error": str(exc)}
 
 
+def check_statusline(settings_path: Path) -> dict:
+    """#142 keep-alive face: the project-level `statusLine` settings key must
+    reference the repo renderer (scripts/statusline_render.mjs). Not a hook —
+    a different key in the same #258 project file, checked by the same
+    keep-alive discipline (lives and dies with the workspace). Absent file /
+    unparseable settings -> not ok (repair face rewrites the key)."""
+    try:
+        from hook_activation import STATUSLINE_RENDER_FILE, STATUSLINE_SETTINGS_KEY
+    except Exception as exc:  # noqa: BLE001 — keep-alive never crashes the tick
+        return {"present": False, "ok": True, "command": None,
+                "detail": f"statusline constants unavailable (fail-open): {exc}"}
+    try:
+        s = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return {"present": False, "ok": False, "command": None,
+                "detail": f"unreadable settings ({exc})"}
+    entry = s.get(STATUSLINE_SETTINGS_KEY) if isinstance(s, dict) else None
+    cmd = str(entry.get("command", "")) if isinstance(entry, dict) else None
+    ok = (isinstance(entry, dict) and entry.get("type") == "command"
+          and STATUSLINE_RENDER_FILE in (cmd or ""))
+    return {"present": bool(entry), "ok": ok, "command": cmd}
+
+
+def repair_statusline(ws: Path) -> dict:
+    """#142 repair face: re-register the project-scoped statusLine key via
+    hook_activation.register_statusline (THE registration entry). Returns
+    the registration report; never raises."""
+    try:
+        from hook_activation import register_statusline
+        return register_statusline(ws)
+    except Exception as exc:  # noqa: BLE001 — keep-alive never crashes the tick
+        return {"ok": False, "error": str(exc)}
+
+
 def check_stamp_version(ws: Path) -> dict:
     """#536: three-carrier template version stamp consistency.
 
@@ -167,6 +201,22 @@ def main() -> int:
             # maker-checker: re-read the file — don't trust the subprocess claim.
             proj_check = check_settings(proj_settings)
 
+    # #142: statusline keep-alive — same project file, different key. The
+    # hooks rebuild above already re-registers the statusline (wire-up flow);
+    # when hooks were fine but the statusLine key drifted, repair just it.
+    # Cosmetic face: a failed repair is reported and WARNed, never fails
+    # the tick (the rc weights stay hook-owned).
+    sl_check = check_statusline(proj_settings)
+    sl_repair: dict = {}
+    if not sl_check.get("ok"):
+        sl_repair = repair_statusline(ws)
+        if sl_repair.get("ok"):
+            sl_check = check_statusline(proj_settings)
+        else:
+            print(f"WARNING: statusline keep-alive repair failed "
+                  f"({sl_repair.get('error') or sl_repair}) — the statusLine "
+                  f"key stays missing from {proj_settings}", file=sys.stderr)
+
     report = {
         "ts": utc_now(),
         "project_settings": str(proj_settings),
@@ -175,6 +225,7 @@ def main() -> int:
         "user_level": user_check,
         "user_migration_warning": migration_warning,
         "project_rebuild": rebuilt,
+        "statusline": {**sl_check, "repair": sl_repair},
         # #536: stamp faults = per-carrier missing/mismatch map
         "template_version_stamps": check_stamp_version(ws),
     }
@@ -187,6 +238,8 @@ def main() -> int:
 
     proj_ok = proj_check.get("hooks_segment") and not proj_check.get("missing")
     status = f"project={'OK' if proj_ok else 'MISSING ' + str(proj_check.get('missing'))}"
+    # #142: statusline keep-alive rides the status line (non-fatal).
+    status += f" statusline={'OK' if sl_check.get('ok') else 'MISSING'}"
     if migration_warning:
         status += " (global has leftover kunglao hooks — migrate)"
     # #536: stamp faults ride the status line (non-fatal here — see

--- a/scripts/kunglao_log.py
+++ b/scripts/kunglao_log.py
@@ -90,7 +90,7 @@ LEGACY_ACTORS = frozenset({
     "plan_drift", "plan_drift_detector", "priority", "priority_ratio",
     "queue", "recall_inject", "refutation_propagate", "rho_checkpoint",
     "rollup", "retract_claim", "rho_verifier", "scan_worker_budget",
-    "statusline_snapshot",  # #883 per-tick statusline health-snapshot writer
+    "statusline_snapshot",  # #883 statusline health-snapshot writer (event-driven, #142)
     "telemetry", "think_seat", "toolchain_install", "tuition_curve",
     "update_index", "upgrade", "user", "user_signal", "verdict_scorer",
     "verify_status_watch", "verifier", "violation_capture",

--- a/scripts/statusline_render.mjs
+++ b/scripts/statusline_render.mjs
@@ -1,6 +1,38 @@
 #!/usr/bin/env node
 // statusline_render.mjs — kunglao statusline v2 renderer (issue #142).
 //
+// DUAL-USE MAP (owner principle: every displayed metric is consumed by agent
+// decisions AND informative to humans — display-only = decoration = cut).
+// Every chip names its agent-side consumer; the computation is single-sourced
+// in the producer / shared modules, never in this view layer:
+//
+//   chip                  human meaning                agent-side consumer
+//   --------------------  ---------------------------  --------------------------------------
+//   state glyph+label     loop phase at a glance       #634 noop-breaker stall fingerprint +
+//   (cyan/amber/red)                                   #597/#754 liveness gates (dispatch +
+//                                                      budget gates read the same inputs)
+//   sparkline + %         a_t momentum as shape        a_t momentum + budget pacing (v_norm
+//   (v_hist, v_norm)                                   series drives eta/budget extrapolation;
+//                                                       producer-owned, tick-sampled)
+//   H bits + trend        learning honesty (v rising   strategy-arbiter gear-shift signal —
+//   (entropy_face)        while H flat = luck/fake)    the SAME h_bits/h_trend ride the tick
+//                                                      report face (scripts/entropy_face.py);
+//                                                      also gates exploration budget
+//   health dots x3        oracle / retro / dormant     #473 completion-gate power (oracle),
+//                         one-glance liveness          #38 backtrack gate (retro lag < 8),
+//                                                      #127 detector liveness (no DORMANT)
+//   task chip             who is working on what NOW   lib_kunglao worker-status protocol —
+//   (now{claim,op})       (idle · last C-<id> parked)  the same scan feeds dispatch gate +
+//                                                      capacity checks (check_workers_lt_3)
+//   flash (⚡, 5s)        milestone/state-change ping  producer-detected triggers the tick's
+//                                                      action loop already acts on
+//   eta (snapshot-level;  time remaining via flash    budget pacing (eta_ticks extrapolation,
+//   not a v2 chip)        text "剩 ~Nt"                tuition_curve._slope)
+//
+// Designed, v0.2-gated — slots stay unimplemented until their decision
+// consumers land: policy-belief chip (favored operator composition,
+// #12/#13) and Class-2 event light (self-anchor/vacuous attempts, #130).
+//
 // The repo-side renderer: a PURE VIEW over the producer snapshot
 // (<ws>/runs/.kunglao-statusline.json, written by scripts/statusline_snapshot.py).
 // All kunglao data is producer-owned — this script reads the ONE snapshot
@@ -13,10 +45,13 @@
 //
 // Contract: read stdin JSON once, pass through to claude-hud verbatim (when
 // present), then append the kunglao line to the LAST line (Claude Code
-// renders only the last statusline line). Watchdog kept: snapshot mtime
-// older than T_LIVE -> render frozen "down" frame, never trust a stale
-// "healthy" frame. Freshness kept: heartbeat_touch refreshes the snapshot
-// per tool use (#142), idle refreshes per tick.
+// renders only the last statusline line). Watchdog (three-valued, see the
+// event-driven contract below the imports): fresh -> snapshot's own state
+// face; stale within liveness policy -> IDLE face (dim, truthful — alive,
+// no events); beyond policy or snapshot state "down" -> frozen red DOWN.
+// Writes are event-driven only: heartbeat_touch refreshes the snapshot per
+// tool use and the tick writes only after hosting a settlement; there is
+// no fixed tick-cadence refresh (idle staleness is truthful).
 //
 // Line shape (owner-approved, issue #142):
 //   ◈ analyzing ▂▄▆█ 42% H1.3b ●●● │ C-409 sign-algo probe ⚡CASE-GREEN
@@ -31,7 +66,24 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync, statSync, existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 
-const T_LIVE_MS = 35 * 60 * 1000; // align with liveness_policy.HEARTBEAT_STALE_MINUTES
+// Event-driven contract (#142 refinement): snapshot WRITES happen on
+// semantic events only — tool use via hooks/heartbeat_touch, plus
+// tick-hosted settlement/rollup (heartbeat_tick writes right after its
+// settlement block); RENDERS are free pulls. Beyond that the 5-min tick
+// keeps its monitoring/breaker duties but is NO display dependency. An
+// idle workspace writes nothing — stale is TRUTHFUL. Staleness is
+// therefore THREE-VALUED, not binary — raw mtime
+// age alone conflates "idle" (alive, no events — stale is TRUTHFUL) with
+// "dead" (broken):
+//   fresh                    -> render the snapshot's own state face
+//   stale <= policy (idle)   -> alive+no-events: render the state machine's
+//                               IDLE face (its own dim-blue-gray idle hue,
+//                               never red)
+//   stale > policy, or the   -> the liveness face says dead: DOWN, red,
+//   snapshot itself is down     frozen (empty dots)
+// Horizons mirror scripts/liveness_policy.py (renderer cannot import it):
+const T_IDLE_MS = 5 * 60 * 1000;   // TICK_INTERVAL_DEFAULT_MIN — a full tick with zero tool events = idle
+const T_DEAD_MS = 35 * 60 * 1000;  // HEARTBEAT_STALE_MINUTES — beyond liveness policy = dead
 // Test seam: KUNGLAO_STATUSLINE_HUD='' disables the HUD passthrough so
 // renderer tests are deterministic on machines that do have the plugin.
 const HUD = process.env.KUNGLAO_STATUSLINE_HUD !== undefined
@@ -163,12 +215,21 @@ function renderKunglao(snapPath, nowMs) {
   } catch {
     return '';
   }
-  const down = nowMs - mtime > T_LIVE_MS;
+  const ageMs = Math.max(0, nowMs - mtime);
 
-  const state = down ? 'down' : (typeof snap.state === 'string' ? snap.state : 'idle');
+  // Three-valued staleness (see the event-driven contract above): the
+  // snapshot's own state field is the liveness face's verdict (producer
+  // computes "down" from the heartbeat/ledger probes); mtime age only
+  // separates fresh from idle-stale from beyond-policy dead.
+  const snapState = typeof snap.state === 'string' ? snap.state : 'idle';
+  const down = snapState === 'down' || ageMs > T_DEAD_MS;
+  const idleStale = !down && ageMs > T_IDLE_MS;
+  const state = down ? 'down' : (idleStale ? 'idle' : snapState);
   const stateLabel = STATE_LABELS[state] || 'idle';
   const glyph = GLYPHS[state] || '○';
-  const hue = down ? 0 : (snap.color?.hue ?? STATE_HUE_FALLBACK[state] ?? 220);
+  const hue = down ? 0
+    : (idleStale ? STATE_HUE_FALLBACK.idle
+                 : (snap.color?.hue ?? STATE_HUE_FALLBACK[state] ?? 220));
   const stateColor = (s) =>
     `\x1b[38;5;${Math.max(1, Math.min(230, Math.round((hue / 360) * 230) + 16))}m${s}\x1b[0m`;
 

--- a/scripts/statusline_render.mjs
+++ b/scripts/statusline_render.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+// statusline_render.mjs — kunglao statusline v2 renderer (issue #142).
+//
+// The repo-side renderer: a PURE VIEW over the producer snapshot
+// (<ws>/runs/.kunglao-statusline.json, written by scripts/statusline_snapshot.py).
+// All kunglao data is producer-owned — this script reads the ONE snapshot
+// JSON and nothing else on the kunglao side (zero spawn, zero raw-log reads;
+// the external combined-statusline's direct rl-signals.jsonl read was the
+// contract violation #142 removes, and its undefined `blocked` reference on
+// the coarse path — a strict-mode ReferenceError that killed the whole
+// statusline — is the crash class this renderer structurally cannot have:
+// every field is read off the parsed snapshot with ?? fallbacks).
+//
+// Contract: read stdin JSON once, pass through to claude-hud verbatim (when
+// present), then append the kunglao line to the LAST line (Claude Code
+// renders only the last statusline line). Watchdog kept: snapshot mtime
+// older than T_LIVE -> render frozen "down" frame, never trust a stale
+// "healthy" frame. Freshness kept: heartbeat_touch refreshes the snapshot
+// per tool use (#142), idle refreshes per tick.
+//
+// Line shape (owner-approved, issue #142):
+//   ◈ analyzing ▂▄▆█ 42% H1.3b ●●● │ C-409 sign-algo probe ⚡CASE-GREEN
+// Four-meaning palette ONLY (color IS data, no rainbow):
+//   cyan = working (state)          green = learning/healthy (uptrend, H falling, solid dots)
+//   amber = stall-suspect (H flat, retro-lag >= 8, DORMANT present)
+//   red = broken (down, empty dot)
+// Deleted as noise vs the external renderer: `CONVERGENCE HEALTH:` duplicate
+// text, tick number, slope chip.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, statSync, existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+const T_LIVE_MS = 35 * 60 * 1000; // align with liveness_policy.HEARTBEAT_STALE_MINUTES
+// Test seam: KUNGLAO_STATUSLINE_HUD='' disables the HUD passthrough so
+// renderer tests are deterministic on machines that do have the plugin.
+const HUD = process.env.KUNGLAO_STATUSLINE_HUD !== undefined
+  ? process.env.KUNGLAO_STATUSLINE_HUD
+  : `${process.env.HOME}/.claude/plugins/cache/claude-hud/claude-hud/0.1.0/dist/index.js`;
+
+const FLASH_WINDOW_MS = 5000; // 5s fade window (render-clock side, kept)
+
+// Four-meaning palette (ANSI SGR; color IS data — no decorative hues).
+const PALETTE = {
+  cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  amber: (s) => `\x1b[33m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+};
+// State hue system (kept): glyph + label ride the snapshot's state color.
+const STATE_HUE_FALLBACK = { analyzing: 140, toss: 190, idle: 220, stall: 45, down: 0, flawless: 48 };
+const GLYPHS = { analyzing: '◈', toss: '◇', idle: '○', stall: '◌', down: '✖', flawless: '◉' };
+const STATE_LABELS = {
+  analyzing: 'analyzing', toss: 'tossing', idle: 'idle',
+  stall: 'stall', down: 'DOWN', flawless: 'flawless',
+};
+const SPARK_CHARS = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+
+function readStdin() {
+  try {
+    return readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function findSnapshot(startDir) {
+  const start = resolve(startDir);
+  // Probe DOWN one level first: session cwd is often the project root with
+  // the workspace a child (known kunglao workspace dir names), then walk UP
+  // from the dir (cwd may be inside the ws). Bounded, no globbing.
+  const childDirs = ['analysis_workspace', 'malware-analysis-workspace'];
+  for (const name of childDirs) {
+    const p = join(start, name, 'runs', '.kunglao-statusline.json');
+    if (existsSync(p)) return p;
+  }
+  let dir = start;
+  for (let i = 0; i < 4; i++) {
+    const p = join(dir, 'runs', '.kunglao-statusline.json');
+    if (existsSync(p)) return p;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+// Sparkline of the last ~8 v_norm points (issue #142: momentum as shape).
+// Normalized within the window — the shape is the signal, not the level.
+function sparkline(vHist) {
+  if (!Array.isArray(vHist)) return '';
+  const vals = vHist.map((v) => Number(v)).filter((v) => Number.isFinite(v));
+  if (vals.length === 0) return '';
+  const lo = Math.min(...vals);
+  const hi = Math.max(...vals);
+  const span = hi - lo;
+  return vals
+    .map((v) => SPARK_CHARS[Math.min(7, Math.floor((((v - lo) / (span || 1)) * 7.99)))])
+    .join('');
+}
+
+// Uptrend within the sparkline window: last point strictly above the first
+// is learning (green); flat/declining is stall-suspect (amber).
+function isUptrend(vHist) {
+  if (!Array.isArray(vHist)) return false;
+  const vals = vHist.map((v) => Number(v)).filter((v) => Number.isFinite(v));
+  if (vals.length < 2) return false;
+  return vals[vals.length - 1] > vals[0];
+}
+
+// Health dots x3: oracle registered / retro lag < 8 / no DORMANT.
+// ok -> green solid; suspect (retro lag, DORMANT) -> amber; broken (oracle
+// unregistered) -> red; down -> all red empty (broken face).
+function healthDots(health, down) {
+  if (!health || typeof health !== 'object') return '';
+  const specs = [
+    { ok: health.oracle, suspect: false },
+    { ok: health.retro, suspect: true },
+    { ok: health.dormant, suspect: true },
+  ];
+  return specs
+    .map(({ ok, suspect }) => {
+      if (down) return PALETTE.red('○');
+      if (ok) return PALETTE.green('●');
+      return suspect ? PALETTE.amber('●') : PALETTE.red('●');
+    })
+    .join('');
+}
+
+// Current-task chip: `C-<id> <op short>` from the active worker; `idle ·
+// last C-<id>` when parked. Producer truncates op to 24 chars; defensive
+// re-trim here so the chip budget holds even on hand-built snapshots.
+function taskChip(now) {
+  if (!now || typeof now !== 'object') return '';
+  const claim = typeof now.claim === 'string' ? now.claim.trim() : '';
+  const op = typeof now.op === 'string' ? now.op.trim().slice(0, 24) : '';
+  if (claim && op) return PALETTE.cyan(`${claim} ${op}`);
+  if (claim) return PALETTE.cyan(`idle · last ${claim}`);
+  return '';
+}
+
+function entropyBadge(snap) {
+  if (typeof snap.h_bits !== 'number' || !Number.isFinite(snap.h_bits)) return '';
+  const text = `H${snap.h_bits.toFixed(1)}b`;
+  const trend = snap.h_trend;
+  if (trend === 'falling') return PALETTE.green(text); // learning
+  if (trend === 'rising') return PALETTE.red(text);    // luck/fake-progress alert
+  return PALETTE.amber(text);                          // flat/unknown = suspect
+}
+
+function renderKunglao(snapPath, nowMs) {
+  let snap;
+  try {
+    snap = JSON.parse(readFileSync(snapPath, 'utf8'));
+  } catch {
+    return '';
+  }
+  if (!snap || typeof snap !== 'object') return '';
+  let mtime = 0;
+  try {
+    mtime = statSync(snapPath).mtimeMs;
+  } catch {
+    return '';
+  }
+  const down = nowMs - mtime > T_LIVE_MS;
+
+  const state = down ? 'down' : (typeof snap.state === 'string' ? snap.state : 'idle');
+  const stateLabel = STATE_LABELS[state] || 'idle';
+  const glyph = GLYPHS[state] || '○';
+  const hue = down ? 0 : (snap.color?.hue ?? STATE_HUE_FALLBACK[state] ?? 220);
+  const stateColor = (s) =>
+    `\x1b[38;5;${Math.max(1, Math.min(230, Math.round((hue / 360) * 230) + 16))}m${s}\x1b[0m`;
+
+  // Value: sparkline of v_hist + percent (fine v_norm preferred, coarse PQ
+  // fraction as fallback). The coarse path is a FIRST-CLASS render, not an
+  // afterthought: `blocked` and friends are always declared via ?? fallbacks
+  // (the external renderer's undefined `blocked` on exactly this path was
+  // the line-137 strict-mode crash).
+  const vHist = Array.isArray(snap.v_hist) ? snap.v_hist : [];
+  const sparks = sparkline(vHist);
+  const trendUp = isUptrend(vHist);
+  const pq = snap.pq && typeof snap.pq === 'object' ? snap.pq : {};
+  const answered = Number.isFinite(Number(pq.answered)) ? Number(pq.answered) : 0;
+  const total = Number.isFinite(Number(pq.total)) ? Number(pq.total) : 0;
+  const blocked = Number.isFinite(Number(pq.blocked)) ? Number(pq.blocked) : 0; // always declared
+  let pct = null;
+  if (Number.isFinite(Number(snap.v_norm)) && Number(snap.v_norm) > 0) {
+    pct = Number(snap.v_norm);
+  } else if (total > 0) {
+    pct = answered / total;
+  }
+  const valueColor = down ? PALETTE.red : (trendUp ? PALETTE.green : PALETTE.amber);
+  let valueSeg = '';
+  if (pct !== null) {
+    const bar = '█'.repeat(Math.round(pct * 10)) + '░'.repeat(10 - Math.round(pct * 10));
+    const barText = sparks ? `${sparks} ${(pct * 100).toFixed(0)}%` : `${bar} ${(pct * 100).toFixed(0)}%`;
+    valueSeg = valueColor(barText);
+  } else if (total > 0) {
+    valueSeg = valueColor(`PQ ${answered}/${total}` + (blocked ? ` (blocked ${blocked})` : ''));
+  }
+
+  const badge = entropyBadge(snap);
+  const dots = healthDots(snap.health, down);
+  const chip = taskChip(snap.now);
+
+  // Flash (5s window, kept): producer-detected triggers ship {seq, ts, text}.
+  let flash = '';
+  if (snap.flash?.text && snap.flash?.ts) {
+    try {
+      const t = Date.parse(snap.flash.ts);
+      if (Number.isFinite(t) && nowMs - t < FLASH_WINDOW_MS) {
+        flash = ` ${PALETTE.amber(`⚡${snap.flash.text}`)}`;
+      }
+    } catch { /* ignore */ }
+  }
+
+  const parts = [stateColor(`${glyph} ${stateLabel}`)];
+  if (valueSeg) parts.push(valueSeg);
+  if (badge) parts.push(badge);
+  if (dots) parts.push(dots);
+  if (chip) parts.push(PALETTE.dim('│'), chip);
+  if (flash) parts.push(flash.trim());
+  return parts.join(' ');
+}
+
+function main() {
+  const stdinText = readStdin();
+  let hudOut = '';
+  if (HUD) {
+    try {
+      if (existsSync(HUD)) {
+        hudOut = execFileSync('node', [HUD], { input: stdinText, encoding: 'utf8', timeout: 8000 });
+      }
+    } catch {
+      hudOut = '';
+    }
+  }
+
+  const cwd = (() => {
+    try {
+      const j = JSON.parse(stdinText);
+      return j?.workspace?.current_dir || process.cwd();
+    } catch {
+      return process.cwd();
+    }
+  })();
+
+  const snapPath = findSnapshot(cwd);
+  const kunglaoSeg = snapPath ? renderKunglao(snapPath, Date.now()) : '';
+
+  const lines = hudOut.replace(/\n+$/, '').split('\n').filter((l) => l !== '');
+  if (!kunglaoSeg) {
+    process.stdout.write(hudOut);
+    return;
+  }
+  // kunglao metrics on their OWN last line (Claude Code renders only the
+  // last statusline line); HUD lines stay above untouched.
+  lines.push(kunglaoSeg);
+  process.stdout.write(lines.join('\n') + '\n');
+}
+
+main();

--- a/scripts/statusline_snapshot.py
+++ b/scripts/statusline_snapshot.py
@@ -33,13 +33,30 @@ register (OPEN count), noop breaker (stall fingerprint, #634), heartbeat
 file mtime (alive, #534/#754), ledger tail (activity rate + sparks,
 #459), hooks_selfcheck's registry constants (deployed, #381/#258).
 
+#142 (statusline v2, schema 2) — the snapshot becomes the SINGLE data
+owner for the whole kunglao segment (producer-owned data): it gains
+``v_hist`` (last ~8 v_norm points — the sparkline), ``h_bits``/``h_pq``/
+``h_trend`` (frontier PQ categorical entropy from runs/posteriors.yaml
+via posteriors.PQCategorical.entropy; trend vs the previous stored
+value), ``health{oracle,retro,dormant}`` (#473 oracle marker check /
+retro lag < 8 / #127 no DORMANT detectors), ``now{claim,op}`` (active
+worker from the lib_kunglao worker-status scan; op is a <=24-char task
+phrase), ``pq_rows`` + ``difficulty`` (the fine-grained PQ collection
+the external renderer used to read DIRECTLY from rl-signals.jsonl — a
+zero-spawn contract violation; that read is gone), and named phase-2
+placeholder slots (``v_oracle_gap`` #133, ``baseline_inv_k`` #129) so
+the renderer never changes twice.
+
 Usage: python statusline_snapshot.py <workspace>
-(attached from heartbeat_tick after the #873 cockpit sample; fail-open).
+(attached from heartbeat_tick after the #873 cockpit sample AND from the
+heartbeat_touch per-tool-use path since #142 — working-period freshness
+~= per tool call; fail-open everywhere).
 """
 from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import datetime
 from pathlib import Path
@@ -56,6 +73,12 @@ from liveness_policy import HEARTBEAT_STALE_MINUTES, TICK_INTERVAL_DEFAULT_MIN
 SKILL_DIR = Path(__file__).resolve().parent.parent  # kunglao-agent/ root
 SNAPSHOT_REL = Path("runs") / ".kunglao-statusline.json"
 
+# #142: snapshot schema version — 2 adds the producer-owned v2 fields
+# (v_hist / h_bits / h_trend / health / now / pq_rows / difficulty and the
+# phase-2 placeholder slots). No-backcompat policy: readers probe the field
+# set, never a version ladder.
+SCHEMA_VERSION = 2
+
 TICK_MINUTES = TICK_INTERVAL_DEFAULT_MIN          # 5 — elapsed/eta wall bridge
 LEDGER_STALE_MINUTES = 90                          # ledger tail alive budget
 TOSS_WINDOW_S = 120                                # dispatch -> toss window
@@ -69,6 +92,14 @@ LEDGER_TAIL_BYTES = 65_536                         # bounded O(64KB) tail read
 # #882 probe thresholds (the cockpit trio's WARN lines)
 BACKTRACK_LAG_WARN = 8                             # settlements since retro
 UNATTRIBUTED_RATE_WARN = 0.30                      # unattributed fraction
+# #142 v2 fields
+V_HIST_POINTS = 8                                  # sparkline window (~8 points)
+H_TREND_EPS = 1e-6                                 # |ΔH| below this = flat
+NOW_OP_MAX_CHARS = 24                              # task-chip phrase budget
+# Display-only worker-status field extraction (kunglao_status precedent:
+# NOT liveness parsing — liveness stays in lib_kunglao's protocol owners).
+_CLAIM_RE = re.compile(r"claim\s*:?\s+([A-Za-z0-9][\w.-]*)")
+_STEP_RE = re.compile(r"step\s*:?\s+([^|\n]+)")
 
 # Color semantics are COMPUTED Python-side (kunglao logic stays out of Node);
 # Node only interpolates brightness on its render clock (breathing) and ramps
@@ -429,7 +460,7 @@ def _mission_state(ws: Path) -> dict:
     out = {"answered": 0, "blocked": 0, "unattempted": 0, "total": 0,
            "coverage": 0.0, "v_m": 0.0, "v_norm": 0.0,
            "d_slope": 0.0, "d_slope_norm": 0.0, "eta_ticks": None,
-           "elapsed_ticks": 0, "started_ts": None}
+           "elapsed_ticks": 0, "started_ts": None, "v_hist": []}
     try:
         led = yaml.safe_load((ws / "runs" / "mission_ledger.yaml")
                              .read_text(encoding="utf-8")) or {}
@@ -452,6 +483,7 @@ def _mission_state(ws: Path) -> dict:
             out["d_slope"] = round(slope, 6)
             if norm:
                 out["v_norm"] = round(norm[-1], 6)
+                out["v_hist"] = [round(x, 6) for x in norm[-V_HIST_POINTS:]]
                 norm_slope = _slope(norm[-5:])
                 out["d_slope_norm"] = round(norm_slope, 6)
                 out["eta_ticks"] = (round((1.0 - norm[-1]) / norm_slope, 2)
@@ -464,31 +496,39 @@ def _mission_state(ws: Path) -> dict:
     return out
 
 
-def _ledger_activity(ws: Path, now_s: float) -> dict:
-    """账本尾部（末 64KB 有界读）-> 近窗事件数 + 最近 dispatch 是否在 toss 窗口。"""
+def _ledger_rows(ws: Path) -> list[dict]:
+    """账本尾部（末 64KB 有界读）-> 已解析行。首行可能残缺，丢弃。"""
     logs = ws / "runs" / "logs"
     try:
         latest = max((p for p in logs.glob("kunglao-*.jsonl") if p.is_file()),
                      key=lambda p: p.stat().st_mtime, default=None)
         if latest is None:
-            return {"events_recent": 0, "spark_count": 0, "toss": False}
+            return []
         with latest.open("rb") as f:
             f.seek(0, os.SEEK_END)
             size = f.tell()
             f.seek(max(0, size - LEDGER_TAIL_BYTES))
             tail = f.read().decode("utf-8", errors="replace")
     except OSError:
-        return {"events_recent": 0, "spark_count": 0, "toss": False}
+        return []
     lines = tail.splitlines()
     if len(lines) > 1:
         lines = lines[1:]  # drop possibly-partial first line
-    recent = 0
-    toss = False
+    rows = []
     for line in lines:
         try:
-            row = json.loads(line)
+            rows.append(json.loads(line))
         except json.JSONDecodeError:
             continue
+    return rows
+
+
+def _ledger_activity(ws: Path, now_s: float) -> dict:
+    """账本尾部 -> 近窗事件数 + 最近 dispatch 是否在 toss 窗口。"""
+    rows = _ledger_rows(ws)
+    recent = 0
+    toss = False
+    for row in rows:
         ts = _parse_ts(row.get("ts"))
         if ts is not None and now_s - ts <= ACTIVITY_WINDOW_S:
             recent += 1
@@ -498,6 +538,172 @@ def _ledger_activity(ws: Path, now_s: float) -> dict:
     return {"events_recent": recent,
             "spark_count": min(3, recent),  # sparks: event density, capped
             "toss": toss}
+
+
+# ---------------------------------------------------------------------------
+# #142 v2 data plane (producer-owned: the renderer never reads raw logs)
+# ---------------------------------------------------------------------------
+
+def _frontier_pq_id(ws: Path) -> str | None:
+    """任务前沿 = mission_ledger PQ 序里第一个未 answered 的 PQ id。
+    读失败/全答 -> None（调用方回退 max-entropy 或缺省）。"""
+    try:
+        led = yaml.safe_load((ws / "runs" / "mission_ledger.yaml")
+                             .read_text(encoding="utf-8")) or {}
+        for p in (led.get("mission", {}) or {}).get("pqs") or []:
+            if not isinstance(p, dict):
+                continue
+            if str(p.get("state") or "") != "answered":
+                return str(p.get("id")) if p.get("id") is not None else None
+    except (OSError, yaml.YAMLError, TypeError):
+        pass
+    return None
+
+
+def _frontier_entropy(ws: Path) -> tuple[float | None, str | None]:
+    """#142 学习诚实度徽章的数据面：前沿 PQ categorical 熵（bit）。
+
+    runs/posteriors.yaml -> posteriors.PQCategorical.entropy()。前沿 id 取
+    _frontier_pq_id；前沿无后验时回退全库 max-entropy PQ（仍是一个确定性的
+    熵读数）；账本空/读失败 -> (None, None)（渲染端整体省略徽章，fail-open）。
+    """
+    try:
+        from posteriors import PosteriorLedger
+        led = PosteriorLedger.load(ws)
+        if not led.pqs:
+            return None, None
+        frontier_id = _frontier_pq_id(ws)
+        pq = led.pqs.get(frontier_id) if frontier_id is not None else None
+        if pq is None:
+            pq = max(led.pqs.values(), key=lambda p: p.entropy())
+        return round(pq.entropy(), 4), pq.pq_id
+    except Exception:  # noqa: BLE001 — 快照永不打断 tick
+        return None, None
+
+
+def _h_trend(h_bits: float | None, prev: dict | None) -> str:
+    """熵趋势 = 与上一快照存储值比较：falling / flat / rising / unknown。"""
+    if not isinstance(h_bits, (int, float)):
+        return "unknown"
+    prev_h = (prev or {}).get("h_bits")
+    if not isinstance(prev_h, (int, float)):
+        return "unknown"
+    delta = float(h_bits) - float(prev_h)
+    if delta < -H_TREND_EPS:
+        return "falling"
+    if delta > H_TREND_EPS:
+        return "rising"
+    return "flat"
+
+
+def _health_oracle(ws: Path) -> bool:
+    """>#473 门电力面：task-oracle.yaml 已注册（init skeleton marker 不算）。
+    Single-sourced on heartbeat_tick._oracle_registered（lazy import —
+    heartbeat_tick 反向只在 main() 内 lazy import 本模块，无环）。"""
+    try:
+        from heartbeat_tick import _oracle_registered
+        return bool(_oracle_registered(ws))
+    except Exception:  # noqa: BLE001 — a probe never kills the tick
+        return False
+
+
+def _health_retro(ws: Path) -> bool:
+    """retro 滞后健康 = settlements since retro < 8（runs/.retro-state.json）。
+    读失败 fail-open（无故障证据 != 故障）。"""
+    try:
+        from backtrack_loop import lag
+        return lag(ws) < BACKTRACK_LAG_WARN
+    except Exception:  # noqa: BLE001 — a probe never kills the tick
+        return True
+
+
+def _health_dormant(ws: Path) -> bool:
+    """>#127 liveness face：无 DORMANT 探测器（evaluated, never fired）。
+    读失败 fail-open。"""
+    try:
+        from detector_liveness import liveness_report
+        return not liveness_report(ws).get("dormant")
+    except Exception:  # noqa: BLE001 — a probe never kills the tick
+        return True
+
+
+def _health(ws: Path) -> dict:
+    """#142 三颗健康点：oracle 已注册 / retro 滞后 < 8 / 无 DORMANT。"""
+    return {"oracle": _health_oracle(ws), "retro": _health_retro(ws),
+            "dormant": _health_dormant(ws)}
+
+
+def _last_dispatch_claim(ws: Path) -> str | None:
+    """>parked 状态的 `last C-<id>`：账本尾部逆序第一条带 claim 的行。"""
+    for row in reversed(_ledger_rows(ws)):
+        claim = row.get("claim")
+        if isinstance(claim, str) and claim.strip():
+            return claim.strip()
+    return None
+
+
+def _now_chip(ws: Path) -> dict:
+    """#142 当前任务 chip：活跃 worker 的 claim + 短任务短语（<=24 字符）。
+
+    活跃 = lib_kunglao.iter_worker_states 里 LAST status 非 terminal 且非
+    waiting 的 worker（liveness 协议归 lib_kunglao 所有；此处只取身份），
+    多活跃取 mtime 最新。空闲时 claim 回退最近一次 dispatch（`last C-<id>`）。
+    全程 fail-open -> {claim: None, op: None}。
+    """
+    claim: str | None = None
+    op: str | None = None
+    try:
+        from _hooks_path import load_hooks_lib
+        lib = load_hooks_lib()
+        states = lib.iter_worker_states(ws)
+        active = [s for s in states
+                  if s.get("status") not in lib.TERMINAL_WORKER_STATUSES
+                  and s.get("status") != lib.WAITING_WORKER_STATUS]
+        if active:
+            cur = max(active, key=lambda s: s.get("mtime"))
+            text = cur["file"].read_text(encoding="utf-8", errors="replace")
+            m = _CLAIM_RE.search(text)
+            if m:
+                claim = m.group(1)
+            steps = _STEP_RE.findall(text)
+            if steps:
+                op = steps[-1].strip()[:NOW_OP_MAX_CHARS]
+        if claim is None:
+            claim = _last_dispatch_claim(ws)
+    except Exception:  # noqa: BLE001 — 快照永不打断 tick
+        pass
+    return {"claim": claim, "op": op}
+
+
+def _pq_detail(ws: Path) -> list[dict]:
+    """细粒度 PQ 面（原 external renderer 直接读 rl-signals.jsonl 的那部分
+    数据 — 合同违规，#142 收归 producer）：逐 PQ {id,state,coverage}。"""
+    rows: list[dict] = []
+    try:
+        led = yaml.safe_load((ws / "runs" / "mission_ledger.yaml")
+                             .read_text(encoding="utf-8")) or {}
+        for p in (led.get("mission", {}) or {}).get("pqs") or []:
+            if not isinstance(p, dict):
+                continue
+            try:
+                cov = round(float(p.get("coverage") or 0.0), 4)
+            except (TypeError, ValueError):
+                cov = 0.0
+            rows.append({"id": str(p.get("id")), "state": p.get("state"),
+                         "coverage": cov})
+    except (OSError, yaml.YAMLError, TypeError):
+        pass
+    return rows
+
+
+def _difficulty(ws: Path) -> str | None:
+    """难度档（mission_ledger.read_difficulty_tier — evidence/difficulty.json
+    first, task_spec.yaml second）。缺/读失败 -> None（渲染端省略）。"""
+    try:
+        import mission_ledger
+        return mission_ledger.read_difficulty_tier(ws)
+    except Exception:  # noqa: BLE001 — 快照永不打断 tick
+        return None
 
 
 def _eta_fade_cells(d_slope: float) -> int:
@@ -600,7 +806,6 @@ def build_snapshot(ws: Path, now: datetime.datetime | None = None) -> dict:
 
     pq = _mission_state(ws)
     activity = _ledger_activity(ws, now_s)
-    activity = _ledger_activity(ws, now_s)
     state = _detect_state(ws, alive_ok=alive_ok, open_claims=open_claims,
                           failed_claims=failed_claims, pq=pq, toss=activity["toss"],
                           stall_ok=stall_ok)
@@ -643,8 +848,17 @@ def build_snapshot(ws: Path, now: datetime.datetime | None = None) -> dict:
     except OSError:
         pass
 
+    # #142 v2 producer-owned fields — each traced to its disk observation,
+    # each fail-open (the snapshot never breaks the tick / the touch).
+    h_bits, h_pq = _frontier_entropy(ws)
+    h_trend = _h_trend(h_bits, prev)
+    health = _health(ws)
+    now_chip = _now_chip(ws)
+    pq_rows = _pq_detail(ws)
+    difficulty = _difficulty(ws)
+
     return {
-        "schema": 1,
+        "schema": SCHEMA_VERSION,
         "ts": now_iso,
         "workspace": str(ws.resolve()),
         "tick": tick,
@@ -658,6 +872,19 @@ def build_snapshot(ws: Path, now: datetime.datetime | None = None) -> dict:
         "pq": pq,
         "v_m": pq["v_m"],
         "v_norm": pq["v_norm"],
+        # ---- #142 v2: producer-owned data (the renderer is a dumb view) ----
+        "v_hist": pq.get("v_hist") or [],
+        "h_bits": h_bits,
+        "h_pq": h_pq,
+        "h_trend": h_trend,
+        "health": health,
+        "now": now_chip,
+        "pq_rows": pq_rows,
+        "difficulty": difficulty,
+        # #142 phase-2 slots: named now, populated later — no renderer change
+        # twice (#133 v_norm-v_oracle gap, #129 1/k baseline).
+        "v_oracle_gap": None,
+        "baseline_inv_k": None,
         "d_slope": pq["d_slope"],
         "d_slope_norm": pq["d_slope_norm"],
         "eta_ticks": pq["eta_ticks"],

--- a/scripts/statusline_snapshot.py
+++ b/scripts/statusline_snapshot.py
@@ -2,12 +2,20 @@
 # -*- coding: utf-8 -*-
 """statusline_snapshot.py — #883 statusline 健康段数据面（快照解耦）.
 
-THE architectural decision (issue #883, 定案): kunglao logic never enters
-Node. This module pre-writes ONE snapshot file per heartbeat tick
-(``runs/.kunglao-statusline.json``) and the user's combined-statusline.mjs
-only reads it (O(1), zero spawn) to interpolate animation frames on its own
-render clock. Watchdog semantics fall out for free: kunglao dies -> tick
-stops -> snapshot mtime stalls -> Node judges down (no self-report).
+THE architectural decision (issue #883, refined #142): kunglao logic never
+enters Node. This module pre-writes ONE snapshot file per SEMANTIC EVENT
+(``runs/.kunglao-statusline.json`` — tool use via hooks/heartbeat_touch,
+plus tick-hosted settlement/rollup: heartbeat_tick writes right after its
+settlement block) and the repo's
+statusline_render.mjs only reads it (O(1), zero spawn). EVENT-DRIVEN
+WRITES: if nothing happened, nothing changed — a stale snapshot during
+idle is TRUTHFUL, so there is no tick-cadence refresh (the 5-min tick
+keeps monitoring/breaker duties but is not a display dependency).
+Watchdog: the renderer judges idle-vs-dead from the liveness policy —
+mtime within HEARTBEAT_STALE_MINUTES with no events = the state machine's
+own dim-blue-gray idle face;
+beyond policy, or this module's own probe-driven "down" verdict = DOWN.
+Never self-reported; always disk-observed.
 
 Three planes, all pure disk observation (看门狗原则：磁盘观测，永不
 self-report):
@@ -37,8 +45,11 @@ file mtime (alive, #534/#754), ledger tail (activity rate + sparks,
 owner for the whole kunglao segment (producer-owned data): it gains
 ``v_hist`` (last ~8 v_norm points — the sparkline), ``h_bits``/``h_pq``/
 ``h_trend`` (frontier PQ categorical entropy from runs/posteriors.yaml
-via posteriors.PQCategorical.entropy; trend vs the previous stored
-value), ``health{oracle,retro,dormant}`` (#473 oracle marker check /
+via scripts/posteriors.py PQCategorical.entropy; trend vs the previous
+stored value — SINGLE-SOURCED in scripts/entropy_face.py so the heartbeat
+tick report face and the future policy/strategy arbiter read the SAME
+computed values this snapshot renders; dual-use display, no decoration),
+``health{oracle,retro,dormant}`` (#473 oracle marker check /
 retro lag < 8 / #127 no DORMANT detectors), ``now{claim,op}`` (active
 worker from the lib_kunglao worker-status scan; op is a <=24-char task
 phrase), ``pq_rows`` + ``difficulty`` (the fine-grained PQ collection
@@ -48,9 +59,9 @@ placeholder slots (``v_oracle_gap`` #133, ``baseline_inv_k`` #129) so
 the renderer never changes twice.
 
 Usage: python statusline_snapshot.py <workspace>
-(attached from heartbeat_tick after the #873 cockpit sample AND from the
-heartbeat_touch per-tool-use path since #142 — working-period freshness
-~= per tool call; fail-open everywhere).
+(attached from the heartbeat_touch per-tool-use path and from
+heartbeat_tick's post-settlement step — event-driven writes, #142
+refinement. Fail-open everywhere.)
 """
 from __future__ import annotations
 
@@ -70,8 +81,14 @@ from ws_layout import resolve_strict as _resolve_ws
 # #597: staleness constants are single-sourced in liveness_policy.
 from liveness_policy import HEARTBEAT_STALE_MINUTES, TICK_INTERVAL_DEFAULT_MIN
 
+# #142 follow-up: the entropy-honesty face is single-sourced in
+# entropy_face (display + decision faces share one computation).
+from entropy_face import face as _entropy_face
+
 SKILL_DIR = Path(__file__).resolve().parent.parent  # kunglao-agent/ root
-SNAPSHOT_REL = Path("runs") / ".kunglao-statusline.json"
+# #142 follow-up: the snapshot path is single-sourced in entropy_face (the
+# trend-baseline reader owns the constant; the writer reuses it — no twin).
+from entropy_face import SNAPSHOT_REL
 
 # #142: snapshot schema version — 2 adds the producer-owned v2 fields
 # (v_hist / h_bits / h_trend / health / now / pq_rows / difficulty and the
@@ -94,7 +111,6 @@ BACKTRACK_LAG_WARN = 8                             # settlements since retro
 UNATTRIBUTED_RATE_WARN = 0.30                      # unattributed fraction
 # #142 v2 fields
 V_HIST_POINTS = 8                                  # sparkline window (~8 points)
-H_TREND_EPS = 1e-6                                 # |ΔH| below this = flat
 NOW_OP_MAX_CHARS = 24                              # task-chip phrase budget
 # Display-only worker-status field extraction (kunglao_status precedent:
 # NOT liveness parsing — liveness stays in lib_kunglao's protocol owners).
@@ -544,56 +560,10 @@ def _ledger_activity(ws: Path, now_s: float) -> dict:
 # #142 v2 data plane (producer-owned: the renderer never reads raw logs)
 # ---------------------------------------------------------------------------
 
-def _frontier_pq_id(ws: Path) -> str | None:
-    """任务前沿 = mission_ledger PQ 序里第一个未 answered 的 PQ id。
-    读失败/全答 -> None（调用方回退 max-entropy 或缺省）。"""
-    try:
-        led = yaml.safe_load((ws / "runs" / "mission_ledger.yaml")
-                             .read_text(encoding="utf-8")) or {}
-        for p in (led.get("mission", {}) or {}).get("pqs") or []:
-            if not isinstance(p, dict):
-                continue
-            if str(p.get("state") or "") != "answered":
-                return str(p.get("id")) if p.get("id") is not None else None
-    except (OSError, yaml.YAMLError, TypeError):
-        pass
-    return None
-
-
-def _frontier_entropy(ws: Path) -> tuple[float | None, str | None]:
-    """#142 学习诚实度徽章的数据面：前沿 PQ categorical 熵（bit）。
-
-    runs/posteriors.yaml -> posteriors.PQCategorical.entropy()。前沿 id 取
-    _frontier_pq_id；前沿无后验时回退全库 max-entropy PQ（仍是一个确定性的
-    熵读数）；账本空/读失败 -> (None, None)（渲染端整体省略徽章，fail-open）。
-    """
-    try:
-        from posteriors import PosteriorLedger
-        led = PosteriorLedger.load(ws)
-        if not led.pqs:
-            return None, None
-        frontier_id = _frontier_pq_id(ws)
-        pq = led.pqs.get(frontier_id) if frontier_id is not None else None
-        if pq is None:
-            pq = max(led.pqs.values(), key=lambda p: p.entropy())
-        return round(pq.entropy(), 4), pq.pq_id
-    except Exception:  # noqa: BLE001 — 快照永不打断 tick
-        return None, None
-
-
-def _h_trend(h_bits: float | None, prev: dict | None) -> str:
-    """熵趋势 = 与上一快照存储值比较：falling / flat / rising / unknown。"""
-    if not isinstance(h_bits, (int, float)):
-        return "unknown"
-    prev_h = (prev or {}).get("h_bits")
-    if not isinstance(prev_h, (int, float)):
-        return "unknown"
-    delta = float(h_bits) - float(prev_h)
-    if delta < -H_TREND_EPS:
-        return "falling"
-    if delta > H_TREND_EPS:
-        return "rising"
-    return "flat"
+# The entropy-honesty badge is SINGLE-SOURCED in scripts/entropy_face.py
+# (#142 follow-up, dual-use display): the snapshot face and the heartbeat
+# tick report face read the SAME computed {h_bits, h_pq, h_trend} — no
+# second computation lives here anymore.
 
 
 def _health_oracle(ws: Path) -> bool:
@@ -850,8 +820,7 @@ def build_snapshot(ws: Path, now: datetime.datetime | None = None) -> dict:
 
     # #142 v2 producer-owned fields — each traced to its disk observation,
     # each fail-open (the snapshot never breaks the tick / the touch).
-    h_bits, h_pq = _frontier_entropy(ws)
-    h_trend = _h_trend(h_bits, prev)
+    h = _entropy_face(ws, prev)
     health = _health(ws)
     now_chip = _now_chip(ws)
     pq_rows = _pq_detail(ws)
@@ -874,9 +843,9 @@ def build_snapshot(ws: Path, now: datetime.datetime | None = None) -> dict:
         "v_norm": pq["v_norm"],
         # ---- #142 v2: producer-owned data (the renderer is a dumb view) ----
         "v_hist": pq.get("v_hist") or [],
-        "h_bits": h_bits,
-        "h_pq": h_pq,
-        "h_trend": h_trend,
+        "h_bits": h["h_bits"],
+        "h_pq": h["h_pq"],
+        "h_trend": h["h_trend"],
         "health": health,
         "now": now_chip,
         "pq_rows": pq_rows,

--- a/tests/test_statusline_health_883.py
+++ b/tests/test_statusline_health_883.py
@@ -12,7 +12,8 @@ Coverage map (issue #883 ten acceptance items, Python-side half):
   - flash triggers (milestone / every-N-ticks / state change) — 时间数字仅闪现的数据面
   - snapshot schema + atomic write
   - down auto-flip on stale heartbeat (kill kunglao -> down)
-  - heartbeat_tick integration (snapshot written per tick, fail-open)
+  - heartbeat_tick integration (#142 refinement: event-driven — writes are
+    semantic events only: tool use, plus tick-hosted settlement/rollup)
 """
 from __future__ import annotations
 
@@ -445,8 +446,12 @@ class TestSnapshotWriter:
                             .read_text(encoding="utf-8"))
         assert second["state"] == "down"
 
-    def test_tick_integration_writes_snapshot(self, tmp_path):
-        """挂点集成：真实 heartbeat_tick CLI 跑完 → 快照在盘上（fail-open 不失败 tick）。"""
+    def test_tick_does_not_write_snapshot_event_driven(self, tmp_path):
+        """>#142 refinement (event-driven): the fixed tick-cadence snapshot
+        pre-write is gone. A LEDGER-LESS workspace hosts no settlement
+        event, so this tick must leave the snapshot absent/untouched —
+        stale is truthful (see test_tick_settlement_writes_snapshot for
+        the settlement-hosting counterpart)."""
         ws = _make_ws(tmp_path)
         _touch_heartbeat(ws)
         r = subprocess.run(
@@ -454,22 +459,52 @@ class TestSnapshotWriter:
             capture_output=True, text=True, encoding="utf-8",
             errors="replace", timeout=180)
         out = ws / "runs" / ".kunglao-statusline.json"
-        assert out.exists(), (
-            f"tick must pre-write the statusline snapshot; rc={r.returncode} "
+        assert not out.exists(), (
+            "tick must not write the statusline snapshot (event-driven "
+            f"writes only, #142 refinement); rc={r.returncode} "
             f"stderr={r.stderr[-300:]}")
-        assert json.loads(out.read_text(encoding="utf-8"))["schema"] == 2  # #142
+        assert r.returncode in (0, 1)  # tick ran to its own verdict
 
-    def test_tick_survives_snapshot_failure(self, tmp_path, monkeypatch):
-        """writer 崩溃不得失败 tick：fail-open 同款（#873 cockpit 惯例）。"""
+    def test_tick_settlement_writes_snapshot(self, tmp_path):
+        """#142 refinement: a tick-hosted settlement IS a semantic event —
+        a workspace with a mission ledger gets a post-settlement snapshot
+        write (the display would otherwise lag the frontier indefinitely
+        during LLM-idle). No tool-use flow required."""
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        pqs = [{"id": "PQ-1", "question": "q", "state": "unattempted",
+                "coverage": 0.0, "answered_by": [], "blocker": None,
+                "wake": None, "weight": 1.0}]
+        hist = [{"ts": _iso(datetime.now(timezone.utc)), "v_m": 0.5}]
+        (ws / "runs" / "mission_ledger.yaml").write_text(
+            yaml.safe_dump({"mission": {"pqs": pqs, "beta": 0.5,
+                                        "history": hist,
+                                        "feature_used": True}},
+                           sort_keys=False), encoding="utf-8")
+        r = subprocess.run(
+            [sys.executable, str(SCRIPTS / "heartbeat_tick.py"), str(ws)],
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=180)
+        out = ws / "runs" / ".kunglao-statusline.json"
+        assert out.exists(), (
+            f"settlement event must trigger the snapshot write; rc={r.returncode} "
+            f"stderr={r.stderr[-300:]}")
+        snap = json.loads(out.read_text(encoding="utf-8"))
+        assert snap["pq"]["total"] == 1  # the settled frontier is visible
+
+    def test_tick_never_calls_snapshot_writer(self, tmp_path, monkeypatch):
+        """Event-driven contract pin: with no mission ledger the tick
+        hosts no settlement and makes ZERO write_snapshot calls."""
         ws = _make_ws(tmp_path)
         _touch_heartbeat(ws)
         import heartbeat_tick as hbt
-        orig = sls.write_snapshot
+        calls = []
 
-        def boom(ws_, *a, **k):
-            raise RuntimeError("boom")
+        def spy(ws_, *a, **k):
+            calls.append(ws_)
+            return ws / "runs" / ".kunglao-statusline.json"
 
-        monkeypatch.setattr(sls, "write_snapshot", boom)
+        monkeypatch.setattr(sls, "write_snapshot", spy)
         rc = hbt.main([str(ws)])
-        monkeypatch.setattr(sls, "write_snapshot", orig)
         assert rc in (0, 1)  # tick ran to its own verdict, not a crash
+        assert calls == [], "tick must not write the statusline snapshot"

--- a/tests/test_statusline_health_883.py
+++ b/tests/test_statusline_health_883.py
@@ -412,7 +412,7 @@ class TestSnapshotWriter:
         _emit(ws, "tool_call")
         _mission(ws, answered=1, total=4)
         snap = sls.build_snapshot(ws)
-        assert snap["schema"] == 1
+        assert snap["schema"] == 2  # #142: schema 2 — producer-owned v2 fields
         for key in ("ts", "workspace", "state", "state_since", "prev_state",
                     "color", "probe_codes", "probe_detail", "pq", "v_m",
                     "d_slope", "eta_ticks", "eta_fade_cells", "elapsed",
@@ -427,7 +427,7 @@ class TestSnapshotWriter:
         out = ws / "runs" / ".kunglao-statusline.json"
         assert out.exists()
         assert not (ws / "runs" / ".kunglao-statusline.json.tmp").exists()
-        assert json.loads(out.read_text(encoding="utf-8"))["schema"] == 1
+        assert json.loads(out.read_text(encoding="utf-8"))["schema"] == 2  # #142
 
     def test_down_auto_flip(self, tmp_path):
         """kill kunglao（停 touch）→ 下一次 writer 看到陈旧 heartbeat → down。"""
@@ -457,7 +457,7 @@ class TestSnapshotWriter:
         assert out.exists(), (
             f"tick must pre-write the statusline snapshot; rc={r.returncode} "
             f"stderr={r.stderr[-300:]}")
-        assert json.loads(out.read_text(encoding="utf-8"))["schema"] == 1
+        assert json.loads(out.read_text(encoding="utf-8"))["schema"] == 2  # #142
 
     def test_tick_survives_snapshot_failure(self, tmp_path, monkeypatch):
         """writer 崩溃不得失败 tick：fail-open 同款（#873 cockpit 惯例）。"""

--- a/tests/test_statusline_v2_142.py
+++ b/tests/test_statusline_v2_142.py
@@ -346,6 +346,16 @@ def _write_snapshot(ws: Path, snap: dict, age_s: int = 0) -> None:
 # (fixture snapshots are built via _full_snap() — fresh flash ts per call).
 
 
+def _run_renderer(ws: Path) -> subprocess.CompletedProcess:
+    """Drive the renderer subprocess against a fixture workspace (stdin
+    JSON names the ws dir; HUD disabled via the KUNGLAO_STATUSLINE_HUD seam)."""
+    payload = json.dumps(
+        {"workspace": {"current_dir": str(ws)}, "model": {"display_name": "t"}})
+    return subprocess.run(
+        ["node", str(RENDERER)], input=payload, capture_output=True,
+        text=True, timeout=30, cwd=str(ws.parent))
+
+
 @pytest.mark.skipif(shutil.which("node") is None, reason="node unavailable")
 class TestRenderer142:
     @pytest.fixture(autouse=True)
@@ -354,11 +364,7 @@ class TestRenderer142:
         monkeypatch.setenv("KUNGLAO_STATUSLINE_HUD", "")
 
     def _run(self, ws: Path, stdin_payload: dict | None = None) -> subprocess.CompletedProcess:
-        payload = json.dumps(
-            {"workspace": {"current_dir": str(ws)}, "model": {"display_name": "t"}})
-        return subprocess.run(
-            ["node", str(RENDERER)], input=payload, capture_output=True,
-            text=True, timeout=30, cwd=str(ws.parent))
+        return _run_renderer(ws)
 
     def test_renders_all_chips_from_fixture_snapshot(self, tmp_path):
         ws = _make_ws(tmp_path)
@@ -452,7 +458,7 @@ class TestRenderer142:
 
     def test_down_freeze_watchdog(self, tmp_path):
         ws = _make_ws(tmp_path)
-        _write_snapshot(ws, _full_snap(), age_s=36 * 60)  # older than T_LIVE
+        _write_snapshot(ws, _full_snap(), age_s=36 * 60)  # beyond T_DEAD_MS
         r = self._run(ws)
         assert r.returncode == 0
         out = _strip_ansi(r.stdout)
@@ -615,3 +621,247 @@ class TestStatuslineRegistration142:
         committed = yaml.safe_load(
             (ROOT / "deploy-manifest.yaml").read_text(encoding="utf-8"))
         assert committed.get("files") == dm.build_entries()
+
+
+# ===========================================================================
+# 4. follow-up — entropy face single-sourcing + dual-use display
+# ===========================================================================
+
+class TestEntropyFace142:
+    """The entropy-trend computation lives in ONE shared module
+    (scripts/entropy_face.py): the snapshot renders it, the heartbeat tick
+    report carries the SAME computed values, decision-side consumers read
+    the display's numbers (dual-use display, owner principle)."""
+
+    def test_snapshot_delegates_to_the_shared_face(self):
+        """Single-source pin: the snapshot module must not carry a second
+        h_bits/trend computation — it delegates to entropy_face.face."""
+        import entropy_face
+        assert sls._entropy_face is entropy_face.face
+
+    def test_frontier_entropy_known_value(self, tmp_path):
+        from entropy_face import frontier_entropy
+        ws = _make_ws(tmp_path)
+        _mission(ws, [_pq("PQ-1")], [1.0])
+        _posteriors(ws, {"PQ-1": {"a": 1, "b": 1}})
+        h_bits, h_pq = frontier_entropy(ws)
+        assert h_pq == "PQ-1"
+        assert h_bits == pytest.approx(1.0, abs=1e-3)
+
+    def test_trend_transitions(self):
+        from entropy_face import trend
+        assert trend(0.8, 1.5) == "falling"
+        assert trend(1.0, 1.0) == "flat"
+        assert trend(1.5, 0.8) == "rising"
+        assert trend(None, 1.0) == "unknown"
+        assert trend(1.0, None) == "unknown"
+
+    def test_face_reads_prev_from_stored_snapshot(self, tmp_path):
+        from entropy_face import face, prev_h_bits
+        ws = _make_ws(tmp_path)
+        _mission(ws, [_pq("PQ-1")], [1.0])
+        _posteriors(ws, {"PQ-1": {"a": 1, "b": 1}})
+        assert prev_h_bits(ws) is None  # no snapshot yet
+        f = face(ws)
+        assert f["h_trend"] == "unknown"
+        # store a prev with higher entropy -> next face reads falling
+        (ws / "runs" / ".kunglao-statusline.json").write_text(
+            json.dumps({"h_bits": 2.0}), encoding="utf-8")
+        assert prev_h_bits(ws) == 2.0
+        f = face(ws)
+        assert f["h_bits"] == pytest.approx(1.0, abs=1e-3)
+        assert f["h_trend"] == "falling"
+
+    def test_face_prev_dict_bypasses_disk_read(self, tmp_path):
+        from entropy_face import face
+        ws = _make_ws(tmp_path)
+        _mission(ws, [_pq("PQ-1")], [1.0])
+        _posteriors(ws, {"PQ-1": {"a": 1, "b": 1}})
+        f = face(ws, prev={"h_bits": 0.5})
+        assert f["h_trend"] == "rising"
+
+    def test_face_fail_open_on_empty_ws(self, tmp_path):
+        from entropy_face import face
+        ws = _make_ws(tmp_path)
+        f = face(ws)
+        assert f == {"h_bits": None, "h_pq": None, "h_trend": "unknown"}
+
+    def test_snapshot_and_tick_report_read_the_same_values(self, tmp_path):
+        """The dual-use contract, end to end: producer and tick report must
+        carry byte-identical h fields for the same workspace state."""
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        _mission(ws, [_pq("PQ-1")], [1.0])
+        _posteriors(ws, {"PQ-1": {"a": 1, "b": 1}})
+        import entropy_face
+        snap = sls.build_snapshot(ws)
+        face = entropy_face.face(ws)  # tick-face call shape (no prev arg)
+        assert snap["h_bits"] == face["h_bits"]
+        assert snap["h_pq"] == face["h_pq"]
+        # first observation -> both faces say unknown, identically
+        assert snap["h_trend"] == face["h_trend"] == "unknown"
+
+    def test_tick_report_carries_entropy_face(self, tmp_path):
+        """heartbeat_tick's report face (runs/.heartbeat-tick.json) gains
+        h_bits/h_pq/h_trend — the gear-shift signal decision-side."""
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        _mission(ws, [_pq("PQ-1")], [1.0])
+        _posteriors(ws, {"PQ-1": {"a": 1, "test-tick-face": 1}})
+        r = subprocess.run(
+            [sys.executable, str(SCRIPTS / "heartbeat_tick.py"), str(ws)],
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=180)
+        out = ws / "runs" / ".heartbeat-tick.json"
+        assert out.exists(), (
+            f"tick must write the report; rc={r.returncode} "
+            f"stderr={r.stderr[-300:]}")
+        report = json.loads(out.read_text(encoding="utf-8"))
+        assert report["h_pq"] == "PQ-1"
+        assert report["h_bits"] == pytest.approx(1.0, abs=1e-3)
+        assert report["h_trend"] == "unknown"
+
+    def test_renderer_documented_dual_use_map(self):
+        """Owner principle, mechanical pin: the renderer's header must carry
+        the dual-use map (every chip -> agent-side consumer)."""
+        source = RENDERER.read_text(encoding="utf-8")
+        assert "DUAL-USE MAP" in source
+        for consumer in ("noop-breaker", "budget pacing",
+                         "gear-shift", "backtrack gate",
+                         "worker-status protocol"):
+            assert consumer in source
+
+
+# ===========================================================================
+# 5. follow-up 2 — event-driven freshness contract (#142 refinement)
+# ===========================================================================
+
+class TestTokenZero142:
+    """Token-zero invariant: the per-tool-use snapshot refresh rides the
+    heartbeat_touch hook, whose output would enter the model context — so
+    the refresh must be SILENT on success AND on failure (fail-open both
+    ways, zero stdout / zero stderr / zero additionalContext)."""
+
+    def _run_touch(self, tmp_path, monkeypatch, capsys, *, boom):
+        """Load the HOOK file by explicit path: `heartbeat_touch` is a
+        pre-existing hooks/scripts shared-name twin (#671 class) and the
+        registered PreToolUse/Bash hook is hooks/heartbeat_touch.py — the
+        by-path load pins the tested artifact regardless of sys.modules
+        history from earlier test modules."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "kunglao_142_statusline_touch", ROOT / "hooks" / "heartbeat_touch.py")
+        hook = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(hook)
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        (ws / "runs" / ".kunglao-statusline.json").write_text(
+            json.dumps({"schema": 2, "state": "idle"}), encoding="utf-8")
+        calls = []
+        if boom:
+            def boom_fn(*a, **k):
+                calls.append("boom")
+                raise RuntimeError("boom")
+            monkeypatch.setattr(sls, "write_snapshot", boom_fn)
+        else:
+            def ok_fn(*a, **k):
+                calls.append("ok")
+                return ws / "runs" / ".kunglao-statusline.json"
+            monkeypatch.setattr(sls, "write_snapshot", ok_fn)
+        monkeypatch.chdir(ws)
+        rc = hook.main()
+        captured = capsys.readouterr()
+        return rc, captured, ws, calls
+
+    def test_refresh_success_is_silent(self, tmp_path, monkeypatch, capsys):
+        rc, captured, ws, calls = self._run_touch(tmp_path, monkeypatch,
+                                                  capsys, boom=False)
+        assert rc == 0
+        assert calls == ["ok"], "the touch path must refresh the snapshot"
+        assert captured.out == "" and captured.err == "", \
+            "hook output enters context = token cost; refresh must be silent"
+
+    def test_refresh_failure_is_silent(self, tmp_path, monkeypatch, capsys):
+        rc, captured, ws, calls = self._run_touch(tmp_path, monkeypatch,
+                                                  capsys, boom=True)
+        assert rc == 0  # fail-open: never blocks the tool call
+        assert calls == ["boom"], "the refresh ran and its failure was swallowed"
+        assert captured.out == "" and captured.err == "", \
+            "even a failed refresh must stay token-zero"
+
+    def test_touch_hook_subprocess_is_silent(self, tmp_path):
+        """End-to-end: the real hook subprocess emits nothing on either
+        stream (Claude Code captures hook stdout into the tool flow)."""
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        r = subprocess.run(
+            [sys.executable, str(ROOT / "hooks" / "heartbeat_touch.py")],
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=120, cwd=str(ws))
+        assert r.returncode == 0
+        assert r.stdout == "" and r.stderr == ""
+        assert (ws / "runs" / ".kunglao-statusline.json").exists(), \
+            "per-tool-use refresh must write the snapshot"
+
+
+class TestThreeValuedStaleness142:
+    """Renderer staleness is three-valued, not binary: fresh -> snapshot's
+    own state face; stale within liveness policy -> IDLE face (dim, not
+    red — alive with no events is truthful); beyond policy (or the
+    snapshot's own down verdict) -> DOWN red. The 5-min tick is not a
+    display dependency anymore."""
+
+    def _run_at_age(self, tmp_path, *, age_min, state="analyzing"):
+        ws = _make_ws(tmp_path)
+        snap = _full_snap()
+        snap["state"] = state
+        _write_snapshot(ws, snap, age_s=age_min * 60)
+        return _run_renderer(ws)
+
+    def test_stale_within_policy_renders_idle_face(self, tmp_path):
+        r = self._run_at_age(tmp_path, age_min=10)  # > tick, < policy
+        assert r.returncode == 0
+        out = _strip_ansi(r.stdout)
+        assert "idle" in out and "DOWN" not in out
+        assert "analyzing" not in out  # last-event state is not shown as live
+
+    def test_fresh_renders_snapshot_state(self, tmp_path):
+        r = self._run_at_age(tmp_path, age_min=0)
+        assert r.returncode == 0
+        assert "analyzing" in _strip_ansi(r.stdout)
+
+    def test_beyond_policy_renders_down(self, tmp_path):
+        r = self._run_at_age(tmp_path, age_min=36)
+        assert r.returncode == 0
+        assert "DOWN" in _strip_ansi(r.stdout)
+
+    def test_producer_down_verdict_is_trusted_when_fresh(self, tmp_path):
+        """The liveness face's own down verdict (probe-driven) shows DOWN
+        even on a fresh snapshot — mtime age never overrides it."""
+        r = self._run_at_age(tmp_path, age_min=0, state="down")
+        assert r.returncode == 0
+        assert "DOWN" in _strip_ansi(r.stdout)
+        assert "○○○" in _strip_ansi(r.stdout)
+
+    def test_staleness_boundaries_are_strict(self, tmp_path):
+        """Boundary pin for the three-valued horizons (strict >): just
+        under 5min = fresh (own state); just over 5min = idle; just under
+        35min = still idle (alive); just over 35min = DOWN."""
+        cases = [(4 * 60 + 59, "analyzing", False),
+                 (5 * 60 + 1, "idle", False),
+                 (34 * 60 + 59, "idle", False),
+                 (35 * 60 + 1, "DOWN", True)]
+        for age_s, label, is_down in cases:
+            # drive seconds directly (mtime strictness matters at the edges);
+            # one workspace per case (each renders independently)
+            ws = _make_ws(tmp_path / f"age-{age_s}")
+            snap = _full_snap()
+            _write_snapshot(ws, snap, age_s=age_s)
+            r = _run_renderer(ws)
+            out = _strip_ansi(r.stdout)
+            assert r.returncode == 0, r.stderr
+            if is_down:
+                assert "DOWN" in out, f"age {age_s}s must render DOWN"
+            else:
+                assert label in out, f"age {age_s}s must render {label}"
+                assert "DOWN" not in out, f"age {age_s}s must not render DOWN"

--- a/tests/test_statusline_v2_142.py
+++ b/tests/test_statusline_v2_142.py
@@ -804,6 +804,7 @@ class TestTokenZero142:
             "per-tool-use refresh must write the snapshot"
 
 
+@pytest.mark.skipif(shutil.which("node") is None, reason="node unavailable")
 class TestThreeValuedStaleness142:
     """Renderer staleness is three-valued, not binary: fresh -> snapshot's
     own state face; stale within liveness policy -> IDLE face (dim, not

--- a/tests/test_statusline_v2_142.py
+++ b/tests/test_statusline_v2_142.py
@@ -1,0 +1,617 @@
+# -*- coding: utf-8 -*-
+"""#142 statusline v2 — producer schema fields, repo renderer, project-scoped deployment.
+
+Coverage map (issue #142 acceptance, Python-side):
+  - producer emits the schema-2 field set: v_hist / h_bits+h_pq+h_trend /
+    health{oracle,retro,dormant} / now{claim,op} / pq_rows + difficulty /
+    the #133/#129 phase-2 placeholder slots
+  - frontier PQ categorical entropy via posteriors.PQCategorical.entropy;
+    trend = compare vs the previous stored snapshot value
+  - health faces: #473 oracle marker check / retro lag < 8 / #127 no DORMANT
+  - now chip: active worker claim + short op; parked -> last dispatch claim
+  - fine-grained PQ data is producer-owned (a poisoned legacy rl-signals
+    log must not move a single rendered number — behavioral pin)
+  - renderer renders all chips from fixture snapshots; COARSE-PATH NO-THROW
+    regression (the external combined-statusline's undefined `blocked` on
+    line 137 — a strict-mode ReferenceError that killed the whole statusline)
+  - down-freeze watchdog kept
+  - PROJECT-scoped statusLine registration (same #258 project file, different
+    key); the user-global settings file is NEVER written
+  - hooks_selfcheck keep-alive + repair face; deploy manifest carries the
+    renderer into the workspace
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+RENDERER = SCRIPTS / "statusline_render.mjs"
+sys.path.insert(0, str(SCRIPTS))
+
+import statusline_snapshot as sls  # noqa: E402
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _make_ws(tmp_path: Path) -> Path:
+    """Minimal kunglao workspace: identity + register + runs/."""
+    ws = tmp_path / "ws"
+    (ws / "runs").mkdir(parents=True)
+    (ws / "analysis_state.txt").write_text(
+        "# analysis_state\nproject_type=windows\n", encoding="utf-8")
+    (ws / "claim-register.yaml").write_text("claims: []\n", encoding="utf-8")
+    return ws
+
+
+def _touch_heartbeat(ws: Path) -> None:
+    (ws / "runs" / ".heartbeat.json").write_text(json.dumps({
+        "started_ts": _iso(datetime.now(timezone.utc) - timedelta(seconds=60)),
+        "last_tick_ts": _iso(datetime.now(timezone.utc)),
+    }), encoding="utf-8")
+
+
+def _mission(ws: Path, pqs: list[dict], history: list[float]) -> None:
+    """mission_ledger.yaml with explicit PQ rows + a v_m history."""
+    now = datetime.now(timezone.utc)
+    hist = [{"ts": _iso(now), "v_m": float(v)} for v in history]
+    (ws / "runs" / "mission_ledger.yaml").write_text(
+        yaml.safe_dump({"mission": {"pqs": pqs, "beta": 0.5,
+                                    "history": hist,
+                                    "feature_used": True}},
+                       sort_keys=False), encoding="utf-8")
+
+
+def _pq(pid: str, state: str = "unattempted", coverage: float = 0.0,
+        weight: float = 1.0) -> dict:
+    return {"id": pid, "question": "q", "state": state, "coverage": coverage,
+            "answered_by": [], "blocker": None, "wake": None,
+            "weight": weight}
+
+
+def _posteriors(ws: Path, pqs: dict[str, dict[str, float]]) -> None:
+    """runs/posteriors.yaml via the real PosteriorLedger persistence."""
+    from posteriors import PosteriorLedger, PQCategorical
+    led = PosteriorLedger(pqs={pid: PQCategorical(pid, cands)
+                               for pid, cands in pqs.items()})
+    led.save(ws)
+
+
+def _worker_status(ws: Path, name: str, body: str, age_s: int = 0) -> Path:
+    p = ws / "runs" / f"worker-status-{name}.md"
+    p.write_text(body, encoding="utf-8")
+    if age_s:
+        old = time.time() - age_s
+        os.utime(p, (old, old))
+    return p
+
+
+def _retro_state(ws: Path, lag: int) -> None:
+    (ws / "runs" / ".retro-state.json").write_text(
+        json.dumps({"settlements_since_retro": lag,
+                    "last_retro_ts": _iso(datetime.now(timezone.utc))}),
+        encoding="utf-8")
+
+
+def _detector_rows(ws: Path, *, fired: bool) -> None:
+    import kunglao_log
+    kunglao_log.emit(ws, "test", "detector_eval",
+                     detail=json.dumps({"detector": "stall_watch"}))
+    if fired:
+        kunglao_log.emit(ws, "test", "detector_fired",
+                         detail=json.dumps({"detector": "stall_watch"}))
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch) -> Path:
+    """Fake HOME so Path.home()-derived checks bind to the test area
+    (same seam the other registration test modules pin)."""
+    home = tmp_path / "fake-home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
+def _full_snap() -> dict:
+    """Fresh fixture snapshot (flash ts must be wall-clock fresh per test)."""
+    return {
+        "schema": 2, "state": "analyzing",
+        "color": {"hue": 140, "sat": 72, "light": 55},
+        "v_hist": [0.1, 0.18, 0.25, 0.31, 0.4, 0.42],
+        "v_norm": 0.42,
+        "pq": {"answered": 2, "total": 5, "blocked": 1},
+        "h_bits": 1.3, "h_trend": "falling",
+        "health": {"oracle": True, "retro": True, "dormant": True},
+        "now": {"claim": "C-409", "op": "sign-algo probe"},
+        "flash": {"seq": 3, "reason": "claim_progress",
+                  "ts": _iso(datetime.now(timezone.utc)),
+                  "text": "CASE-GREEN"},
+    }
+
+
+# ===========================================================================
+# 1. producer — snapshot schema-2 field set
+# ===========================================================================
+
+class TestProducerSchema142:
+    def test_schema2_fields_present(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        snap = sls.build_snapshot(ws)
+        assert snap["schema"] == 2
+        for key in ("v_hist", "h_bits", "h_pq", "h_trend", "health", "now",
+                    "pq_rows", "difficulty", "v_oracle_gap", "baseline_inv_k"):
+            assert key in snap, f"schema-2 field {key} missing"
+        # #133/#129 phase-2 slots: named now, populated later.
+        assert snap["v_oracle_gap"] is None
+        assert snap["baseline_inv_k"] is None
+        assert set(snap["health"]) == {"oracle", "retro", "dormant"}
+        assert set(snap["now"]) == {"claim", "op"}
+
+    def test_v_hist_last_8_normalized_points(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        pqs = [_pq("PQ-1", "answered", 1.0), _pq("PQ-2")]
+        # v_m <= Σweight (2.0) so the normalized series stays in [0,1]
+        _mission(ws, pqs, [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.6])
+        snap = sls.build_snapshot(ws)
+        assert len(snap["v_hist"]) == sls.V_HIST_POINTS
+        assert all(0.0 <= v <= 1.0 for v in snap["v_hist"])
+        assert snap["v_hist"][-1] == pytest.approx(snap["v_norm"])
+        # sparkline momentum: rising history ends above its start
+        assert snap["v_hist"][-1] > snap["v_hist"][0]
+
+    def test_v_hist_empty_without_history(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        snap = sls.build_snapshot(ws)
+        assert snap["v_hist"] == []
+
+    # ---------- entropy badge ----------
+
+    def test_h_bits_frontier_entropy(self, tmp_path):
+        from posteriors import PQCategorical
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        pqs = [_pq("PQ-1", "answered", 1.0), _pq("PQ-2")]
+        _mission(ws, pqs, [1.0])
+        # frontier = first non-answered PQ (PQ-2); 50/50 -> exactly 1 bit
+        _posteriors(ws, {"PQ-1": {"a": 1, "b": 1}, "PQ-2": {"a": 1, "b": 1}})
+        snap = sls.build_snapshot(ws)
+        assert snap["h_pq"] == "PQ-2"
+        assert snap["h_bits"] == pytest.approx(
+            PQCategorical("PQ-2", {"a": 1, "b": 1}).entropy(), abs=1e-3)
+        assert snap["h_bits"] == pytest.approx(1.0, abs=1e-3)
+
+    def test_h_bits_falls_back_to_max_entropy_pq(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        pqs = [_pq("PQ-1", "answered", 1.0), _pq("PQ-2")]
+        _mission(ws, pqs, [1.0])
+        # frontier PQ-2 has NO posterior -> deterministic max-entropy fallback
+        _posteriors(ws, {"PQ-9": {"a": 1, "b": 1}, "PQ-8": {"a": 9, "b": 1}})
+        snap = sls.build_snapshot(ws)
+        assert snap["h_pq"] == "PQ-9"
+
+    def test_h_bits_absent_without_posteriors(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        snap = sls.build_snapshot(ws)
+        assert snap["h_bits"] is None and snap["h_pq"] is None
+        assert snap["h_trend"] == "unknown"
+
+    def test_h_trend_compares_previous_stored_value(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        _mission(ws, [_pq("PQ-1")], [1.0])
+        _posteriors(ws, {"PQ-1": {"a": 1, "b": 1}})
+        prev_tpl = {"schema": 2, "state": "analyzing", "tick": 1,
+                    "flash": {"seq": 0, "ts": None, "reason": None,
+                              "text": None}}
+        for prev_h, expected in ((1.5, "falling"), (1.0, "flat"),
+                                 (0.5, "rising"), (None, "unknown")):
+            prev = dict(prev_tpl, h_bits=prev_h)
+            (ws / "runs" / ".kunglao-statusline.json").write_text(
+                json.dumps(prev), encoding="utf-8")
+            snap = sls.build_snapshot(ws)
+            assert snap["h_trend"] == expected, f"prev h_bits={prev_h}"
+
+    # ---------- health dots ----------
+
+    def test_health_oracle_marker_vs_registered(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        (ws / "task-oracle.yaml").write_text(
+            "oracle: pending-user-input-backfill\n", encoding="utf-8")
+        assert sls.build_snapshot(ws)["health"]["oracle"] is False
+        (ws / "task-oracle.yaml").write_text(
+            "goal: recover the algorithm\nchecks: []\n", encoding="utf-8")
+        assert sls.build_snapshot(ws)["health"]["oracle"] is True
+
+    def test_health_retro_lag_threshold(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        _retro_state(ws, 9)  # >= 8 settlements since retro
+        assert sls.build_snapshot(ws)["health"]["retro"] is False
+        _retro_state(ws, 2)
+        assert sls.build_snapshot(ws)["health"]["retro"] is True
+
+    def test_health_dormant_detectors(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        _detector_rows(ws, fired=False)  # evaluated, never fired -> DORMANT
+        assert sls.build_snapshot(ws)["health"]["dormant"] is False
+        _detector_rows(ws, fired=True)
+        assert sls.build_snapshot(ws)["health"]["dormant"] is True
+
+    # ---------- current-task chip ----------
+
+    def test_now_active_worker_claim_and_op(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        _worker_status(ws, "w1",
+                       "[10:00] claim: C-409 | step: sign-algo probe "
+                       "| status: in-progress\n")
+        snap = sls.build_snapshot(ws)
+        assert snap["now"]["claim"] == "C-409"
+        assert snap["now"]["op"] == "sign-algo probe"
+
+    def test_now_op_capped_at_24_chars(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        _worker_status(ws, "w1",
+                       "claim: C-1 | step: a very long task phrase that "
+                       "exceeds the chip budget | status: in-progress\n")
+        snap = sls.build_snapshot(ws)
+        assert len(snap["now"]["op"]) <= sls.NOW_OP_MAX_CHARS
+
+    def test_now_waiting_worker_is_not_active(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        _worker_status(ws, "w1",
+                       "claim: C-1 | step: x | status: waiting\n")
+        snap = sls.build_snapshot(ws)
+        assert snap["now"]["op"] is None
+
+    def test_now_idle_falls_back_to_last_dispatch_claim(self, tmp_path):
+        import kunglao_log
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        kunglao_log.emit(ws, "orchestrator", "dispatch", claim="C-7",
+                         detail="dispatch")
+        snap = sls.build_snapshot(ws)
+        assert snap["now"]["claim"] == "C-7"
+        assert snap["now"]["op"] is None
+
+    # ---------- producer-owned fine-grained PQ data ----------
+
+    def test_pq_rows_and_difficulty_are_producer_owned(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        pqs = [_pq("PQ-1", "answered", 1.0), _pq("PQ-2", "unattempted", 0.25)]
+        _mission(ws, pqs, [1.0])
+        (ws / "evidence").mkdir()
+        (ws / "evidence" / "difficulty.json").write_text(
+            json.dumps({"tier": "hard"}), encoding="utf-8")  # canonical key
+        snap = sls.build_snapshot(ws)
+        assert snap["pq_rows"] == [
+            {"id": "PQ-1", "state": "answered", "coverage": 1.0},
+            {"id": "PQ-2", "state": "unattempted", "coverage": 0.25},
+        ]
+        assert snap["difficulty"] == "hard"
+
+    def test_snapshot_write_round_trips_v2_fields(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        _mission(ws, [_pq("PQ-1")], [0.2, 0.6])
+        _posteriors(ws, {"PQ-1": {"a": 3, "b": 1}})
+        out = sls.write_snapshot(ws)
+        snap = json.loads(out.read_text(encoding="utf-8"))
+        assert snap["schema"] == 2
+        assert snap["v_hist"] and snap["h_bits"] is not None
+
+
+# ===========================================================================
+# 2. renderer — pure view over the snapshot (node subprocess)
+# ===========================================================================
+
+def _strip_ansi(text: str) -> str:
+    return ANSI_RE.sub("", text)
+
+
+def _write_snapshot(ws: Path, snap: dict, age_s: int = 0) -> None:
+    p = ws / "runs" / ".kunglao-statusline.json"
+    p.write_text(json.dumps(snap), encoding="utf-8")
+    if age_s:
+        old = time.time() - age_s
+        os.utime(p, (old, old))
+
+
+# (fixture snapshots are built via _full_snap() — fresh flash ts per call).
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node unavailable")
+class TestRenderer142:
+    @pytest.fixture(autouse=True)
+    def _no_hud(self, monkeypatch):
+        # deterministic: no claude-hud passthrough in tests
+        monkeypatch.setenv("KUNGLAO_STATUSLINE_HUD", "")
+
+    def _run(self, ws: Path, stdin_payload: dict | None = None) -> subprocess.CompletedProcess:
+        payload = json.dumps(
+            {"workspace": {"current_dir": str(ws)}, "model": {"display_name": "t"}})
+        return subprocess.run(
+            ["node", str(RENDERER)], input=payload, capture_output=True,
+            text=True, timeout=30, cwd=str(ws.parent))
+
+    def test_renders_all_chips_from_fixture_snapshot(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _write_snapshot(ws, _full_snap())
+        r = self._run(ws)
+        assert r.returncode == 0, r.stderr
+        out = _strip_ansi(r.stdout)
+        assert "analyzing" in out                     # state (cyan face)
+        assert any(c in out for c in "▁▂▃▄▅▆▇█")      # sparkline shape
+        assert "42%" in out                           # fine v_norm percent
+        assert "H1.3b" in out                         # entropy badge
+        assert "●●●" in out                           # three solid health dots
+        assert "C-409 sign-algo probe" in out         # current-task chip
+        assert "⚡CASE-GREEN" in out                  # 5s flash kept
+        # deleted as noise: CONVERGENCE HEALTH text / tick number / slope chip
+        assert "CONVERGENCE HEALTH" not in out
+        assert "tick " not in out
+        assert "slope=" not in out
+
+    def test_color_is_data_four_meaning_palette(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _write_snapshot(ws, _full_snap())
+        r = self._run(ws)
+        assert r.returncode == 0
+        # green = learning (uptrend sparkline + H falling), cyan = working,
+        # and NO decorative hues beyond the four-meaning set.
+        assert "\x1b[32m" in r.stdout
+        assert "\x1b[36m" in r.stdout
+
+    def test_entropy_badge_trend_colors(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        for trend, color in (("falling", "\x1b[32m"), ("rising", "\x1b[31m"),
+                             ("flat", "\x1b[33m")):
+            _write_snapshot(ws, dict(_full_snap(), h_trend=trend,
+                                     flash={"seq": 0, "reason": None,
+                                            "ts": None, "text": None}))
+            r = self._run(ws)
+            assert r.returncode == 0
+            badge_colored = re.search(r"mH1\.3b", r.stdout)
+            assert badge_colored, f"badge missing for {trend}"
+            idx = r.stdout.find("H1.3b")
+            assert color in r.stdout[max(0, idx - 12):idx], \
+                f"trend {trend} must color the badge {color!r}"
+
+    def test_health_dots_amber_when_retro_lag(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        snap = dict(_full_snap(), health={"oracle": True, "retro": False,
+                                       "dormant": True})
+        _write_snapshot(ws, snap)
+        r = self._run(ws)
+        assert r.returncode == 0
+        # suspect dots render amber (stall-suspect face), healthy stay green
+        assert "\x1b[33m●" in r.stdout
+        assert "\x1b[32m●" in r.stdout
+
+    def test_health_dots_red_when_oracle_unregistered(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        snap = dict(_full_snap(), health={"oracle": False, "retro": True,
+                                       "dormant": True})
+        _write_snapshot(ws, snap)
+        r = self._run(ws)
+        assert r.returncode == 0
+        assert "\x1b[31m●" in r.stdout
+
+    def test_idle_chip_when_parked(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        snap = dict(_full_snap(), now={"claim": "C-7", "op": None})
+        _write_snapshot(ws, snap)
+        r = self._run(ws)
+        assert r.returncode == 0
+        assert "idle · last C-7" in _strip_ansi(r.stdout)
+
+    def test_coarse_path_renders_without_throwing(self, tmp_path):
+        """THE #142 crash regression: the external combined-statusline
+        referenced an undefined `blocked` on exactly this path (line 137) —
+        .mjs strict mode raises ReferenceError and killed the whole
+        statusline. The coarse path (legacy snapshot, no v2 fields, no
+        fine-grained data) must render as a first-class frame."""
+        ws = _make_ws(tmp_path)
+        legacy = {"schema": 1, "state": "analyzing",
+                  "color": {"hue": 140},
+                  "pq": {"answered": 2, "total": 5, "blocked": 1}}
+        _write_snapshot(ws, legacy)
+        r = self._run(ws)
+        assert r.returncode == 0, f"coarse path threw: {r.stderr}"
+        assert "ReferenceError" not in r.stderr
+        out = _strip_ansi(r.stdout)
+        assert "analyzing" in out
+        assert "40%" in out
+        assert out.strip().endswith("40%")
+
+    def test_down_freeze_watchdog(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _write_snapshot(ws, _full_snap(), age_s=36 * 60)  # older than T_LIVE
+        r = self._run(ws)
+        assert r.returncode == 0
+        out = _strip_ansi(r.stdout)
+        assert "DOWN" in out
+        assert "○○○" in out  # empty dots — the broken face
+
+    def test_renderer_ignores_legacy_rl_signals_log(self, tmp_path):
+        """Producer-owned data (the #142 contract fix, behavioral): the
+        external renderer read fine-grained PQ data DIRECTLY from
+        runs/rl-signals.jsonl — a zero-spawn contract violation. A poisoned
+        legacy log must not move a single rendered number."""
+        ws = _make_ws(tmp_path)
+        (ws / "runs" / "rl-signals.jsonl").write_text(
+            json.dumps({"kind": "voi_settle", "total_claims": 9,
+                        "v_norm": 0.99,
+                        "pq": {"X": {"cov": 0.99}},
+                        "difficulty": {"difficulty": "max"}}),
+            encoding="utf-8")
+        _write_snapshot(ws, _full_snap())  # says 42%
+        r = self._run(ws)
+        assert r.returncode == 0, r.stderr
+        out = _strip_ansi(r.stdout)
+        assert "42%" in out and "99%" not in out, \
+            "renderer consumed the legacy raw log — producer-owned data violated"
+        assert "q5" not in out and "X:" not in out
+
+    def test_no_snapshot_renders_nothing(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        r = self._run(ws)
+        assert r.returncode == 0
+        assert r.stdout == ""
+
+
+# ===========================================================================
+# 3. deployment — PROJECT-scoped registration + keep-alive
+# ===========================================================================
+
+class TestStatuslineRegistration142:
+    def test_register_statusline_writes_project_settings(self, tmp_path):
+        from hook_activation import register_statusline
+        ws = _make_ws(tmp_path)
+        settings = ws / ".claude" / "settings.json"
+        settings.parent.mkdir(parents=True)
+        settings.write_text(json.dumps({"env": {"A": "b"}}), encoding="utf-8")
+        res = register_statusline(ws)
+        assert res["ok"] is True
+        doc = json.loads(settings.read_text(encoding="utf-8"))
+        assert doc["env"] == {"A": "b"}, "unrelated keys preserved"
+        entry = doc["statusLine"]
+        assert entry["type"] == "command"
+        assert entry["command"].startswith("node ")
+        assert entry["command"].endswith("statusline_render.mjs")
+        assert "/scripts/statusline_render.mjs" in entry["command"]
+
+    def test_register_statusline_idempotent(self, tmp_path):
+        from hook_activation import register_statusline
+        ws = _make_ws(tmp_path)
+        first = register_statusline(ws)
+        second = register_statusline(ws)
+        assert first["command"] == second["command"]
+        doc = json.loads((ws / ".claude" / "settings.json")
+                         .read_text(encoding="utf-8"))
+        assert isinstance(doc["statusLine"], dict)
+
+    def test_register_statusline_prefers_workspace_local_copy(self, tmp_path):
+        from hook_activation import register_statusline
+        ws = _make_ws(tmp_path)
+        local = ws / ".claude" / "scripts"
+        local.mkdir(parents=True)
+        (local / "statusline_render.mjs").write_text("// deployed copy\n",
+                                                     encoding="utf-8")
+        res = register_statusline(ws)
+        assert res["command"] == f"node {(ws / '.claude' / 'scripts' / 'statusline_render.mjs').as_posix()}"
+
+    def test_register_hooks_wires_statusline_project_scoped(
+            self, tmp_path, fake_home):
+        """--wire-up now registers BOTH faces into the #258 project file —
+        and never touches the user-global settings."""
+        from hook_activation import register_hooks
+        ws = _make_ws(tmp_path)
+        rc = register_hooks(workspace=ws)
+        assert rc > 0
+        doc = json.loads((ws / ".claude" / "settings.json")
+                         .read_text(encoding="utf-8"))
+        assert doc["statusLine"]["type"] == "command"
+        assert "statusline_render.mjs" in doc["statusLine"]["command"]
+        assert not (fake_home / ".claude" / "settings.json").exists(), \
+            "user-global settings must never be written (#258/#142)"
+
+    def test_register_hooks_global_opt_in_never_registers_statusline(
+            self, tmp_path, fake_home):
+        """The user-global escape hatch is hooks-only: even with explicit
+        opt-in, the statusline never lands in ~/.claude/settings.json."""
+        from hook_activation import register_hooks
+        ws = _make_ws(tmp_path)
+        register_hooks(workspace=ws, global_opt_in=True)
+        doc = json.loads((fake_home / ".claude" / "settings.json")
+                         .read_text(encoding="utf-8"))
+        assert "statusLine" not in doc, \
+            "statusLine is PROJECT-scoped only — no global registration path"
+
+    def test_selfcheck_repairs_missing_statusline(self, tmp_path, fake_home,
+                                                  monkeypatch):
+        """keep-alive face: hooks fine, statusLine key deleted -> selfcheck
+        repairs it in the PROJECT file and records the row."""
+        from hook_activation import register_hooks
+        ws = _make_ws(tmp_path)
+        register_hooks(workspace=ws)
+        settings_path = ws / ".claude" / "settings.json"
+        doc = json.loads(settings_path.read_text(encoding="utf-8"))
+        doc.pop("statusLine")
+        settings_path.write_text(json.dumps(doc), encoding="utf-8")
+
+        sys.modules.pop("hooks_selfcheck", None)
+        import hooks_selfcheck
+        monkeypatch.setattr(sys, "argv", ["hooks_selfcheck.py", str(ws)])
+        rc = hooks_selfcheck.main()
+        assert rc == 0
+        repaired = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert "statusline_render.mjs" in repaired["statusLine"]["command"]
+        report = json.loads((ws / "runs" / ".hooks-selfcheck.json")
+                            .read_text(encoding="utf-8"))
+        assert report["statusline"]["ok"] is True
+
+    def test_selfcheck_report_carries_statusline_row(self, tmp_path, fake_home,
+                                                     monkeypatch):
+        sys.modules.pop("hooks_selfcheck", None)
+        import hooks_selfcheck
+        ws = _make_ws(tmp_path)
+        settings = ws / ".claude" / "settings.json"
+        settings.parent.mkdir(parents=True, exist_ok=True)
+        settings.write_text(json.dumps({
+            "hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [
+                {"type": "command",
+                 "command": "PYTHONUTF8=1 uv run --project "
+                            f"{ROOT.as_posix()} {ROOT / 'hooks' / 'heartbeat_touch.py'}"}]}]},
+        }), encoding="utf-8")
+        # KONG chain incomplete -> rebuild fires via --wire-up (which also
+        # registers the statusline); the report row must end ok either way.
+        monkeypatch.setattr(sys, "argv", ["hooks_selfcheck.py", str(ws)])
+        hooks_selfcheck.main()
+        report = json.loads((ws / "runs" / ".hooks-selfcheck.json")
+                            .read_text(encoding="utf-8"))
+        assert report["statusline"]["ok"] is True
+        assert "statusline_render.mjs" in (report["statusline"]["command"] or "")
+
+    def test_deploy_manifest_carries_the_renderer(self):
+        from deploy_manifest import build_entries
+        entries = build_entries()
+        match = [e for e in entries
+                 if e["src"] == "scripts/statusline_render.mjs"]
+        assert match, "renderer must ride the deployment manifest"
+        assert match[0]["dest"] == ".claude/scripts/statusline_render.mjs"
+
+    def test_committed_manifest_matches_build_entries(self):
+        """The committed deploy-manifest.yaml is a full mirror of
+        build_entries() (incl. the #142 renderer entry)."""
+        import deploy_manifest as dm
+        import yaml
+        committed = yaml.safe_load(
+            (ROOT / "deploy-manifest.yaml").read_text(encoding="utf-8"))
+        assert committed.get("files") == dm.build_entries()

--- a/tests/test_wire_up_settings.py
+++ b/tests/test_wire_up_settings.py
@@ -198,7 +198,11 @@ def test_wire_up_preserves_existing_keys(tmp_path, fake_home):
     register_hooks(workspace=ws)
     settings = json.loads(settings_path.read_text(encoding="utf-8"))
     assert settings["env"]["KUNGLAO_VM_HOST"] == "192.168.20.128", "env keys preserved"
-    assert settings["statusLine"]["command"] == "echo hi", "statusLine preserved"
+    # #142: statusLine is now a KUNGLAO-OWNED key (project-scoped, keep-alive
+    # repaired every tick) — a pre-existing value is repointed at the repo
+    # renderer, not preserved (same ownership discipline as `hooks`).
+    assert "statusline_render.mjs" in settings["statusLine"]["command"], \
+        "statusLine key owned by kunglao (#142), repointed at the repo renderer"
     other = [e for e in settings["hooks"]["PreToolUse"] if e.get("matcher") == "Bash"
              and "other/hook.py" in e.get("hooks", [{}])[0].get("command", "")]
     assert other, "unrelated hook entries preserved"


### PR DESCRIPTION
Closes #142.

## What

Statusline v2, three artifacts:

**1. Producer — `scripts/statusline_snapshot.py` (snapshot schema 1 -> 2)**

The snapshot becomes the single data owner for the whole kunglao segment. New producer-owned fields, all fail-open:
- `v_hist` — last ~8 `v_norm` points (`V_HIST_POINTS`) from `runs/mission_ledger.yaml` history -> the sparkline
- `h_bits` / `h_pq` / `h_trend` — frontier PQ categorical entropy from `runs/posteriors.yaml` via `posteriors.PQCategorical.entropy()`; frontier = first non-answered PQ (deterministic max-entropy fallback); trend = compare vs the previous stored snapshot value (`falling/flat/rising/unknown`)
- `health{oracle,retro,dormant}` — #473 task-oracle registered check (single-sourced on `heartbeat_tick._oracle_registered`), retro lag < 8 (`backtrack_loop.lag` on `runs/.retro-state.json`), no DORMANT detectors (#127, `detector_liveness.liveness_report`)
- `now{claim,op}` — active worker from the `lib_kunglao` worker-status protocol (op <= 24 chars); parked falls back to the last dispatch claim (`idle · last C-<id>`)
- `pq_rows` + `difficulty` — the fine-grained PQ data the external renderer read DIRECTLY from `rl-signals.jsonl` (zero-spawn contract violation); that read is gone
- named phase-2 placeholder slots `v_oracle_gap` (#133) and `baseline_inv_k` (#129) — populated later, no renderer change twice

Freshness: `hooks/heartbeat_touch.py` now refreshes the snapshot on EVERY tool use (fail-open), so working-period snapshot mtime advances ~= per tool call without waiting for the 5-min tick; idle = tick cadence; death = watchdog freeze.

**2. Renderer — `scripts/statusline_render.mjs` (NEW, checked into the repo)**

A dumb pure view over ONE snapshot JSON (plus optional claude-hud passthrough). Approved one-line shape:
```
◈ analyzing ▂▄▆█ 42% H1.3b ●●● │ C-409 sign-algo probe ⚡CASE-GREEN
```
- four-meaning palette only (cyan=working, green=learning/healthy, amber=stall-suspect, red=broken) — color IS data
- entropy badge colored by trend (falling=green, flat=amber, rising=red)
- 3 health dots; current-task chip; 5s flash kept; down-freeze watchdog kept (mtime > 35 min -> frozen DOWN frame)
- deleted as noise: `CONVERGENCE HEALTH:` duplicate text, tick number, slope chip
- the external combined-statusline's live crash (undefined `blocked`, its line 137 — .mjs strict-mode ReferenceError on the coarse path) is structurally impossible here: every field is read off the parsed snapshot with `??` fallbacks, and `test_coarse_path_renders_without_throwing` pins the regression

**3. Deployment — PROJECT-SCOPED ONLY (#258 discipline)**

- `hook_activation.register_statusline()` writes the `statusLine` key into `<ws>/.claude/settings.json` ONLY — same #258 project file as hooks, different key (the existing registration machinery is hooks/event-shaped, so statusLine follows the #258 project-target pattern on a distinct top-level key). There is deliberately NO global opt-in hatch: `~/.claude/settings.json` is never written (test-enforced, including on the `global_opt_in=True` hooks path).
- wired into `register_hooks` (non-global) and `register_hooks_deployed` so `--wire-up` deploys hooks + statusline together
- `hooks_selfcheck` gains `check_statusline` + `repair_statusline` keep-alive: the key lives and dies with the workspace like the hooks do; repair is reported (`statusline` report row + status-line segment) and rc weights stay hook-owned
- `deploy_manifest.build_entries()` now mirrors `scripts/*.mjs` beside `scripts/*.py`; manifest regenerated (390 entries, `--verify` green) so the registered command points at the workspace-local, self-contained renderer copy

## Migration note (one-time)

The repo now owns a renderer; repoint your statusline at it. For workspaces wired by kunglao this is automatic (wire-up/selfcheck register `<ws>/.claude/settings.json` `statusLine` = `node <ws>/.claude/scripts/statusline_render.mjs` after init/deploy-local materializes the copy). If your user-global `~/.claude/settings.json` still points at the old external `combined-statusline.mjs`, remove that entry (project-scoped only per #142/#258 — the global copy has the line-137 crash and the rl-signals contract violation). This PR changes no `~/.claude/settings.json`.

## Gates

- `env -u KUNGLAO_VALUE_ALGO python3 -m pytest tests/ -q`: 5922 passed, 10 skipped, 5 failed — all 5 pre-existing at base 8e17741 and untouched by this diff: `test_env_check::test_all_pass_exit_0` (known baseline red) + 4 × `test_hypothesis_loop_integration_111` (proven failing at pristine base in a throwaway worktree — #126's `hypothesis_ref` admission lint rejects the #111 test's `case-s1.yaml` fixture; landed broken on arrival, separate fix needed)
- ruff: clean on all touched files; repo-wide exactly the 5 pre-existing findings (`hooks/dispatch_gate.py` F841 + 4 test-file F401s) — reported, not fixed
- 1-reviewer gate: `r1-142-statusline` PASS (no CRITICAL/HIGH; evidence in `.review-gate/feat-142-statusline-v2.json`)
- anchor tests green at HEAD (decide-regression / decision-surface / secondstop / state anchors)

## Reviewer findings logged as follow-ups (non-blocking)

- MEDIUM: statusLine command path is unquoted for `sh -c` (matches the repo-wide `build_hook_entry` convention; `shlex.quote` would harden both)
- MEDIUM: per-tool-use snapshot refresh parses the full unified log via `detector_liveness` — cost grows with mission age; follow-up: tail-bound or TTL-cache that read, dedup the snapshot emit like #618
- LOW: coarse fixture could omit `blocked` entirely; `check_statusline` fail-open reports ok when constants import fails; HUD path hardcodes claude-hud 0.1.0; entropy fallback can label a non-frontier PQ; minor sparkline/idle-chip edge cases

## Deviations (deliberate, flagged)

- `statusLine` becomes a kunglao-OWNED settings key: a pre-existing project-level value is repointed at the repo renderer by wire-up (same ownership discipline as `hooks`; keep-alive would revert a preserve-behavior every tick anyway). `test_wire_up_settings` updated to pin the new semantics; `env` and unrelated hook entries remain preserved.
- snapshot schema bump 1 -> 2: `test_statusline_health_883` schema pins updated accordingly (no-backcompat policy: readers probe fields, not a version ladder).
- main-window events (rate-limited hook systemMessage face) from the issue's design are NOT in this PR — they are a companion channel, not part of the three landed artifacts; the repo renderer has no Claude Code hook channel to speak to yet.


---

## Follow-up commit: dual-use display — h_trend leaves the view layer (owner principle)

Every displayed metric must be consumed by agent decisions AND informative to humans; display-only metrics are decoration. The entropy-trend computation therefore moved out of the producer's private helpers into a NEW shared module, **`scripts/entropy_face.py`** — THE single source of `{h_bits, h_pq, h_trend}`:

- **display face**: `statusline_snapshot.build_snapshot` delegates to `entropy_face.face(ws, prev)` (a single-source delegation pin test asserts the module no longer carries a second computation);
- **decision face**: `heartbeat_tick` step 8b puts the SAME computed `h_bits`/`h_pq`/`h_trend` into the tick report (`runs/.heartbeat-tick.json`), computed BEFORE the snapshot write so both faces compare against the same stored baseline; the future policy/strategy arbiter reads the same module — the renderer keeps being a dumb view, but the computation it shows is now the one decisions consume.
- fail-open preserved (empty/unreadable posterior ledger → `h_bits=None` / `trend="unknown"`); behavior identical (same rounding, same frontier selection, same trend semantics).

### Dual-use map (every chip -> human meaning + agent-side consumer)

| chip | human meaning | agent-side consumer |
|---|---|---|
| state glyph + label (cyan/amber/red) | loop phase at a glance | #634 noop-breaker stall fingerprint + #597/#754 liveness gates (dispatch + budget gates read the same inputs) |
| sparkline + % (`v_hist` / `v_norm`) | a_t momentum as shape | a_t momentum + budget pacing (eta/budget extrapolation over the normalized series, tick-sampled) |
| H bits + trend | learning honesty (v rising while H flat = luck/fake progress) | strategy-arbiter gear-shift signal — the same values now ride the tick report face (`entropy_face`); also gates exploration budget |
| health dots x3 | oracle / retro / dormant liveness at a glance | #473 completion-gate power (oracle), #38 backtrack gate (retro lag < 8), #127 detector liveness (no DORMANT) |
| task chip (`now{claim,op}`) | who is working on what NOW; `idle · last C-<id>` when parked | lib_kunglao worker-status protocol — the same scan feeds the dispatch gate + capacity checks (`check_workers_lt_3`) |
| flash (⚡, 5s window) | milestone / state-change ping | producer-detected triggers the tick's action loop already acts on |
| eta (snapshot-level; human-visible via flash text `剩 ~Nt`) | time remaining | budget pacing (`eta_ticks` extrapolation) |

No chip lacks an agent-side consumer — nothing needed cutting under the owner principle. The map also lives as a comment block atop `scripts/statusline_render.mjs` (mechanically pinned by a test).

### Designed, v0.2-gated (slots stay unimplemented for now)

- **policy-belief chip** — current favored operator composition (lands with #12/#13)
- **Class-2 event light** — self-anchor / vacuous attempts (lands with #130)

**Gates re-run for the follow-up**: full suite green except the same pre-existing base reds (plus `test_declaration_scan` caught the new script missing from `scripts/README.md` — catalogued, fixed in this commit); ruff clean on touched files; deploy-manifest regenerated (391 entries, `--verify` green, `entropy_face.py` joins the scaffold); ext-index still fresh; anchors green; review-gate re-minted on the new staged diff.

---

## Follow-up commit 2: event-driven freshness (owner directive — timers are inelegant, the tick path burns tokens)

- **Writes are event-driven ONLY.** The fixed tick-cadence snapshot write is deleted. Writes happen on semantic events: (a) per-tool-use via `hooks/heartbeat_touch` (zero marginal cost — the hook fires anyway, and it stays SILENT: no stdout/additionalContext, pinned token-zero by tests on both the success and failure paths), and (b) tick-hosted settlement/rollup — a settlement moves the frontier, so `heartbeat_tick` writes the snapshot right after its settlement block (gated on a ledger actually being hosted; a ledger-less idle workspace writes nothing). If nothing happened, nothing changed — **a stale snapshot during idle is TRUTHFUL, not a bug.** The 5-min tick keeps its monitoring/breaker duties but is no longer a display dependency.
- **Renderer staleness is three-valued, not binary.** Raw mtime age alone conflates "idle" (alive, no events) with "dead" (broken): fresh → the snapshot's own state face; stale within liveness policy (5-min tick interval) → the IDLE face (the state machine's own dim-blue-gray idle hue — never red); beyond policy (35-min `HEARTBEAT_STALE_MINUTES`) or the snapshot's own probe-driven `down` verdict → frozen red DOWN with empty dots. Horizons mirror `scripts/liveness_policy.py` and are boundary-pinned (299s/301s/2099s/2101s).
- The entropy-trend computation also left the view layer in this push: `scripts/entropy_face.py` is the single source of `{h_bits, h_pq, h_trend}` for BOTH the display and the tick report face (see the dual-use section below the first follow-up) — decision-side consumers read the same numbers the renderer shows.

### Dual-use map (owner principle: every displayed metric is consumed by agent decisions AND informative to humans)

| chip | human meaning | agent-side consumer |
|---|---|---|
| state glyph + label (cyan/amber/red) | loop phase at a glance | #634 noop-breaker stall fingerprint + #597/#754 liveness gates (dispatch + budget gates read the same inputs) |
| sparkline + % (`v_hist` / `v_norm`) | a_t momentum as shape | a_t momentum + budget pacing (eta/budget extrapolation over the normalized series) |
| H bits + trend | learning honesty (v rising while H flat = luck/fake) | strategy-arbiter gear-shift signal — same values on the tick report face (`entropy_face`); also gates exploration budget |
| health dots x3 | oracle / retro / dormant liveness | #473 completion-gate power, #38 backtrack gate (lag < 8), #127 detector liveness |
| task chip (`now{claim,op}`) | who works on what NOW; `idle · last C-<id>` parked | lib_kunglao worker-status protocol — same scan feeds the dispatch gate + capacity checks |
| flash (⚡, 5s) | milestone / state-change ping | producer-detected triggers the tick action loop already acts on |
| eta (snapshot-level; visible via flash text `剩 ~Nt`) | time remaining | budget pacing (`eta_ticks` extrapolation) |

No chip lacks an agent-side consumer — nothing needed cutting. The map also lives as a comment block atop `scripts/statusline_render.mjs` (mechanically pinned by a test).

### Designed, v0.2-gated (slots stay unimplemented)

- **policy-belief chip** — current favored operator composition (lands with #12/#13)
- **Class-2 event light** — self-anchor / vacuous attempts (lands with #130)

**Follow-up gates**: full suite 5940 passed / 10 skipped with only the 5 documented base reds; ruff clean on touched files; deploy-manifest 391 entries verified (entropy_face.py joins the scaffold); ext-index fresh; declaration scan green (new script catalogued in `scripts/README.md`); review gate re-minted per round (`r1-142-statusline-fu` PASS, 5 review rounds — the reviewer caught and I fixed a staging defect and a settlement-write gap mid-flight).

**Documented follow-ups (non-blocking reviewer LOWs)**: snapshot-docstring "no tick-cadence refresh" line deserves the renderer's hedged "no FIXED tick-cadence refresh" phrasing; renderer contract-summary "(dim, truthful)" line vs hue-220 implementation; `settlement_hosted` is ledger-presence (update() is idempotent, usually a no-op) rather than an actual-settlement signal; a `kunglao_log` degraded marker when `frontier_entropy` fail-opens on a corrupt posteriors.yaml.

Note: the three-valued staleness boundary pins (and all renderer subprocess tests) are node-gated — the ubuntu CI runner has no node, so they skip there and run on dev machines; the python-only producer/registration/token-zero pins run everywhere.
