### PR TITLE
feat(#145): worker-entry lookup constitution — front-loaded lookups + rule slices (guidance, not enforcement)

### DIFF
--- a/agents/floss-filter.md
+++ b/agents/floss-filter.md
@@ -48,6 +48,23 @@ You are the dedicated post-processor for flare-floss output in `mal-recon` Stage
 
 **v6 critical:** You **write** `evidence/floss-filtered.json` yourself using the Write tool. The main loop does NOT write this file for you. Return a one-line summary of findings; the file is the primary output.
 
+## Reference lookup (aids, not mandates)
+
+- `references/_INDEX.md` — a methodology card may already cover this problem class (grep the index keywords: strings, floss, deobfuscate, noise filtering).
+- `tools/_INDEX.yaml` — a registered CLI may already cover this capability (the flare-floss pipeline remains primary; this covers gaps outside the pipeline).
+- `scripts/` — an existing parameterized CLI may be reusable.
+
+## Working rules
+
+- Explicit error handling at every level.
+- Never swallow errors silently.
+- No hardcoded secrets.
+- Validate inputs at boundaries.
+- Small focused functions.
+- Reuse-first.
+
+These lookups are advisory; where they yield nothing applicable, proceed with a hand-rolled implementation at your discretion.
+
 ## Inputs (passed by caller)
 
 - `floss_output_path`: `evidence/floss-raw.txt` (e.g., 20k lines for a Go binary)

--- a/agents/ghidra-light.md
+++ b/agents/ghidra-light.md
@@ -62,6 +62,23 @@ You perform **light static reconnaissance** via Ghidra. Two-tier strategy: try M
 
 **Autonomy rule:** the subagent AUTONOMOUSLY creates a Ghidra project via analyzeHeadless when MCP is offline — does NOT degrade silently. The user does not need to manually open Ghidra GUI.
 
+## Reference lookup (aids, not mandates)
+
+- `references/_INDEX.md` — a methodology card may already cover this problem class (grep the index keywords: ghidra, xref, decompile, static analysis).
+- `tools/_INDEX.yaml` — a registered CLI may already cover this capability (the Ghidra MCP / analyzeHeadless pipeline tools remain primary; this covers gaps outside the pipeline).
+- `scripts/` — an existing parameterized CLI may be reusable.
+
+## Working rules
+
+- Explicit error handling at every level.
+- Never swallow errors silently.
+- No hardcoded secrets.
+- Validate inputs at boundaries.
+- Small focused functions.
+- Reuse-first.
+
+These lookups are advisory; where they yield nothing applicable, proceed with a hand-rolled implementation at your discretion.
+
 ## How Ghidra MCP and analyzeHeadless relate
 
 - **Ghidra MCP bridge** (`<GHIDRA_MCP_DIR>/bridge_mcp_ghidra.py` — path from the workspace `analysis_state.txt` toolchain probe or the caller's input) exposes ~250 tools, but analysis tools are only registered after `connect_instance(project="<name>")` succeeds. Requires Ghidra GUI running + project open + MCP plugin enabled.

--- a/agents/go-symbols.md
+++ b/agents/go-symbols.md
@@ -60,6 +60,23 @@ isolation: none
 
 Recover Go symbols/types/itabs from pclntab via unstrip (no decompile) -> emit a Ghidra apply script **plus** a decision-and-annotation plan that ghidra-light persists onto the program.
 
+## Reference lookup (aids, not mandates)
+
+- `references/_INDEX.md` — a methodology card may already cover this problem class (grep the index keywords: go, pclntab, symbol recovery).
+- `tools/_INDEX.yaml` — a registered CLI may already cover this capability (the unstrip pipeline remains primary; this covers gaps outside the pipeline).
+- `scripts/` — an existing parameterized CLI may be reusable.
+
+## Working rules
+
+- Explicit error handling at every level.
+- Never swallow errors silently.
+- No hardcoded secrets.
+- Validate inputs at boundaries.
+- Small focused functions.
+- Reuse-first.
+
+These lookups are advisory; where they yield nothing applicable, proceed with a hand-rolled implementation at your discretion.
+
 ## Inputs (passed by caller)
 - `binary_path`: local Go binary
 - `evidence_dir`: mal-recon/<sha1>/evidence/

--- a/agents/kunglao-worker.md
+++ b/agents/kunglao-worker.md
@@ -45,6 +45,23 @@ You are the **WORKER** for the `kunglao-agent` orchestrator. The orchestrator
 dispatched you for ONE claim. You gather evidence and write the fact file.
 That is your entire job.
 
+## Reference lookup (aids, not mandates)
+
+- `references/_INDEX.md` — a methodology card may already cover this problem class (grep the index keywords for the claim's domain).
+- `tools/_INDEX.yaml` — a registered CLI may already cover this capability.
+- `scripts/` — an existing parameterized CLI may be reusable.
+
+## Working rules
+
+- Explicit error handling at every level.
+- Never swallow errors silently.
+- No hardcoded secrets.
+- Validate inputs at boundaries.
+- Small focused functions.
+- Reuse-first.
+
+These lookups are advisory; where they yield nothing applicable, proceed with a hand-rolled implementation at your discretion.
+
 ## ⚡ GOLDEN RULES (top of context — read these first)
 
 1. **MAKER, never CHECKER** (kunglao-agent §1b) — raw evidence only, NEVER a verdict.

--- a/agents/pefile-signature.md
+++ b/agents/pefile-signature.md
@@ -61,6 +61,23 @@ You extract two things DIE doesn't natively provide:
 1. **Authenticode digital signature** — full subject/issuer/serial/validity/cert chain via pefile
 2. **Packer family identification** — UPX/VMProtect/Themida/ASPack/MPRESS/PECompact/PELock/WinUPack via YARA + DIE cross-check
 
+## Reference lookup (aids, not mandates)
+
+- `references/_INDEX.md` — a methodology card may already cover this problem class (grep the index keywords: pe, authenticode, packer, yara).
+- `tools/_INDEX.yaml` — a registered CLI may already cover this capability (the pefile / YARA / DIE pipeline remains primary; this covers gaps outside the pipeline).
+- `scripts/` — an existing parameterized CLI may be reusable.
+
+## Working rules
+
+- Explicit error handling at every level.
+- Never swallow errors silently.
+- No hardcoded secrets.
+- Validate inputs at boundaries.
+- Small focused functions.
+- Reuse-first.
+
+These lookups are advisory; where they yield nothing applicable, proceed with a hand-rolled implementation at your discretion.
+
 ## Inputs (passed by caller)
 
 - `die_json_path`: `evidence/die.json` (already-written DIE output)

--- a/agents/web-re-worker.md
+++ b/agents/web-re-worker.md
@@ -93,6 +93,23 @@ five-section methodology is internalized below; read the quickref for depth).
 > structurally impossible; switch to the instruction-trace methodology
 > before burning more AST passes.
 
+## Reference lookup (aids, not mandates)
+
+- `references/_INDEX.md` — a methodology card may already cover this problem class (for the web lane the source of record is `references/re-library/web-re-quickref.md`).
+- `tools/_INDEX.yaml` — a registered CLI may already cover this capability (camoufox/CDP instrumentation and the quickref's unpack/deobfuscate CLIs remain primary; this covers gaps outside the pipeline).
+- `scripts/` — an existing parameterized CLI may be reusable.
+
+## Working rules
+
+- Explicit error handling at every level.
+- Never swallow errors silently.
+- No hardcoded secrets.
+- Validate inputs at boundaries.
+- Small focused functions.
+- Reuse-first.
+
+These lookups are advisory; where they yield nothing applicable, proceed with a hand-rolled implementation at your discretion.
+
 ## ⚡ GOLDEN RULES
 
 1. **MAKER, never CHECKER** (kunglao-agent §1b) — raw evidence only, never a

--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -83,15 +83,15 @@ files:
   - src: agents/floss-filter.md
     dest: .claude/agents/floss-filter.md
     kind: agent
-    sha256: afede035009233e2343fc9a563971d0805260cab58bb462bb53597485d9fddc9
+    sha256: 60287afafdc9d4dd498f8bcc4e03aec56cf1445ed076e4cfafe62ec2eaf3c9f3
   - src: agents/ghidra-light.md
     dest: .claude/agents/ghidra-light.md
     kind: agent
-    sha256: 4361102de61789d15abf23178a1e11afb32f460e2c49a6f18de7f28da1dbd963
+    sha256: cb1cd2a1f04b4de73148351ae2052a1d5a6c2f129435f684bb58fd8321b2c790
   - src: agents/go-symbols.md
     dest: .claude/agents/go-symbols.md
     kind: agent
-    sha256: 398d5edfc1522c5b6148c35df738b452bfeda1f22e6e21aa96d9198f6a58f98c
+    sha256: b4275f45f362e8f084e469d74d046cd7e18977851e21449e73fdc9e56c84d419
   - src: agents/kunglao-init-worker.md
     dest: .claude/agents/kunglao-init-worker.md
     kind: agent
@@ -103,11 +103,11 @@ files:
   - src: agents/kunglao-worker.md
     dest: .claude/agents/kunglao-worker.md
     kind: agent
-    sha256: d6f4c7700cb517c88e0714e074f91ad3e11e50f6f481f1675f6c366e98ec6f2a
+    sha256: 144fd8c18b58ad00f4aeb5ef42b20091b2fc0deab4e02afacb8cb0fc9dc22fdd
   - src: agents/pefile-signature.md
     dest: .claude/agents/pefile-signature.md
     kind: agent
-    sha256: 9592e4e1042131c8cae738a1aab099d84385a4074d226b23a4c71ce401339832
+    sha256: 9c870100b255ccfeb947abcf75717e7d2b6bf44fa755c7643fbb866f9cb1fdd1
   - src: agents/verdict-scorer.md
     dest: .claude/agents/verdict-scorer.md
     kind: agent
@@ -115,7 +115,7 @@ files:
   - src: agents/web-re-worker.md
     dest: .claude/agents/web-re-worker.md
     kind: agent
-    sha256: 2e241d6adf810b655fab62ba70af801e35ec3cb5c1cc9e3ae854b1e320e28834
+    sha256: 214d3d6830ca54d56e7b4cd8965c4c7413c0840e0ec7cf2cba430dac121700ea
   - src: scripts/_entry.py
     dest: .claude/scripts/_entry.py
     kind: scaffold

--- a/tests/test_worker_lookup_constitution_145.py
+++ b/tests/test_worker_lookup_constitution_145.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""tests/test_worker_lookup_constitution_145.py — worker-entry lookup
+constitution sync pin (issue #145, guidance layer — ZERO enforcement).
+
+Contract: every worker-facing agent file carries a front-loaded, formal-
+voice reference-lookup + working-rules block (owner-revised wording 2026-09-07:
+discretionary consultations — "a registered CLI may already cover this
+capability" — never imperative "use X first" framing), closing on the
+advisory-discretion line. Two byte-stable headings:
+  ## Reference lookup (aids, not mandates)
+  ## Working rules
+
+Position rule (owner ruling): IDENTITY FIRST — the file's H1 title and
+opening role prose stay ahead of the block (the agent learns who it is
+before where to look), so the block sits at the END of the opening
+identity/role prose, immediately before the file's first pre-existing `##`
+section. Still front-loaded: the block must sit within the first
+MAX_MARKER_BODY_LINE body lines. Guidance buried past line ~400 of a
+constitution loses to the immediate task text (issue #34 disease) — a block
+that rots to the bottom is behaviorally absent.
+
+Windows are measured body-relative (after YAML frontmatter, which runs
+40-76 lines today; the pure-insertion contract forbids rewriting it).
+
+Deliberately pinned to a fixed file list (WORKER_FILES): protocol agents
+(kunglao-redteam, kunglao-init-worker, verdict-scorer) are optional per the
+issue and absent from this registry.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AGENT_DIR = REPO_ROOT / "agents"
+
+# Worker-facing agent files (issue #145 target set, pinned — additions to
+# agents/ do NOT auto-enter this registry; extend explicitly).
+WORKER_FILES = (
+    "kunglao-worker.md",
+    "ghidra-light.md",
+    "go-symbols.md",
+    "floss-filter.md",
+    "pefile-signature.md",
+    "web-re-worker.md",
+)
+
+# Byte-stable block headings (sync markers).
+MARKER = "## Reference lookup (aids, not mandates)"
+RULES_MARKER = "## Working rules"
+
+# Byte-stable advisory-discretion closing line.
+CLOSING = "proceed with a hand-rolled implementation at your discretion"
+
+# Compressed rule slice (worker-relevant subset; the full rule text stays
+# out of agent files — context budget).
+RULE_SLICE_MARKERS = (
+    "Explicit error handling at every level",
+    "Never swallow errors silently",
+    "No hardcoded secrets",
+    "Validate inputs at boundaries",
+    "Small focused functions",
+    "Reuse-first",
+)
+
+# Owner-rejected first-draft forms (2026-09-07): MUST NOT reappear — the
+# registry wording was covert-mandate ("...first") and the closing line plus
+# system-meta commentary were informal. Guarded here so a future edit cannot
+# silently regress to the rejected form.
+REJECTED_FORMS = (
+    "Before you build (first 3 lookups",
+    "Hand-roll freely",
+    "rule files never load in subagent sessions",
+)
+
+# "Still early": the Reference-lookup heading must sit within the first N
+# body lines (identity prose stays ahead of it; web-re-worker's opening
+# prose puts it deepest at body line 20).
+MAX_MARKER_BODY_LINE = 40
+
+
+def _body_lines(path: Path) -> list[str]:
+    """Lines after the YAML frontmatter closing `---` (fail-closed on
+    missing/malformed frontmatter)."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert lines and lines[0].strip() == "---", f"{path.name}: no frontmatter"
+    try:
+        end = lines.index("---", 1)
+    except ValueError as exc:  # unterminated frontmatter
+        raise AssertionError(f"{path.name}: unterminated frontmatter") from exc
+    return lines[end + 1 :]
+
+
+def _marker_idx(body: list[str], name: str) -> int:
+    hits = [i for i, line in enumerate(body) if line.strip() == MARKER]
+    assert hits, f"{name}: block heading missing: {MARKER!r}"
+    return hits[0]
+
+
+@pytest.mark.parametrize("name", WORKER_FILES)
+def test_block_within_first_n_body_lines(name: str) -> None:
+    body = _body_lines(AGENT_DIR / name)
+    idx = _marker_idx(body, name)
+    assert idx < MAX_MARKER_BODY_LINE, (
+        f"{name}: block heading at body line {idx + 1} — not front-loaded "
+        f"(must sit within the first {MAX_MARKER_BODY_LINE} body lines)"
+    )
+
+
+@pytest.mark.parametrize("name", WORKER_FILES)
+def test_identity_precedes_block(name: str) -> None:
+    """Owner position ruling: the H1 identity title comes BEFORE the block
+    (the agent learns who it is before where to look)."""
+    body = _body_lines(AGENT_DIR / name)
+    marker_idx = _marker_idx(body, name)
+    h1_idx = next(
+        (i for i, line in enumerate(body) if line.lstrip().startswith("# ")),
+        None,
+    )
+    assert h1_idx is not None, f"{name}: no H1 identity title in body"
+    assert h1_idx < marker_idx, (
+        f"{name}: block (body line {marker_idx + 1}) precedes the H1 "
+        f"identity title (body line {h1_idx + 1}) — identity must come first"
+    )
+
+
+@pytest.mark.parametrize("name", WORKER_FILES)
+def test_block_precedes_existing_first_heading(name: str) -> None:
+    """Position: the block closes the opening identity/role prose — it sits
+    before the file's pre-existing first `##` section heading (its own two
+    headings do not count)."""
+    body = _body_lines(AGENT_DIR / name)
+    marker_idx = _marker_idx(body, name)
+    section_idx = next(
+        (
+            i
+            for i, line in enumerate(body)
+            if line.lstrip().startswith("## ")
+            and line.strip() not in (MARKER, RULES_MARKER)
+        ),
+        None,
+    )
+    assert section_idx is not None, f"{name}: no content section in body"
+    assert marker_idx < section_idx, (
+        f"{name}: block (body line {marker_idx + 1}) sits AFTER the existing "
+        f"first section heading (body line {section_idx + 1}) — block must "
+        "close the opening identity/role prose"
+    )
+
+
+@pytest.mark.parametrize("name", WORKER_FILES)
+def test_closing_line_present(name: str) -> None:
+    text = (AGENT_DIR / name).read_text(encoding="utf-8")
+    assert CLOSING in text, f"{name}: closing line missing: {CLOSING!r}"
+
+
+@pytest.mark.parametrize("name", WORKER_FILES)
+def test_rule_slice_present(name: str) -> None:
+    text = (AGENT_DIR / name).read_text(encoding="utf-8")
+    missing = [m for m in RULE_SLICE_MARKERS if m not in text]
+    assert not missing, f"{name}: rule-slice lines missing: {missing}"
+
+
+@pytest.mark.parametrize("name", WORKER_FILES)
+def test_no_rejected_form(name: str) -> None:
+    """The owner-rejected first-draft wording must not reappear."""
+    text = (AGENT_DIR / name).read_text(encoding="utf-8")
+    hits = [r for r in REJECTED_FORMS if r in text]
+    assert not hits, f"{name}: owner-rejected wording reappeared: {hits}"


### PR DESCRIPTION
## Summary

Implements #145 (v0.1.5). Every worker-facing agent file now carries a front-loaded, formal-voice lookup-and-rules block, so the registry affordance is discoverable at the worker's moment of starting work instead of buried past line ~400 where context rot makes guidance behaviorally absent (issue #34 disease). Guidance only — zero enforcement; the dispatch-layer teeth (tool-first gate, agenttype gate, script discipline) are untouched.

Owner-revised design (2026-09-07 rulings applied):
- **Identity first** — the block sits after the H1 title + opening role prose, immediately before the file's first pre-existing section; the agent learns who it is before where to look.
- **Discretionary phrasing** — "a methodology card may already cover this problem class" / "a registered CLI may already cover this capability" / "an existing parameterized CLI may be reusable"; no "use X first" / "before writing" imperative framing.
- **Formal charter voice** — advisory-discretion closing line; the system-meta rationale lives in commit messages, not worker-facing text.

## Changes

- `agents/{kunglao-worker,ghidra-light,go-symbols,floss-filter,pefile-signature,web-re-worker}.md`: pure insertion, +17 lines each (102 total), zero modification of existing content:
  - `## Reference lookup (aids, not mandates)` — references/_INDEX.md, tools/_INDEX.yaml, scripts/; specialists note their fixed pipeline remains primary (registries cover gaps).
  - `## Working rules` — explicit error handling; never swallow errors; no hardcoded secrets; validate inputs at boundaries; small focused functions; reuse-first.
  - Closing advisory line: hand-rolled implementations remain at the agent's discretion.
- `tests/test_worker_lookup_constitution_145.py`: sync pin — byte-stable headings + closing line, 6 rule-slice markers, position guards (identity precedes block; block precedes first pre-existing `##` section; within first 40 body lines, body-relative after frontmatter), owner-rejected-form guard, fixed 6-file registry (protocol agents optional per the issue, excluded).
- `deploy-manifest.yaml`: mechanical regen (389 entries) — agent definitions are deployed surface (#783).

## Non-goals

No hooks, no gates, no rejection paths; no changes to dispatch_gate / worker_budget / skills/ / templates/ (verified: diff is pure addition, +276/-0 across feature commits).

## Test plan

- [x] `env -u KUNGLAO_VALUE_ALGO python3 -m pytest tests/test_worker_lookup_constitution_145.py -q` — 36/36 green (incl. mutation-verified guards: block deletion, moved-below-section, rejected-wording revert, block-above-H1 all fail the pin)
- [x] Full suite at HEAD: 5921 passed / 11 skipped / 6 failed — 5 failures pre-exist on bare base 8e17741 (4x test_hypothesis_loop_integration_111, 1x test_env_check::test_all_pass_exit_0 documented baseline red), verified by running them on a clean baseline worktree; 1x test_load_lock is a transient machine-lock contention flake (7/7 green in isolation)
- [x] `ruff check .` — 5 pre-existing baseline findings only (hooks/dispatch_gate.py F841 + 4 test-file F401s), none in changed files
- [x] `python3 scripts/deploy_manifest.py --verify` — 389 entries green
- [x] Review gate: one code-reviewer PASS on the staged diff (mutation-tested), per-commit mints `r1-145-constitution`