### PR TITLE
feat(#147): convergence requires declared oracle coverage — generalization-bit gate + declared fast path

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -247,7 +247,7 @@ files:
   - src: scripts/convergence_check.py
     dest: .claude/scripts/convergence_check.py
     kind: scaffold
-    sha256: 16e1dd75f99f18ac510ccc16b3ea7ea0dea6eddf283c97a2485279561213ece7
+    sha256: b87ed658df3c97a88388694a1d3fab583dc097992c6accf530e8d089ee1ffeb5
   - src: scripts/convergence_health.py
     dest: .claude/scripts/convergence_health.py
     kind: scaffold

--- a/scripts/convergence_check.py
+++ b/scripts/convergence_check.py
@@ -64,6 +64,10 @@ from retract_claim import RETRACTED, TERMINAL_WITH_RETRACTED
 # STUCK_WORKERS_PRESENT path (no parallel detector, no second scan pass).
 import worker_death as _worker_death
 from liveness_policy import DEAD_WORKER_MINUTES as _DEAD_WORKER_MINUTES
+# #147: the Phase-0 goal operationalization validator (#128). Its declared
+# `generalization` bit is the coverage contract the DRAIN oracle face
+# enforces — convergence requires DECLARED oracle coverage.
+import goal_operationalization as _goal_op
 # #863 Family C: workspace resolution is single-sourced in ws_layout (this
 # module used to be the ONLY manifest-aware copy — now every consumer is).
 from ws_layout import resolve_quiet as _resolve_ws
@@ -363,6 +367,13 @@ def _load_oracle_status(workspace: Path) -> dict:
         precedent — a corrupt verdict file cannot silently re-enable
         CONVERGED). Unknown status values normalize to "pending" (the
         conservative member of the triad).
+
+    #147 revocation: the absent-file fail-open above is REVOKED at the
+    gate for workspaces under the coverage contract — a declared
+    required/unknown generalization turns the absent/armed-empty face into
+    a BLOCK (see _load_goal_op + _DecideInputs.coverage_blocks). The
+    untouched behavior now applies ONLY to true-legacy workspaces (no
+    goal-operationalization.yaml AND no task-oracle.yaml).
     """
     path = workspace.joinpath(*ORACLE_STATUS_REL)
     if not path.exists():
@@ -391,6 +402,73 @@ def _load_oracle_status(workspace: Path) -> dict:
         return {"cases": [], "low_discriminativity": [],
                 "error": f"{type(exc).__name__}: {exc}"}
     return {"cases": cases, "low_discriminativity": low, "error": None}
+
+
+# #147 declared oracle coverage: the Phase-0 declaration files. The
+# goal-operationalization.yaml `generalization` bit (#128) is the coverage
+# contract; task-oracle.yaml (#473, the verbatim task heartbeat_tick marks
+# registered) is the marker that a workspace OWES that contract — a
+# workspace carrying neither predates it entirely (true legacy) and keeps
+# the pre-#147 untouched behavior.
+GOAL_OP_NAME = "goal-operationalization.yaml"
+TASK_ORACLE_NAME = "task-oracle.yaml"
+
+# The two named block reasons (issue text, quoted verbatim in the action).
+COVERAGE_UNDECLARED = (
+    "verification requirements undeclared — complete the Phase-0 "
+    "operationalization")
+COVERAGE_MISSING = (
+    "verification declared required but no oracle coverage delivered")
+
+
+def _load_goal_op(workspace: Path) -> dict:
+    """Classify the workspace's declared-coverage contract (#147).
+
+    Returns {"present", "valid", "legacy", "generalization", "declared_ts",
+    "post_dispatch", "errors", "error"}:
+      - legacy=True: neither contract file exists (pre-#473 workspace) —
+        the coverage gate stays silent, #108 behavior untouched;
+      - present=False (and task-oracle.yaml registered): the workspace owes
+        the Phase-0 operationalization and does not have it — undeclared;
+      - present + load/validate failure (unreadable, schema mismatch,
+        undeclared bit — GoalOpError walls) or validator errors (incl. the
+        R4 unstamped face): invalid — fail-closed with the cause;
+      - valid: carries the declared bit + the R4 timestamp.
+
+    Loud-rejection domain (#103 tiering): GoalOpError is a ValueError, so
+    the _GATE_INPUT_EXC net below catches IO/parse/shape degradation; the
+    classification treats every degradation as INVALID (fail-closed), the
+    same posture as the contradiction scan.
+    """
+    op_path = workspace / GOAL_OP_NAME
+    legacy = not op_path.exists() and not (workspace / TASK_ORACLE_NAME).exists()
+    if legacy:
+        return {"present": False, "valid": True, "legacy": True,
+                "generalization": None, "declared_ts": "",
+                "post_dispatch": False, "errors": [], "error": None}
+    if not op_path.exists():
+        return {"present": False, "valid": False, "legacy": False,
+                "generalization": None, "declared_ts": "",
+                "post_dispatch": False, "errors": [], "error": None}
+    try:
+        doc = _goal_op.load(op_path)
+        report = _goal_op.validate(doc)
+    except _goal_op.GoalOpError as exc:
+        return {"present": True, "valid": False, "legacy": False,
+                "generalization": None, "declared_ts": "",
+                "post_dispatch": False, "errors": [],
+                "error": f"{type(exc).__name__}: {exc}"}
+    except _GATE_INPUT_EXC as exc:  # defensive net — load/validate raise GoalOpError
+        return {"present": True, "valid": False, "legacy": False,
+                "generalization": None, "declared_ts": "",
+                "post_dispatch": False, "errors": [],
+                "error": f"{type(exc).__name__}: {exc}"}
+    errors = [str(e) for e in report["errors"]]
+    return {"present": True, "valid": not errors, "legacy": False,
+            "generalization": report["generalization"],
+            "declared_ts": str(doc.get("declared_ts") or ""),
+            "post_dispatch": bool(report["post_dispatch"]),
+            "errors": errors, "error": None}
 
 
 def _parse_pq_item(q: dict) -> tuple[str | None, str | None, str | None]:
@@ -671,7 +749,7 @@ class Event(str, Enum):
     # ACTIVE is DRAIN-only (SCHEDULE already routes work by claim face).
     STUCK_WORKERS_PRESENT = "STUCK_WORKERS_PRESENT"   # #595 SCHEDULE / #98 DRAIN: stuck workers gate both stages
     ACTIVE_WORKERS_PRESENT = "ACTIVE_WORKERS_PRESENT"  # #98 DRAIN: live worker on a drained claim surface
-    ORACLE_CASE_RED = "ORACLE_CASE_RED"               # #108 DRAIN: runner verdict joins the completion transaction
+    ORACLE_CASE_RED = "ORACLE_CASE_RED"               # #108 DRAIN: runner verdict joins the completion transaction; #147: the declared-coverage gate composes into the same acceptance face
     DRAIN_CLEAN = "DRAIN_CLEAN"                        # DRAIN catch-all
     # SCHEDULE stage
     WORK_AND_FREE_SLOT = "WORK_AND_FREE_SLOT"
@@ -731,6 +809,7 @@ class _DecideInputs:
     _anomalies: list | None = field(default=None, repr=False)
     _open_hyps: list | None = field(default=None, repr=False)
     _oracle: dict | None = field(default=None, repr=False)
+    _goal_op: dict | None = field(default=None, repr=False)
 
     def open_hypotheses(self) -> list:
         """#662 unadjudicated-hypothesis gate input (lazy + cached).
@@ -825,6 +904,52 @@ class _DecideInputs:
         if st["error"] is None and not st["cases"]:
             face["absent"] = True
         return face
+
+    def goal_op(self) -> dict:
+        """#147 declared-coverage classification (lazy + cached).
+
+        See _load_goal_op for the classification contract. Pure reads —
+        the resume path (emit_snapshot=False) stays side-effect free."""
+        if self._goal_op is None:
+            self._goal_op = _load_goal_op(self.workspace)
+        return self._goal_op
+
+    def armed_cases(self) -> list:
+        """#147: ARMED oracle cases — cases with live instrumentation (the
+        #108 `instrumented` flag). A scaffold case (never instrumented) is
+        not coverage: the runner never ran it against a live client, so it
+        cannot witness the deliverable."""
+        return [c for c in self.oracle_status()["cases"]
+                if c["instrumented"]]
+
+    def coverage_blocks(self) -> list[str]:
+        """#147: the DECLARED oracle-coverage gate — zero or one reason.
+
+        The final semantics (issue body + owner amendments):
+          - true legacy (no contract files) -> silent, #108 untouched;
+          - contract owed but the operationalization missing / invalid /
+            unstamped -> COVERAGE_UNDECLARED (fail-closed on the
+            undeclared, named reason + cause);
+          - generalization required|unknown AND zero armed cases ->
+            COVERAGE_MISSING (an absent verdict file is this block, never
+            untouched — the documented _load_oracle_status fail-open is
+            revoked at this gate for contracted workspaces);
+          - required|unknown + armed cases -> silent here (per-case
+            red/pending stays oracle_blocks()'s call);
+          - not-applicable -> silent (the DECLARED fast path — the
+            timestamped declaration is the audit record; a red verdict on
+            an existing case still blocks via oracle_blocks(): a
+            declaration covers absence of coverage, not failed cases)."""
+        op = self.goal_op()
+        if op["legacy"]:
+            return []
+        if not op["present"] or not op["valid"]:
+            cause = op["error"] or "; ".join(op["errors"]) or "undeclared"
+            return [f"{COVERAGE_UNDECLARED} ({GOAL_OP_NAME}: {cause})"]
+        if op["generalization"] in ("required", "unknown"):
+            if not self.armed_cases():
+                return [COVERAGE_MISSING]
+        return []
 
     def discovery_reason(self) -> str:
         """#147 discovery scan, cached. Computed only when DRAIN asks for it."""
@@ -1021,7 +1146,11 @@ def _oracle_case_red(s: _DecideInputs) -> bool:
     # instrumentation ("unknown" is not "pass"), and on an unreadable
     # verdict file (fail-closed); a missing file is legal (legacy
     # workspaces, no runner yet) — see oracle_blocks().
-    return bool(s.oracle_blocks())
+    # #147: the declared-coverage gate composes into the same acceptance
+    # event — an undeclared operationalization, or a declared
+    # required/unknown with zero armed cases, blocks exactly here (no
+    # second probe row; the issue scopes the gate INTO the oracle face).
+    return bool(s.oracle_blocks() or s.coverage_blocks())
 
 
 def _work_no_free_slot(s: _DecideInputs) -> bool:
@@ -1240,11 +1369,30 @@ def _act_active_workers(s: _DecideInputs) -> str:
 def _act_oracle_red(s: _DecideInputs) -> str:
     # #108: name the offending cases — the orchestrator fixes the
     # implementation (or the case) and re-runs oracle_runner.py.
-    blocks = "; ".join(s.oracle_blocks())
+    # #147: the declared-coverage reasons ride the same face. A pure
+    # coverage block (no case verdict exists to name) gets the coverage
+    # directive verbatim, plus the v0.1.5 SKELETON marker (explicitly
+    # interim): the segment boundary is a POLICY point over the designed
+    # action space and currently routes through failure-analysis routing;
+    # the policy-driven action space is the #12/#13/#59 v0.2 design
+    # landing — no operators/rollouts are implemented here.
+    cov = s.coverage_blocks()
+    case_blocks = s.oracle_blocks()
+    marker = (" [interim #147] the segment boundary routes through "
+              "failure-analysis routing; the policy-driven action space "
+              "is the #12/#13/#59 v0.2 design landing.")
+    if cov and not case_blocks:
+        return (f"Cannot CONVERGE: {cov[0]} -> deliver the declared "
+                f"verification: arm and pass oracle cases via "
+                f"oracle_runner.py (required/unknown generalization), or "
+                f"complete goal-operationalization.yaml first."
+                f"{marker}")
+    blocks = "; ".join(case_blocks + cov)
     return (f"Cannot CONVERGE: oracle runner verdict is not clean ({blocks}) "
             f"-> fix the implementation or strengthen the case, re-run "
             f"oracle_runner.py. A red or pending-instrumented case is not "
-            f"satisfiable: 'unknown' is not 'pass' (#108).")
+            f"satisfiable: 'unknown' is not 'pass' (#108)."
+            f"{marker if cov else ''}")
 
 
 def _act_stuck_workers(s: _DecideInputs) -> str:
@@ -1560,6 +1708,27 @@ def decide(workspace: Path, *, emit_snapshot: bool = True) -> dict:
     # for open_count in heartbeat reports). Without a verdict file the face
     # carries all-zero counts + an explicit absent marker.
     decision["oracle"] = snap.oracle_face()
+    # #147: the declared-coverage face — the #128 generalization declaration
+    # exactly as the gate read it. Attached ONLY when the workspace carries
+    # a coverage contract (goal-operationalization.yaml or task-oracle.yaml);
+    # a true-legacy workspace predates the contract and keeps its
+    # byte-frozen decide() shape (the #829 conditional-key precedent — the
+    # frozen anchor matrix has no contract-bearing case and stays valid
+    # without a re-pin).
+    op = snap.goal_op()
+    if not op["legacy"]:
+        cov = snap.coverage_blocks()
+        decision["declared_coverage"] = {
+            "declared": bool(op["present"] and op["valid"]),
+            "generalization": op["generalization"],
+            "declared_ts": op["declared_ts"],
+            "stamped": bool(op["declared_ts"]),
+            "post_dispatch": op["post_dispatch"],
+            "armed_cases": len(snap.armed_cases()),
+            "status": ("declared" if op["present"] and op["valid"]
+                       else "invalid" if op["present"] else "undeclared"),
+            "blocks": cov,
+        }
     # #634 Part A: PARK — every open claim waits on an EXTERNAL gate
     # (blocker external:true), no active workers, no partials pending.
     # That is legal idle, not a coerced BLOCKED/DISPATCH that burns ticks
@@ -1724,6 +1893,11 @@ def _human(d: dict) -> str:
                 line += (f" (low-discriminativity: {o['low_discriminativity']}"
                          f" — strengthen those cases)")
             lines.append(line)
+    dc = d.get("declared_coverage")  # #147: the declared-coverage face
+    if dc is not None:
+        lines.append(f"declared coverage: {dc['status']} "
+                     f"(generalization: {dc['generalization']}, "
+                     f"armed cases: {dc['armed_cases']})")
     if d.get("failure_blocked"):
         lines.append(f"failure-blocked: {d['failure_blocked']} (run failure_analysis_gate.py <ws> before re-dispatch or NEGATIVE)")
     if d["open_claims"] and d["open_count"] <= 12:

--- a/tests/test_declared_coverage_147.py
+++ b/tests/test_declared_coverage_147.py
@@ -1,0 +1,349 @@
+# -*- coding: utf-8 -*-
+"""#147 declared oracle coverage — the convergence gate consumes the #128 bit.
+
+Final semantics (issue body + owner amendments):
+
+  convergence requires DECLARED oracle coverage. The Phase-0
+  goal-operationalization.yaml ``generalization`` bit
+  (required | not-applicable | unknown, scripts/goal_operationalization.py)
+  is the coverage contract the DRAIN oracle face now enforces:
+
+    - operationalization missing / invalid / unstamped -> BLOCK
+      ("verification requirements undeclared — complete the Phase-0
+      operationalization") — fail-closed on the undeclared;
+    - generalization required|unknown AND zero ARMED oracle cases -> BLOCK
+      ("verification declared required but no oracle coverage delivered");
+      absence of the oracle status file is this block, never untouched;
+    - required|unknown + armed cases present -> the #108 oracle_blocks()
+      behavior unchanged (red / pending-instrumented block);
+    - generalization not-applicable -> the DECLARED fast path: converge
+      without cases, the timestamped declaration is the audit record;
+    - a red verdict on an existing case blocks regardless of the bit
+      (a declaration covers ABSENCE of coverage, not failed cases).
+
+  Legacy carve-out (deliberate, per the fail-closed posture): a workspace
+  with NO goal-operationalization.yaml AND NO task-oracle.yaml predates the
+  contract entirely (pre-#473) and keeps the #108 untouched behavior —
+  task-oracle.yaml registration (#473, heartbeat_tick._oracle_registered)
+  is the marker that a workspace owes the Phase-0 operationalization.
+
+Fixtures: (A) required + zero armed -> BLOCKED (this is THE hole — audit
+passes it pre-fix); (B) not-applicable + declared -> converges untouched,
+declaration visible in decide output; (C) missing operationalization ->
+BLOCKED; (D) unknown + zero -> BLOCKED; (E) required + armed green ->
+converges (normal path intact).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+TESTS = Path(__file__).parent
+if str(TESTS) not in sys.path:  # sibling-module import under and outside pytest
+    sys.path.insert(0, str(TESTS))
+
+import convergence_check as cc
+import goal_operationalization as go
+
+# Anchor builders: the converged-workspace factory shape is shared with the
+# #443 matrix and the #108 block in test_decide_state_machine.py.
+import test_decide_regression_anchor as anchor
+
+
+# ------------------------------------------------------------- factories
+
+def _mk_converged_ws(base: Path, name: str) -> Path:
+    """The fully drained claim face (same shape as the #108 block): claim
+    terminal/PROVEN, pq answered with a passes note, clean facts."""
+    ws = anchor._ws(base, name)
+    anchor._reg(ws, [{"id": "C-1", "status": "PROVEN",
+                      "answers_question": "q1"}])
+    anchor._ts(ws, anchor._pq_canonical())
+    anchor._notes(ws, {"n1.md": ("C-1", "passes")})
+    anchor._fact_dir(ws)
+    return ws
+
+
+def _write_task_oracle(ws: Path) -> None:
+    """#473-style verbatim task file (existence is the contract marker)."""
+    (ws / "task-oracle.yaml").write_text(
+        "task_text: analyze the payload\nopen_items: []\ndeferrals: []\n",
+        encoding="utf-8")
+
+
+def _goal_op_doc(generalization: str = "required",
+                 declared_ts: str = "2026-09-07T01:02:03+00:00") -> dict:
+    """A VALID goal-operationalization document (passes the #128 validator).
+
+    required/unknown carry the mandatory fresh-input probe case;
+    not-applicable carries the mandatory explicit diff_vs_verbatim entry
+    (declaring non-generalization IS a visible narrowing, R3)."""
+    doc = {
+        "schema": go.SCHEMA_ID,
+        "verbatim_ref": "task-oracle.yaml",
+        "declared_ts": declared_ts,
+        "generalization": generalization,
+        "deliverables": [
+            "the client generates valid output for never-captured inputs"],
+        "acceptance": ["oracle cases pass on fresh-input generation"],
+        "not_done": ["a replay of captured traffic does not count as done"],
+        "diff_vs_verbatim": [
+            "translated the verbatim ask into mechanically checkable lists"],
+        "probe_cases": ["fresh-input: generate valid output for a "
+                        "never-captured request"],
+    }
+    if generalization == "not-applicable":
+        doc["diff_vs_verbatim"].append(
+            "generalization not-applicable: the deliverable is judged on "
+            "the captured evidence only, no beyond-evidence inputs")
+        doc["probe_cases"] = []
+    return doc
+
+
+def _write_goal_op(ws: Path, doc: dict) -> None:
+    go.dump(ws / "goal-operationalization.yaml", doc)
+
+
+def _set_oracle_status(ws: Path, cases: dict) -> None:
+    """Synthetic convention (#108): runs/oracle-status.json, written by the
+    oracle runner — {"cases": {id: {"status", "pending_entries", ...}}}."""
+    runs = ws / "runs"
+    runs.mkdir(parents=True, exist_ok=True)
+    (runs / "oracle-status.json").write_text(
+        json.dumps({"schema": "oracle-status/1", "cases": cases}),
+        encoding="utf-8")
+
+
+# ------------------------------------------------- the acceptance fixtures
+
+def test_a_required_zero_armed_cases_blocks_147(tmp_path: Path) -> None:
+    """Fixture A (THE hole): generalization=required, zero armed cases.
+    Pre-fix the audit PASSES this workspace — CONVERGED with no oracle
+    coverage at all. Post-fix: BLOCKED, reason names the missing coverage."""
+    ws = _mk_converged_ws(tmp_path, "required_zero_armed")
+    _write_task_oracle(ws)
+    _write_goal_op(ws, _goal_op_doc("required"))
+    d = cc.decide(ws)
+    assert d["decision"] == "BLOCKED", (
+        f"#147: required + zero armed cases must not converge, "
+        f"got {d['decision']}")
+    assert d["exit_code"] == cc.EXIT_BLOCKED
+    assert "no oracle coverage delivered" in d["action"], d["action"][:300]
+    face = d.get("declared_coverage") or {}
+    assert face.get("generalization") == "required"
+    assert face.get("status") == "declared"
+
+
+def test_b_not_applicable_declared_converges_147(tmp_path: Path) -> None:
+    """Fixture B: the DECLARED fast path. not-applicable + timestamped
+    declaration -> converges untouched, and the declaration is VISIBLE in
+    the decide output (the audit record that the speed was declared, not
+    snuck)."""
+    ws = _mk_converged_ws(tmp_path, "not_applicable_declared")
+    _write_task_oracle(ws)
+    _write_goal_op(ws, _goal_op_doc("not-applicable"))
+    d = cc.decide(ws)
+    assert d["decision"] == "CONVERGED", (
+        f"#147: a declared not-applicable task converges without cases, "
+        f"got {d['decision']}: {d['action'][:200]}")
+    face = d.get("declared_coverage") or {}
+    assert face.get("generalization") == "not-applicable", (
+        "#147: the declaration must be visible in the decide output")
+    assert face.get("declared") is True
+    assert face.get("declared_ts"), "#147: the timestamp is the audit record"
+    assert face.get("blocks") == []
+
+
+def test_c_missing_operationalization_blocks_147(tmp_path: Path) -> None:
+    """Fixture C: a registered workspace (task-oracle.yaml present) with NO
+    goal-operationalization.yaml -> BLOCK, fail-closed on the undeclared."""
+    ws = _mk_converged_ws(tmp_path, "missing_op")
+    _write_task_oracle(ws)
+    d = cc.decide(ws)
+    assert d["decision"] == "BLOCKED", (
+        f"#147: a registered workspace without the operationalization must "
+        f"block, got {d['decision']}")
+    assert "verification requirements undeclared" in d["action"], \
+        d["action"][:300]
+    face = d.get("declared_coverage") or {}
+    assert face.get("status") == "undeclared"
+
+
+def test_d_unknown_zero_cases_blocks_147(tmp_path: Path) -> None:
+    """Fixture D: unknown is fail-closed (= required, #128 R3). Zero armed
+    cases -> BLOCK."""
+    ws = _mk_converged_ws(tmp_path, "unknown_zero_cases")
+    _write_task_oracle(ws)
+    _write_goal_op(ws, _goal_op_doc("unknown"))
+    d = cc.decide(ws)
+    assert d["decision"] == "BLOCKED", (
+        f"#147: unknown + zero armed cases must block (default-closed), "
+        f"got {d['decision']}")
+    assert "no oracle coverage delivered" in d["action"], d["action"][:300]
+
+
+def test_e_required_armed_green_converges_147(tmp_path: Path) -> None:
+    """Fixture E: the normal path intact. required + armed GREEN cases ->
+    converges (coverage delivered, acceptance face clean)."""
+    ws = _mk_converged_ws(tmp_path, "required_armed_green")
+    _write_task_oracle(ws)
+    _write_goal_op(ws, _goal_op_doc("required"))
+    _set_oracle_status(ws, {
+        "case-g1": {"status": "pass", "pending_entries": 0,
+                    "instrumented": True},
+        "case-g2": {"status": "pass", "pending_entries": 0,
+                    "instrumented": True},
+    })
+    d = cc.decide(ws)
+    assert d["decision"] == "CONVERGED", (
+        f"#147: required + armed green cases converge, got {d['decision']}: "
+        f"{d['action'][:200]}")
+    face = d.get("declared_coverage") or {}
+    assert face.get("armed_cases") == 2
+    assert face.get("blocks") == []
+
+
+# ------------------------------------------------- the contract boundaries
+
+def test_true_legacy_carveout_untouched_147(tmp_path: Path) -> None:
+    """True legacy (pre-#473: NO goal-operationalization.yaml AND NO
+    task-oracle.yaml) keeps the #108 untouched behavior — no coverage gate,
+    no declaration face (the workspace predates the contract entirely)."""
+    ws = _mk_converged_ws(tmp_path, "true_legacy")
+    d = cc.decide(ws)
+    assert d["decision"] == "CONVERGED"
+    assert "declared_coverage" not in d, (
+        "#147: a true-legacy workspace has no coverage contract to report")
+
+
+def test_invalid_generalization_value_blocks_147(tmp_path: Path) -> None:
+    """An undeclared bit value ('maybe') is a #128 loud-rejection wall —
+    the gate reads it as undeclared and blocks (fail-closed)."""
+    ws = _mk_converged_ws(tmp_path, "invalid_bit")
+    _write_task_oracle(ws)
+    _write_goal_op(ws, _goal_op_doc("maybe"))
+    d = cc.decide(ws)
+    assert d["decision"] == "BLOCKED"
+    assert "verification requirements undeclared" in d["action"], \
+        d["action"][:300]
+    assert d["declared_coverage"]["status"] == "invalid"
+
+
+def test_unstamped_operationalization_blocks_147(tmp_path: Path) -> None:
+    """#128 R4: a pre-registration without a timestamp is not a record —
+    the unstamped translation is an undeclared verification requirement."""
+    ws = _mk_converged_ws(tmp_path, "unstamped_op")
+    _write_task_oracle(ws)
+    _write_goal_op(ws, _goal_op_doc("required", declared_ts=""))
+    d = cc.decide(ws)
+    assert d["decision"] == "BLOCKED", (
+        f"#147: an unstamped operationalization is not a record, "
+        f"got {d['decision']}")
+    assert "verification requirements undeclared" in d["action"], \
+        d["action"][:300]
+
+
+def test_malformed_operationalization_blocks_147(tmp_path: Path) -> None:
+    """Unreadable/malformed YAML -> loud rejection (#128 GoalOpError) ->
+    the gate blocks with the cause (fail-closed, contradiction-gate
+    precedent)."""
+    ws = _mk_converged_ws(tmp_path, "malformed_op")
+    _write_task_oracle(ws)
+    (ws / "goal-operationalization.yaml").write_text(
+        "{not yaml: [", encoding="utf-8")
+    d = cc.decide(ws)
+    assert d["decision"] == "BLOCKED"
+    assert "verification requirements undeclared" in d["action"], \
+        d["action"][:300]
+
+
+def test_required_scaffold_only_still_blocks_147(tmp_path: Path) -> None:
+    """A status file with only UNINSTRUMENTED scaffold cases is still zero
+    ARMED coverage (#108: a scaffold never ran live instrumentation) —
+    required -> BLOCK, never a laundering path."""
+    ws = _mk_converged_ws(tmp_path, "required_scaffold_only")
+    _write_task_oracle(ws)
+    _write_goal_op(ws, _goal_op_doc("required"))
+    _set_oracle_status(ws, {"case-001": {"status": "pending",
+                                         "pending_entries": 2,
+                                         "instrumented": False}})
+    d = cc.decide(ws)
+    assert d["decision"] == "BLOCKED", (
+        f"#147: scaffold-only is not delivered coverage, got {d['decision']}")
+    assert "no oracle coverage delivered" in d["action"], d["action"][:300]
+    assert d["declared_coverage"]["armed_cases"] == 0
+
+
+def test_not_applicable_red_case_still_blocks_147(tmp_path: Path) -> None:
+    """A declaration covers ABSENCE of coverage, not failed cases: an armed
+    RED case blocks regardless of the bit (#108 acceptance face intact)."""
+    ws = _mk_converged_ws(tmp_path, "not_applicable_red")
+    _write_task_oracle(ws)
+    _write_goal_op(ws, _goal_op_doc("not-applicable"))
+    _set_oracle_status(ws, {"case-204": {"status": "fail",
+                                         "pending_entries": 0,
+                                         "instrumented": True}})
+    d = cc.decide(ws)
+    assert d["decision"] == "BLOCKED", (
+        f"#147: a red case blocks under not-applicable too, "
+        f"got {d['decision']}")
+    assert "case-204" in d["action"], d["action"][:300]
+
+
+def test_required_pending_instrumented_blocks_147(tmp_path: Path) -> None:
+    """required + armed PENDING-instrumented cases: coverage delivered but
+    not satisfiable — the #108 pending block rides unchanged."""
+    ws = _mk_converged_ws(tmp_path, "required_pend_instr")
+    _write_task_oracle(ws)
+    _write_goal_op(ws, _goal_op_doc("required"))
+    _set_oracle_status(ws, {"case-207": {"status": "pending",
+                                         "pending_entries": 3,
+                                         "instrumented": True}})
+    d = cc.decide(ws)
+    assert d["decision"] == "BLOCKED"
+    assert "case-207" in d["action"], d["action"][:300]
+    assert d["declared_coverage"]["armed_cases"] == 1
+
+
+def test_segment_boundary_interim_marker_147(tmp_path: Path) -> None:
+    """The v0.1.5 SKELETON marker (explicitly interim): the #147 coverage
+    action notes that the segment boundary routes through failure-analysis
+    routing, and that the policy-driven action space is the #12/#13/#59
+    v0.2 design landing."""
+    ws = _mk_converged_ws(tmp_path, "boundary_marker")
+    _write_task_oracle(ws)
+    _write_goal_op(ws, _goal_op_doc("required"))
+    d = cc.decide(ws)
+    assert "failure-analysis routing" in d["action"], d["action"][:400]
+    assert "interim" in d["action"]
+    assert "#12/#13/#59" in d["action"]
+
+
+# ------------------------------------------------------- structural pins
+
+def test_gate_composes_into_oracle_predicate_147() -> None:
+    """ORACLE_CASE_RED stays the single DRAIN acceptance event: the #147
+    coverage blocks compose into its predicate (no second probe row — the
+    issue scopes the gate INTO the existing oracle face)."""
+    pred = cc._EVENT_PREDICATES[cc.Event.ORACLE_CASE_RED]
+    assert callable(pred)
+    row = cc.TRANSITIONS[(cc.State.DRAIN, cc.Event.ORACLE_CASE_RED)]
+    assert row[0] is cc.State.BLOCKED
+
+
+def test_declaration_face_absent_for_legacy_anchor_shape(tmp_path: Path) -> None:
+    """The anchor corpus shape (no contract files) keeps its byte-frozen
+    decide() shape: no new keys, no verdict drift (#829 conditional-key
+    precedent; the frozen matrix stays valid without a re-pin)."""
+    ws = _mk_converged_ws(tmp_path, "anchor_shape")
+    d = cc.decide(ws)
+    assert d["decision"] == "CONVERGED"
+    assert d["oracle"] == {"red": 0, "green": 0, "pending": 0,
+                           "low_discriminativity": [], "blocked": [],
+                           "absent": True}
+    assert "declared_coverage" not in d

--- a/tests/test_heartbeat_off.py
+++ b/tests/test_heartbeat_off.py
@@ -47,12 +47,33 @@ def _make_ws(ws: Path, claims: list[dict] | None = None,
 
 def _closed_oracle(ws: Path) -> Path:
     """#717 dual-criterion fixture: a CLOSED task-oracle.yaml (the teardown
-    guard requires convergence AND a judge-clean oracle)."""
+    guard requires convergence AND a judge-clean oracle).
+    #147: a workspace carrying task-oracle.yaml owes the Phase-0 coverage
+    declaration — convergence now requires it, so the fixture declares
+    generalization: not-applicable (a synthetic teardown task judged on the
+    captured evidence only)."""
     (ws / "task-oracle.yaml").write_text(
         'task_text: "synthetic task"\n'
         "open_items:\n"
         "  - id: OC-1\n"
         "    closed_by: F-001\n",
+        encoding="utf-8",
+    )
+    (ws / "goal-operationalization.yaml").write_text(
+        "schema: goal-operationalization/1\n"
+        "verbatim_ref: task-oracle.yaml\n"
+        "declared_ts: '2026-08-13T00:00:00Z'\n"
+        "generalization: not-applicable\n"
+        "deliverables:\n"
+        "  - synthetic teardown fixture deliverable\n"
+        "acceptance:\n"
+        "  - convergence plus a judge-clean closed oracle (#717)\n"
+        "not_done:\n"
+        "  - an OPEN claim does not count as done\n"
+        "diff_vs_verbatim:\n"
+        "  - synthetic teardown fixture; generalization not-applicable — "
+        "judged on the captured evidence only\n"
+        "probe_cases: []\n",
         encoding="utf-8",
     )
     return ws


### PR DESCRIPTION
#147 — close the case-abstention fast-fake hole

## Problem

`convergence_check._load_oracle_status` was fail-open on an ABSENT oracle verdict file ("legacy workspaces converge untouched"), and `oracle_blocks()` only blocked on existing RED/pending-instrumented cases — zero armed cases = zero blocks. A workspace that never armed a case could converge untouched (hard-task fake-fast); nothing designed the easy-task fast path either.

## Fix — the #128 generalization bit is the coverage contract

The Phase-0 `goal-operationalization.yaml` `generalization` declaration (required | not-applicable | unknown) now gates convergence. Final semantics (issue body + owner amendments):

| declaration | armed cases | outcome |
|---|---|---|
| missing (task-oracle.yaml registered) / invalid / unstamped | — | BLOCK "verification requirements undeclared — complete the Phase-0 operationalization" (fail-closed) |
| required / unknown | zero (incl. absent status file, scaffold-only uninstrumented) | BLOCK "verification declared required but no oracle coverage delivered" |
| required / unknown | armed present | #108 `oracle_blocks()` unchanged (red / pending-instrumented block) |
| not-applicable + declared_ts | — | DECLARED fast path: converge untouched; declaration visible in the decide output face |
| any bit | a RED case exists | BLOCK regardless (a declaration covers absence of coverage, not failed cases) |

**Legacy carve-out:** a workspace with NO goal-operationalization.yaml AND NO task-oracle.yaml predates the contract entirely (pre-#473) and keeps the #108 untouched behavior — task-oracle.yaml registration (the `heartbeat_tick._oracle_registered` marker) is what makes a workspace owe the Phase-0 operationalization. When the age marker was ambiguous the gate fails closed, per the issue posture.

## Mechanics

- The gate composes into the EXISTING `ORACLE_CASE_RED` DRAIN event (no new machine row — the issue scopes it INTO the oracle face); `_act_oracle_red` names the coverage reasons verbatim.
- `decide()` attaches a conditional `declared_coverage` face (declared / generalization / declared_ts / stamped / post_dispatch / armed_cases / status / blocks) — attached ONLY for contract-bearing workspaces, so true-legacy workspaces keep their byte-frozen decide() shape (**#829 conditional-key precedent: the frozen anchor matrix passes with ZERO re-pin**, verified case-by-case — all anchor cases are contract-free shapes).
- v0.1.5 SKELETON marker (explicitly interim) rides the #147 coverage action: the segment boundary is a policy point over the composed action space (#12/#13/#59 v0.2 design landing), currently routed through failure-analysis routing. No operators/rollouts implemented.
- `tests/test_heartbeat_off.py` `_closed_oracle` fixture: writes task-oracle.yaml → now also declares generalization: not-applicable (fixture-intent fix, not a weakening).

## Tests

`tests/test_declared_coverage_147.py` (15 tests): fixtures A–E per the issue acceptance list (A is RED on the base tree — the hole proof), plus the contract boundaries: true-legacy carve-out, invalid/unstamped/malformed operationalization, scaffold-only laundering, red-under-not-applicable, pending-instrumented, segment-boundary marker, ORACLE_CASE_RED composition pin, anchor-shape pin.

## Gates

- Full suite: **5902 passed, 5 failed, 10 skipped** — the 5 failures are pre-existing at base 8e17741 (verified on a detached base worktree): `test_env_check::test_all_pass_exit_0` (documented baseline red) + 4 × `test_hypothesis_loop_integration_111` (its fixture predates the #126 `hypothesis_ref` admission requirement in oracle_runner — pre-existing, not touched here).
- ruff clean on touched files; deploy-manifest regenerated (`--write` && `--verify`, 389 entries).
- Review gate: 1 independent code-reviewer PASS (r1-147-coverage) over the full staged diff; no CRITICAL/HIGH findings (3 LOW cosmetic notes recorded in the evidence file).
- Anchor: tests/test_decide_regression_anchor.py green unmodified (zero drift, no re-pin needed).

## Not touched

scripts/oracle_runner.py (#146), scripts/outcome_capture.py (#132), mission_ledger (#133).