### PR TITLE
feat(#146): outcome forensics — settlements record how they were won/lost; failure-analysis arming; case-abandonment protocol

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -351,7 +351,7 @@ files:
   - src: scripts/failure_analysis_gate.py
     dest: .claude/scripts/failure_analysis_gate.py
     kind: scaffold
-    sha256: 0d8c0d1b05e9be82de327c0f76f4a1134ea1b247c34b8684606a172e56119dd1
+    sha256: b2c4090b6f88987aac78a3cbc8df860f3df1ee064917951990db52bc17c8456e
   - src: scripts/feedback.py
     dest: .claude/scripts/feedback.py
     kind: scaffold
@@ -583,7 +583,7 @@ files:
   - src: scripts/oracle_runner.py
     dest: .claude/scripts/oracle_runner.py
     kind: scaffold
-    sha256: 8c1c4c083ec3fbed0a4f2308eabbc4b4533125b054eb39a7aa2da388c86020d1
+    sha256: 4c9bc8a3e7d2b024bcd0bd09991a99b83ceb44b8999587d7cdbfb7379aa9b1bb
   - src: scripts/outcome_capture.py
     dest: .claude/scripts/outcome_capture.py
     kind: scaffold

--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -207,7 +207,7 @@ files:
   - src: scripts/case_bank.py
     dest: .claude/scripts/case_bank.py
     kind: scaffold
-    sha256: 39221df879fa1e7ade6d9c6628ddde01dd1092e825f77bb87d646d2a003e6471
+    sha256: bf2be8f370f50dab53f3b18b13b213f2b20138c69c95a5c6c8cf2ef5f012b12a
   - src: scripts/challenge_ledger.py
     dest: .claude/scripts/challenge_ledger.py
     kind: scaffold
@@ -339,7 +339,7 @@ files:
   - src: scripts/event_taxonomy.py
     dest: .claude/scripts/event_taxonomy.py
     kind: scaffold
-    sha256: 77af56acf70b22ad008f086b702eab2f2535bdc3b14446807680a27604809902
+    sha256: d09e0ef3a8b46a51197ac06bae40753e9c66b755630549ce8151f238111145e2
   - src: scripts/external_kicker.py
     dest: .claude/scripts/external_kicker.py
     kind: scaffold
@@ -351,7 +351,7 @@ files:
   - src: scripts/failure_analysis_gate.py
     dest: .claude/scripts/failure_analysis_gate.py
     kind: scaffold
-    sha256: 768f0f67db4e6b7ed15763a23859114be707fa2b4029f441349a1754e4c72a0a
+    sha256: 0d8c0d1b05e9be82de327c0f76f4a1134ea1b247c34b8684606a172e56119dd1
   - src: scripts/feedback.py
     dest: .claude/scripts/feedback.py
     kind: scaffold
@@ -483,7 +483,7 @@ files:
   - src: scripts/kunglao_log.py
     dest: .claude/scripts/kunglao_log.py
     kind: scaffold
-    sha256: 9c923141071642f27afd7af1249fe2a3c2180822683154d127bb74ef5ee66327
+    sha256: 860ee9b60e35ca9f9fccc99f3dd1dcf09d5671fb7c9e53851e9da9459dba9045
   - src: scripts/kunglao_record.py
     dest: .claude/scripts/kunglao_record.py
     kind: scaffold
@@ -583,7 +583,7 @@ files:
   - src: scripts/oracle_runner.py
     dest: .claude/scripts/oracle_runner.py
     kind: scaffold
-    sha256: 3f390170a677f731eaa4c39ec4e6bc0912ef4655a70e239749dc0ce7c326c27b
+    sha256: 8c1c4c083ec3fbed0a4f2308eabbc4b4533125b054eb39a7aa2da388c86020d1
   - src: scripts/outcome_capture.py
     dest: .claude/scripts/outcome_capture.py
     kind: scaffold

--- a/scripts/case_bank.py
+++ b/scripts/case_bank.py
@@ -21,10 +21,14 @@ Owner ruling 4 (this module's whole contract):
 
 Schema (runs/case-bank.jsonl, one JSON object per line):
   {ts, claim_id, method, context_tags, intent_uncertainty, outcome_observed,
-   roi_class, attribution, premise_correction}
+   roi_class, attribution, premise_correction, how}
   - ts / claim_id / method / roi_class: required (ts filled on append).
   - attribution: required non-empty IFF roi_class == NEGATIVE (ruling 4).
   - premise_correction: optional.
+  - how (#146): OPTIONAL structured forensics block (the outcome's
+    mechanism: mismatch_class / mechanism note) — a mapping when present,
+    refused otherwise (free text is a label, not a lesson); NEVER
+    required: banked rows predating #146 read back with how=None.
   - context_tags: normalized to list[str]; intent_uncertainty: the named
     uncertainty from the dispatch intent (roi_settlement gate, ruling 3).
   - roi_class: roi_settlement's four classes (POSITIVE/NEUTRAL/NEGATIVE/
@@ -102,6 +106,15 @@ def append(ws: Path, entry: dict) -> dict:
     tags = e.get("context_tags")
     if isinstance(tags, str):
         tags = [tags]
+    # #146: `how` is the structured forensics block — a mapping when
+    # present, refused otherwise (free text is a label, not a lesson);
+    # absent stays absent (back-compat with banked rows).
+    how = e.get("how")
+    if how is not None and not isinstance(how, dict):
+        raise CaseBankError(
+            f"case-bank entry for {e['claim_id']} refused: `how` must be a "
+            f"structured mapping (mismatch_class / mechanism), not "
+            f"{type(how).__name__} — a label is not a lesson (#146)")
     stored = {
         "ts": str(e.get("ts") or utc_now_iso()),
         "claim_id": str(e["claim_id"]),
@@ -114,6 +127,7 @@ def append(ws: Path, entry: dict) -> dict:
         "attribution": attribution or None,
         "premise_correction": str(e.get("premise_correction") or "").strip()
         or None,
+        "how": dict(how) if isinstance(how, dict) else None,
     }
     p = bank_path(ws)
     p.parent.mkdir(parents=True, exist_ok=True)
@@ -174,7 +188,8 @@ def retrieve(ws: Path, context_tags: list, limit: int = 5) -> list[dict]:
 
 
 def _hint_line(entry: dict) -> str:
-    """One human-readable line; failures carry attribution + correction."""
+    """One human-readable line; failures carry attribution + correction;
+    the #146 `how` block surfaces its mechanism when present."""
     tags = ",".join(entry.get("context_tags") or [])
     head = (f"[{entry.get('roi_class')}] {entry.get('claim_id')} "
             f"method={entry.get('method')} tags={tags}")
@@ -185,6 +200,12 @@ def _hint_line(entry: dict) -> str:
         parts.append(f"attribution: {entry['attribution']}")
     if entry.get("premise_correction"):
         parts.append(f"correction: {entry['premise_correction']}")
+    how = entry.get("how")
+    if isinstance(how, dict):
+        mcls = str(how.get("mismatch_class") or "").strip()
+        mech = str(how.get("mechanism") or "").strip()
+        if mcls or mech:
+            parts.append(f"how: {mcls}{': ' + mech if mech else ''}")
     return " | ".join(parts)
 
 

--- a/scripts/event_taxonomy.py
+++ b/scripts/event_taxonomy.py
@@ -154,6 +154,7 @@ ALL_EVENT_TYPES = [
 #                                toolchain_install #700 per-item install events
 #   git_snapshot_skipped  kunglao_upgrade.py / kunglao-init.py  #739 git snapshot WARN faces
 EMIT_ACTIONS = [
+    "acceptance_coverage_decreased",  # #146 oracle_runner case-retirement coverage-drop WARN
     "agents_refresh",     # #755 A2 upgrade L2 subagents re-copy face
     "analysis_blocked",
     "analysis_recorded",

--- a/scripts/failure_analysis_gate.py
+++ b/scripts/failure_analysis_gate.py
@@ -51,13 +51,20 @@ blocks the record. `novel-hypothesis` additionally requires non-empty
 candidates: at least the lessons rung must have a recorded hit before a
 novel experiment may be declared (it occupies budget).
 
-Enforcement: a claim with a prior failed attempt (promotion_attempts > 0,
-status non-terminal) that has NO current failure_analysis — or whose
-analysis is missing either artifact — is BLOCKED. The orchestrator cannot
-re-dispatch through the normal flow until the analysis is recorded.
+Enforcement (#146 re-point): the DEAD promotion_attempts arming is removed.
+A claim ARMS when it has >=1 recorded fail settlement on an oracle case
+linked via the claim's ``answers_question`` <-> case ``target_pq`` (the
+same linkage priority_ratio.py uses) and has no covering analysis — then
+re-dispatch is BLOCKED until the analysis is recorded. Settlement state
+comes from the #106 posterior ledger (runs/posteriors.yaml): each red run
+is beta+1 over the Beta(1,1) prior, so a case's fail-settlement count is
+beta-1. Coverage is settlement-versioned too: an analysis records
+``covers_settlements`` (the red total at record time); a NEW red settlement
+drives the total past it and re-arms the gate — each failed attempt needs
+its own analysis, derived, not counted by a writer no live path has.
 
-Each failed attempt needs its own analysis (covers_attempt versioning) — you can't
-coast on the reasoning from attempt 1 when attempt 3 also fails.
+Each failed attempt needs its own analysis (covers_settlements versioning) —
+you can't coast on the reasoning from attempt 1 when attempt 3 also fails.
 
 Usage:
   # check mode — which claims need analysis?
@@ -142,8 +149,8 @@ def _emit_failure_blocked(workspace: Path, d: dict) -> None:
     log. #495 split (#459): a BLOCKED whose analysis is missing the three
     failure artifacts emits analysis_blocked with the missing list (the
     Orient layer's direct to-do); a pure stale-coverage BLOCKED
-    (covers_attempt lags, artifacts all present) keeps failure_blocked —
-    one event per BLOCKED, the word carries the reason.
+    (covers_settlements lags the red total, artifacts all present) keeps
+    failure_blocked — one event per BLOCKED, the word carries the reason.
 
     Guarded — logging must never break the gate (a failed analysis run keeps
     its exit code and BLOCKED output even if the log write fails).
@@ -151,16 +158,18 @@ def _emit_failure_blocked(workspace: Path, d: dict) -> None:
     try:
         from kunglao_log import emit
         missing = d.get("missing_artifacts") or []
+        red_total = sum(int(v) for v in
+                        (d.get("red_settlements") or {}).values())
         if missing:
             emit(workspace, actor="orchestrator", action="analysis_blocked",
                  claim=d.get("claim_id"),
                  detail=f"missing_artifacts={','.join(missing)} "
-                        f"attempts={d.get('promotion_attempts')}")
+                        f"red_settlements={red_total}")
         else:
             emit(workspace, actor="orchestrator", action="failure_blocked",
                  claim=d.get("claim_id"),
                  detail=f"status={d.get('status')} "
-                        f"attempts={d.get('promotion_attempts')}")
+                        f"red_settlements={red_total}")
     except Exception:
         pass
 
@@ -202,13 +211,64 @@ def _load_analysis(workspace: Path, claim_id: str):
         return None
 
 
-def _needs_analysis(claim: dict) -> bool:
-    """A claim needs failure analysis if it was attempted (promotion_attempts > 0)
-    but hasn't reached terminal status — a dispatch happened and didn't close it."""
+def linked_fail_settlements(ws: Path, claim: dict) -> dict[str, int]:
+    """#146 arming data: case_id -> recorded fail-settlement count, for the
+    oracle cases linked to this claim via ``target_pq == answers_question``
+    (the priority_ratio linkage).
+
+    Settlement state = the #106 posterior ledger (runs/posteriors.yaml) —
+    "runner red/green is the only reward signal": each red run is beta+1
+    over the Beta(1,1) case prior, so a case's fail count is beta-1. A
+    retired case has left the acceptance net (#146) and arms nothing.
+    Missing ledger degrades per posteriors.py's fail-open load contract; a
+    WRONG ledger schema raises (the version wall — never a silent wrong
+    read).
+    """
+    pq = str((claim or {}).get("answers_question") or "").strip()
+    if not pq:
+        return {}
+    from oracle_runner import RETIRED_CASE_STATUS  # lazy: no new import edge
+    cdir = Path(ws) / "oracle" / "cases"
+    if not cdir.is_dir():
+        return {}
+    linked: dict[str, int] = {}
+    for p in sorted(cdir.glob("*.yaml")):
+        try:
+            doc = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+        except Exception:  # noqa: BLE001 — unreadable case is not evidence
+            continue
+        if not isinstance(doc, dict):
+            continue
+        case_id = str(doc.get("id") or p.stem).strip()
+        target_pq = str(doc.get("target_pq") or "").strip()
+        if not case_id or not target_pq or target_pq != pq:
+            continue
+        if str(doc.get("status") or "").strip() == RETIRED_CASE_STATUS:
+            continue  # retired left the acceptance net — arms nothing
+        linked[case_id] = 0
+    if not linked:
+        return {}
+    try:
+        import posteriors as po
+        led = po.PosteriorLedger.load(ws)
+    except Exception:  # noqa: BLE001 — missing ledger degrades, not blocks
+        return {}
+    for case_id in linked:
+        cp = led.cases.get(case_id)
+        linked[case_id] = int(round(max((cp.beta if cp else 1.0) - 1.0, 0.0)))
+    return {cid: n for cid, n in linked.items() if n > 0}
+
+
+def _needs_analysis(claim: dict, reds: dict[str, int]) -> bool:
+    """A claim needs failure analysis when the settlements say it does:
+    >=1 fail settlement on a linked oracle case (reds non-empty) while the
+    claim is non-terminal. The promotion_attempts counter is GONE from the
+    arming predicate (#146: it had no live writer — init seeded 0, retract
+    reset 0 — so it never fired in production)."""
     status = (claim.get("status") or "UNKNOWN").upper()
     if status in TERMINAL:
         return False
-    return int(claim.get("promotion_attempts") or 0) > 0
+    return sum(int(v) for v in (reds or {}).values()) > 0
 
 
 def _artifact_gaps(analysis: dict) -> list[str]:
@@ -223,19 +283,18 @@ def _artifact_gaps(analysis: dict) -> list[str]:
     return gaps
 
 
-def _analysis_covers(analysis: dict, claim: dict) -> bool:
-    """Does the recorded analysis cover the latest failed attempt?
-    covers_attempt must match (or exceed) the claim's current promotion_attempts.
-    #495: the three failure artifacts must ALSO be present — an analysis that
-    answers the three questions in prose but records no validated_capability /
-    identified_obstacle is exactly the v0.1.1 trajectory-1 evidence evaporation
-    (decomposition-level knowledge lived in narrative and evaporated on pivot);
-    it does not unblock re-dispatch."""
+def _analysis_covers(analysis: dict, reds: dict[str, int]) -> bool:
+    """Does the recorded analysis cover the CURRENT settlements?
+    #495: the three failure artifacts must be present. #146: coverage is
+    settlement-versioned — the analysis carries ``covers_settlements``
+    (the linked red total at record time); a NEW red settlement drives the
+    total past it and the gate re-arms. Each failed attempt needs its own
+    analysis, derived from the settlement ledger instead of the unwritten
+    promotion_attempts counter."""
     if not analysis:
         return False
-    covers = int(analysis.get("covers_attempt") or 0)
-    attempts = int(claim.get("promotion_attempts") or 0)
-    if covers < attempts:
+    red_total = sum(int(v) for v in (reds or {}).values())
+    if int(analysis.get("covers_settlements") or 0) < red_total:
         return False
     return not _artifact_gaps(analysis)
 
@@ -250,21 +309,23 @@ def check_claim(workspace: Path, claim_id: str, library: Path | None = None) -> 
     if status in TERMINAL:
         return {"state": "TERMINAL", "claim_id": claim_id, "status": status}
 
-    if not _needs_analysis(claim):
+    # #146: arming is settlement-derived — the linked case reds.
+    reds = linked_fail_settlements(workspace, claim)
+    if not _needs_analysis(claim, reds):
         return {"state": "OK_NO_PRIOR_FAILURE", "claim_id": claim_id,
-                "promotion_attempts": claim.get("promotion_attempts")}
+                "red_settlements": reds}
 
     analysis = _load_analysis(workspace, claim_id)
-    if _analysis_covers(analysis, claim):
+    if _analysis_covers(analysis, reds):
         return {"state": "OK_COVERED", "claim_id": claim_id,
-                "promotion_attempts": claim.get("promotion_attempts"),
+                "red_settlements": reds,
                 "analysis": analysis}
 
     return {
         "state": "BLOCKED",
         "claim_id": claim_id,
         "status": status,
-        "promotion_attempts": claim.get("promotion_attempts"),
+        "red_settlements": reds,
         "evidence_tier_attempted": claim.get("evidence_tier_attempted"),
         "statement": (claim.get("statement") or "")[:200],
         "evidence": claim.get("evidence") or [],
@@ -281,14 +342,16 @@ def check_claim(workspace: Path, claim_id: str, library: Path | None = None) -> 
 
 
 def scan_workspace(workspace: Path, library: Path | None = None) -> list:
-    """Return all claims that currently BLOCK (failed attempt, no current analysis)."""
+    """Return all claims that currently BLOCK (a linked case carries fail
+    settlements and no covering analysis)."""
     claims, _ = _load_claims(workspace)
     blocked = []
     for c in claims:
-        if not _needs_analysis(c):
+        reds = linked_fail_settlements(workspace, c)
+        if not _needs_analysis(c, reds):
             continue
         analysis = _load_analysis(workspace, c.get("id"))
-        if not _analysis_covers(analysis, c):
+        if not _analysis_covers(analysis, reds):
             blocked.append(check_claim(workspace, c.get("id"), library=library))
     return blocked
 
@@ -385,9 +448,13 @@ def record_analysis(workspace: Path, claim_id: str, assumption: str,
 
     adir = workspace / ANALYSES_DIR
     adir.mkdir(parents=True, exist_ok=True)
+    # #146: coverage versioning derives from the settlement ledger (the
+    # linked red total at record time) — the unwritten counter is gone.
+    red_total = sum(int(v) for v in
+                    linked_fail_settlements(workspace, claim).values())
     entry = {
         "claim": claim_id,
-        "covers_attempt": int(claim.get("promotion_attempts") or 0),
+        "covers_settlements": red_total,
         "method_assumption": assumption,
         "assumption_validity": validity,
         "next_method": next_method,
@@ -829,12 +896,18 @@ def _failure_modes_recall() -> tuple[str, ...]:
 
 def _print_blocked(d: dict) -> None:
     cid = d["claim_id"]
-    print(f"=== BLOCKED: {cid} (status={d.get('status')}, attempts={d.get('promotion_attempts')}) ===")
+    red_total = sum(int(v) for v in (d.get("red_settlements") or {}).values())
+    print(f"=== BLOCKED: {cid} (status={d.get('status')}, "
+          f"red_settlements={red_total} over "
+          f"{len(d.get('red_settlements') or {})} linked case(s)) ===")
     print(f"claim: {d.get('statement','')}")
     if d.get("evidence"):
         print(f"evidence so far: {d['evidence']}")
     if d.get("stale_analysis"):
-        print(f"stale analysis (covers attempt {d['stale_analysis'].get('covers_attempt')}): update it")
+        print(f"stale analysis (covers_settlements="
+              f"{d['stale_analysis'].get('covers_settlements')} < "
+              f"{red_total}): update it — a NEW fail settlement needs a "
+              f"fresh analysis")
     print()
     print("Before re-dispatching OR concluding NEGATIVE, answer three questions")
     print("(reason from THIS specific failure - do not pick from a fixed menu):")
@@ -1044,11 +1117,13 @@ def main(argv: list[str] | None = None) -> int:
             if r["state"] == "BLOCKED":
                 _print_blocked(r)
             elif r["state"] == "OK_COVERED":
-                print(f"OK: {args.claim_id} - analysis covers attempt {r.get('promotion_attempts')}")
+                print(f"OK: {args.claim_id} - analysis covers "
+                      f"{r.get('red_settlements')} fail settlement(s)")
             elif r["state"] == "TERMINAL":
                 print(f"OK: {args.claim_id} - terminal ({r.get('status')}), no analysis needed")
             elif r["state"] == "OK_NO_PRIOR_FAILURE":
-                print(f"OK: {args.claim_id} - no prior failed attempt (attempts={r.get('promotion_attempts')})")
+                print(f"OK: {args.claim_id} - no fail settlements on linked "
+                      f"oracle cases (red_settlements={r.get('red_settlements')})")
             else:
                 print(f"FAIL: claim {args.claim_id} not found")
         return 1 if r["state"] == "BLOCKED" else (2 if r["state"] == "NOT_FOUND" else 0)

--- a/scripts/failure_analysis_gate.py
+++ b/scripts/failure_analysis_gate.py
@@ -248,9 +248,13 @@ def linked_fail_settlements(ws: Path, claim: dict) -> dict[str, int]:
         linked[case_id] = 0
     if not linked:
         return {}
+    import posteriors as po
     try:
-        import posteriors as po
         led = po.PosteriorLedger.load(ws)
+    except po.PosteriorSchemaError:
+        raise  # the version wall: a wrong-schema ledger must never be
+        # silently read as "no settlements" — that would un-arm the gate
+        # exactly when the ledger is untrustworthy (#146 review r1-1)
     except Exception:  # noqa: BLE001 — missing ledger degrades, not blocks
         return {}
     for case_id in linked:

--- a/scripts/kunglao_log.py
+++ b/scripts/kunglao_log.py
@@ -85,7 +85,8 @@ LEGACY_ACTORS = frozenset({
     "kunglao_record", "kunglao_resume", "kunglao_status", "kunglao_upgrade",
     "kubectl_test", "lessons_telemetry", "lint", "log_setup", "loop_state",
     "migrate_facts", "mission_ledger", "mission_stall", "notes_writer",
-    "nursery", "operator", "orchestrator_tool_guard", "outcome_capture",
+    "nursery", "operator", "oracle_runner",  # #146 retirement coverage WARN face
+    "orchestrator_tool_guard", "outcome_capture",
     "plan_drift", "plan_drift_detector", "priority", "priority_ratio",
     "queue", "recall_inject", "refutation_propagate", "rho_checkpoint",
     "rollup", "retract_claim", "rho_verifier", "scan_worker_budget",

--- a/scripts/oracle_runner.py
+++ b/scripts/oracle_runner.py
@@ -610,14 +610,22 @@ def check_case(case: dict, compute: Compute | None) -> dict:
     if compute is None:
         return row
     row["instrumented"] = True
-    params = dict(case["params"])
+    # crash containment (base behavior, #146 review r1-2): a non-mapping
+    # params is a per-case error, never a whole-run crash
+    try:
+        params = dict(case["params"])
+    except Exception as exc:  # noqa: BLE001 — contained as a verdict of "unknown"
+        row["error"] = f"{type(exc).__name__}: {exc}"
+        return row
+    # #146 snapshot BEFORE the call (review r1-3): the forensic record holds
+    # the derivation INPUT — a client that mutates its argument cannot
+    # corrupt params_used
+    forensics["params_used"] = dict(params)
     try:
         out = compute(params)
     except Exception as exc:  # noqa: BLE001 — a crash is a verdict of "unknown"
         row["error"] = f"{type(exc).__name__}: {exc}"
-        forensics["params_used"] = params
         return row
-    forensics["params_used"] = params
     if not isinstance(out, dict):
         row["error"] = f"client returned {type(out).__name__}, expected dict"
         return row
@@ -975,8 +983,10 @@ def main(argv: list[str] | None = None) -> int:
     cases_dir = ws.joinpath(*CASES_REL)
 
     # #146 case-abandonment face: retire before any run face (a refusal
-    # never touches the status file or the posteriors).
-    if args.retire:
+    # never touches the status file or the posteriors). `is not None` — an
+    # empty --retire value must refuse loudly, never fall through to a run
+    # face (review r1-5).
+    if args.retire is not None:
         try:
             rec = retire_case(
                 ws, args.retire,

--- a/scripts/oracle_runner.py
+++ b/scripts/oracle_runner.py
@@ -93,9 +93,44 @@ case set is blessed as a whole or not at all, before any IO):
     a live competition to discriminate; a self-filed singleton vacuous
     hypothesis fails admission.
 
-Exit codes: 0 = no red case; 1 = at least one red case; 2 = lint refusal.
+Exit codes: 0 = no red case; 1 = at least one red case; 2 = lint refusal
+(also the --retire refusal exit).
 Usage:
   python scripts/oracle_runner.py <ws> [--client <path>] [--mutation] [--json]
+
+#146 — outcome forensics (settlements record HOW they were won/lost):
+
+Every case row in the report gains an ADDITIVE ``forensics`` block (all
+pre-existing report/status fields keep their shape — the status file stays
+narrowed to the three convergence-convention fields):
+
+  forensics:
+    params_used       the params handed to compute() (derivation input
+                      record; {} before compute was invoked)
+    meta              the client's OPTIONAL ``meta`` return key, verbatim
+                      (optional client contract; absent/not-a-dict -> {})
+    mismatches        RED only: the per-field mismatch vector — every
+                      non-matching expected entry as
+                      {field, expected, actual}
+    stages            the client's OPTIONAL ``stages`` return dict
+                      (intermediate derivation steps), verbatim
+    divergence_point  first stage whose output differs from the case's
+                      expected-stage value (``stages:`` case key) — or an
+                      expected stage the client never produced; None when
+                      nothing differs or no expected stages are pinned
+
+#146 — case-abandonment protocol (retirement lives HERE, with the case
+files and OracleCaseError): a case transitions to ``status: retired`` ONLY
+with the structured justification {attribution_class in the closed taxonomy
+{implementation-wrong, case-wrong, client-wrong, channel-wrong,
+capture-obsolete}, disconfirmation, replacement} — anything less is a loud
+OracleCaseError refusal. The transition is append-only (the case file keeps
+its expected entries; status + retirement are ADDED). Retired cases leave
+the acceptance net: load_cases skips them (a retired case must never refuse
+the set because its hypothesis went terminal), run() reports them, and
+retiring emits the coverage-drop WARN event
+(``acceptance_coverage_decreased`` — a registered event word) because the
+armed-case count shrank.
 """
 from __future__ import annotations
 
@@ -111,11 +146,20 @@ from typing import Callable
 
 import yaml
 
+from harness_common import utc_now_iso  # #863 Family F: single source
+
 SCHEMA_ID = "oracle-status/1"
 STATUS_REL = ("runs", "oracle-status.json")
 CASES_REL = ("oracle", "cases")
 DEFAULT_CLIENT_REL = ("oracle", "client.py")
 MUTATION_KINDS = ("swap", "omit", "change")
+
+# #146 case-abandonment protocol: the closed attribution taxonomy a
+# retirement justification must draw from, and the retired marker.
+RETIRED_CASE_STATUS = "retired"
+RETIREMENT_ATTRIBUTION_CLASSES = ("implementation-wrong", "case-wrong",
+                                  "client-wrong", "channel-wrong",
+                                  "capture-obsolete")
 
 Compute = Callable[[dict], dict]
 
@@ -338,6 +382,25 @@ def _parse_update_map(case_path: Path, cid: str, group: str, raw,
             "red_up": [str(h).strip() for h in red]}
 
 
+def _retired_or_stages(p: Path, cid: str, doc: dict) -> tuple[bool, dict]:
+    """#146 pre-admission doc face: (skip_retired, expected_stages).
+
+    A retired case has left the acceptance net — it is skipped BEFORE the
+    admission lints (a retired case must never refuse the set because its
+    linked hypothesis went terminal or its competitor group thinned).
+    ``stages`` is the optional case key pinning expected stage values; a
+    non-mapping is a loud refusal."""
+    if str(doc.get("status") or "").strip() == RETIRED_CASE_STATUS:
+        return True, {}
+    stages = doc.get("stages")
+    if stages is not None and not isinstance(stages, dict):
+        raise OracleCaseError(
+            f"{p.name}: case {cid!r}: `stages` must be a mapping of stage "
+            f"name -> expected value (the runner diffs the client's stages "
+            f"dict stage-wise, #146)")
+    return False, dict(stages or {})
+
+
 def load_cases(cases_dir) -> list[dict]:
     """Load + lint every ``*.yaml`` case. Raises OracleCaseError on the
     first refusal (#108 half C presence lint + #126 admission integrity:
@@ -365,6 +428,11 @@ def load_cases(cases_dir) -> list[dict]:
         cid = str(doc.get("id") or p.stem).strip()
         if not cid:
             raise OracleCaseError(f"{p.name}: case id is empty")
+        # #146: retired skips BEFORE the lints; stages pins expected
+        # stage values for the stage-diff forensics.
+        skip_retired, stages_expected = _retired_or_stages(p, cid, doc)
+        if skip_retired:
+            continue
         expected = _parse_expected(ws, p, cid, doc.get("expected"))
         mutations = _parse_mutations(p, cid, doc.get("mutations"))
         # #126: mutations are an admission requirement now — a case that
@@ -441,10 +509,31 @@ def load_cases(cases_dir) -> list[dict]:
             "competitor_group": hyp.competitor_group,
             "update_map": update_map,
             "params": doc.get("params") or {},
+            "expected_stages": dict(stages_expected or {}),
             "expected": expected,
             "mutations": mutations,
         })
     return cases
+
+
+def retired_case_ids(cases_dir) -> list[str]:
+    """#146: ids of cases whose file marks ``status: retired`` — they left
+    the acceptance net and are skipped by load_cases/run. Tolerant per
+    file (an unreadable case doc is not a retirement signal)."""
+    cases_dir = Path(cases_dir)
+    out: list[str] = []
+    for p in sorted(cases_dir.glob("*.yaml")):
+        try:
+            doc = yaml.safe_load(p.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001 — unreadable is not signal
+            continue
+        if not isinstance(doc, dict):
+            continue
+        cid = str(doc.get("id") or p.stem).strip()
+        if cid and str(doc.get("status") or "").strip() == \
+                RETIRED_CASE_STATUS:
+            out.append(cid)
+    return out
 
 
 # ------------------------------------------------------------ client loader
@@ -486,33 +575,69 @@ def load_client(client_path) -> Compute | None:
 
 # ---------------------------------------------------------------- checking
 
+def _stage_divergence(observed: dict, expected_stages: dict) -> str | None:
+    """#146: first stage whose output differs from the case's expected
+    stage value — or an expected stage the client never produced (a
+    missing stage output differs from its expected value). Pure."""
+    for stage, value in observed.items():
+        if stage in expected_stages and value != expected_stages[stage]:
+            return str(stage)
+    for stage in expected_stages:
+        if stage not in observed:
+            return str(stage)
+    return None
+
+
 def check_case(case: dict, compute: Compute | None) -> dict:
-    """One case -> {"status", "pending_entries", "instrumented", "failures"}.
+    """One case -> {"status", "pending_entries", "instrumented", "failures",
+    "error", "forensics"}.
 
     status: fail (observed entry mismatched) > pending (no client / client
     crash / nothing observed / scaffold entries owed) > pass (every observed
-    entry matches and nothing is owed). "Unknown" is never "pass" (#108 A)."""
+    entry matches and nothing is owed). "Unknown" is never "pass" (#108 A).
+
+    #146 forensics (additive): params_used / meta / mismatches / stages /
+    divergence_point — the settlement records HOW it was won or lost; see
+    the module docstring for the full contract."""
     expected = case["expected"]
     pending_entries = sum(1 for e in expected if e["pending"])
     observed = [e for e in expected if not e["pending"]]
+    forensics: dict = {"params_used": {}, "meta": {}, "mismatches": [],
+                       "stages": {}, "divergence_point": None}
     row = {"status": "pending", "pending_entries": pending_entries,
-           "instrumented": False, "failures": [], "error": None}
+           "instrumented": False, "failures": [], "error": None,
+           "forensics": forensics}
     if compute is None:
         return row
     row["instrumented"] = True
+    params = dict(case["params"])
     try:
-        out = compute(dict(case["params"]))
+        out = compute(params)
     except Exception as exc:  # noqa: BLE001 — a crash is a verdict of "unknown"
         row["error"] = f"{type(exc).__name__}: {exc}"
+        forensics["params_used"] = params
         return row
+    forensics["params_used"] = params
     if not isinstance(out, dict):
         row["error"] = f"client returned {type(out).__name__}, expected dict"
         return row
+    meta = out.get("meta")
+    if isinstance(meta, dict):
+        forensics["meta"] = meta
+    stages = out.get("stages")
+    if isinstance(stages, dict):
+        forensics["stages"] = stages
+        forensics["divergence_point"] = _stage_divergence(
+            stages, case.get("expected_stages")
+            if isinstance(case.get("expected_stages"), dict) else {})
     for e in observed:
         if out.get(e["field"]) != e["value"]:
             row["failures"].append(
                 f"{e['field']}: expected {e['value']!r}, got "
                 f"{out.get(e['field'])!r}")
+            forensics["mismatches"].append(
+                {"field": e["field"], "expected": e["value"],
+                 "actual": out.get(e["field"])})
     if row["failures"]:
         row["status"] = "fail"
     elif not observed or pending_entries:
@@ -595,8 +720,12 @@ def mutation_pass(cases: list[dict], compute: Compute | None) -> dict:
 # ------------------------------------------------------------------ report
 
 def run(cases_dir, client_path, *, mutation: bool = False) -> dict:
-    """Run the whole case set. No client -> ALL pending (never green)."""
-    cases = load_cases(Path(cases_dir))
+    """Run the whole case set. No client -> ALL pending (never green).
+
+    #146: retired cases are reported, not run — they left the acceptance
+    net (load_cases skips them), so counts cover ACTIVE cases only."""
+    cases_dir = Path(cases_dir)
+    cases = load_cases(cases_dir)
     compute = load_client(client_path)
     rows = {c["id"]: check_case(c, compute) for c in cases}
     counts = {"red": 0, "green": 0, "pending": 0}
@@ -609,6 +738,7 @@ def run(cases_dir, client_path, *, mutation: bool = False) -> dict:
         "client": str(client_path) if compute is not None else None,
         "cases": rows,
         "counts": counts,
+        "retired": retired_case_ids(cases_dir),
         "mutation": mutation_pass(cases, compute)
         if (compute is not None and mutation) else None,
     }
@@ -655,6 +785,124 @@ def record_posteriors(ws, report: dict) -> Path | None:
     return led.save(ws)
 
 
+# ------------------------------------------------- #146 case abandonment
+
+def _armed_case_count(cases_dir: Path) -> int:
+    """Cases still in the acceptance net (not retired)."""
+    cases_dir = Path(cases_dir)
+    if not cases_dir.is_dir():
+        return 0
+    total = 0
+    for p in sorted(cases_dir.glob("*.yaml")):
+        try:
+            doc = yaml.safe_load(p.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001 — unreadable is not signal
+            continue
+        if isinstance(doc, dict) and str(doc.get("status") or "").strip() \
+                != RETIRED_CASE_STATUS:
+            total += 1
+    return total
+
+
+def _emit_coverage_decreased(ws, case_id: str, before: int, after: int) -> None:
+    """#146 coverage-drop WARN: retiring shrank the acceptance net. The
+    word is a registered EMIT_ACTIONS member (the #459 controlled
+    vocabulary); fail-open — telemetry never breaks a retirement."""
+    try:
+        from kunglao_log import emit
+        emit(ws, actor="oracle_runner",
+             action="acceptance_coverage_decreased",
+             detail=(f"case={case_id} armed_cases={after} (was {before}) — "
+                     f"acceptance coverage decreased"))
+    except Exception:  # noqa: BLE001 — observability never disturbs the run
+        pass
+
+
+def retire_case(ws, case_id: str, *, attribution_class: str,
+                disconfirmation: str, replacement: str) -> dict:
+    """#146 case-abandonment protocol: retire a case, append-only, with
+    the structured justification — or loud refusal.
+
+    REQUIRED justification (anything less -> OracleCaseError, nothing
+    written):
+      - attribution_class: one of RETIREMENT_ATTRIBUTION_CLASSES (closed
+        taxonomy: implementation-wrong | case-wrong | client-wrong |
+        channel-wrong | capture-obsolete);
+      - disconfirmation: the alternatives were argued away (text);
+      - replacement: re-capture / re-derive / successor plan (text).
+
+    The case file keeps everything it had (append-only): ``status:
+    retired`` and the ``retirement`` block are ADDED. Retiring an
+    already-retired case is refused (one transition, append-only). The
+    armed-case count drop fires the acceptance_coverage_decreased WARN.
+
+    Returns the retirement record; raises OracleCaseError on refusal."""
+    cases_dir = Path(ws).joinpath(*CASES_REL)
+    if not cases_dir.is_dir():
+        raise OracleCaseError(f"no case set under {cases_dir} — nothing to "
+                              f"retire")
+    wanted = str(case_id or "").strip()
+    target: Path | None = None
+    doc: dict | None = None
+    for p in sorted(cases_dir.glob("*.yaml")):
+        try:
+            candidate = yaml.safe_load(p.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001 — skip unreadable candidates
+            continue
+        if not isinstance(candidate, dict):
+            continue
+        cid = str(candidate.get("id") or p.stem).strip()
+        if cid == wanted:
+            target, doc = p, candidate
+            break
+    if target is None or doc is None:
+        raise OracleCaseError(f"no case {wanted!r} under {cases_dir} — "
+                              f"nothing to retire")
+    if str(doc.get("status") or "").strip() == RETIRED_CASE_STATUS:
+        raise OracleCaseError(f"case {wanted!r} is already retired — "
+                              f"retirement is a one-way append-only "
+                              f"transition (#146)")
+    attribution_class = str(attribution_class or "").strip()
+    disconfirmation = str(disconfirmation or "").strip()
+    replacement = str(replacement or "").strip()
+    if attribution_class not in RETIREMENT_ATTRIBUTION_CLASSES:
+        raise OracleCaseError(
+            f"case {wanted!r}: attribution_class {attribution_class!r} is "
+            f"not in the closed taxonomy "
+            f"({', '.join(RETIREMENT_ATTRIBUTION_CLASSES)}) — a retirement "
+            f"without attribution is a silent abandonment (#146)")
+    if not disconfirmation:
+        raise OracleCaseError(
+            f"case {wanted!r}: retirement needs `disconfirmation` — the "
+            f"alternatives must be argued away before the case is "
+            f"abandoned (#146)")
+    if not replacement:
+        raise OracleCaseError(
+            f"case {wanted!r}: retirement needs `replacement` — the "
+            f"acceptance-net hole must have a re-capture / re-derive / "
+            f"successor plan (#146)")
+    armed_before = _armed_case_count(cases_dir)
+    doc["status"] = RETIRED_CASE_STATUS
+    doc["retirement"] = {
+        "attribution_class": attribution_class,
+        "disconfirmation": disconfirmation,
+        "replacement": replacement,
+        "retired_at": utc_now_iso(),
+    }
+    tmp = target.with_name(target.name + ".tmp")
+    tmp.write_text(
+        yaml.safe_dump(doc, allow_unicode=True, sort_keys=False),
+        encoding="utf-8")
+    os.replace(tmp, target)
+    armed_after = _armed_case_count(cases_dir)
+    if armed_after < armed_before:
+        _emit_coverage_decreased(ws, wanted, armed_before, armed_after)
+    return {"case_id": wanted, "status": RETIRED_CASE_STATUS,
+            "retirement": dict(doc["retirement"]),
+            "armed_cases_before": armed_before,
+            "armed_cases_after": armed_after}
+
+
 # --------------------------------------------------------------------- CLI
 
 def _human(report: dict) -> str:
@@ -671,6 +919,14 @@ def _human(report: dict) -> str:
             lines.append(f"         {f}")
         if row["error"]:
             lines.append(f"         error: {row['error']}")
+        fore = row.get("forensics") or {}
+        if fore.get("divergence_point"):
+            lines.append(f"         divergence@{fore['divergence_point']} "
+                         f"(stages: {fore.get('stages')})")
+        if fore.get("meta"):
+            lines.append(f"         meta: {fore['meta']}")
+    if report.get("retired"):
+        lines.append(f"  [RETIRED, not run] {', '.join(report['retired'])}")
     mut = report.get("mutation") or {}
     for cid, rows in (mut.get("mutations") or {}).items():
         for r in rows:
@@ -698,10 +954,41 @@ def main(argv: list[str] | None = None) -> int:
                          "declared mutations (flag low_discriminativity)")
     ap.add_argument("--json", action="store_true",
                     help="machine-readable report on stdout")
+    # #146 case-abandonment face
+    ap.add_argument("--retire", metavar="CASE_ID", default=None,
+                    help="#146: retire a case (append-only status: retired "
+                         "in its case file) — requires the structured "
+                         "justification flags below")
+    ap.add_argument("--attribution-class", default=None,
+                    help="#146 retirement taxonomy: implementation-wrong | "
+                         "case-wrong | client-wrong | channel-wrong | "
+                         "capture-obsolete")
+    ap.add_argument("--disconfirmation", default=None,
+                    help="#146 retirement: how the alternative attributions "
+                         "were argued away")
+    ap.add_argument("--replacement", default=None,
+                    help="#146 retirement: re-capture / re-derive / "
+                         "successor-case plan for the coverage hole")
     args = ap.parse_args(argv)
 
     ws = Path(args.workspace)
     cases_dir = ws.joinpath(*CASES_REL)
+
+    # #146 case-abandonment face: retire before any run face (a refusal
+    # never touches the status file or the posteriors).
+    if args.retire:
+        try:
+            rec = retire_case(
+                ws, args.retire,
+                attribution_class=args.attribution_class or "",
+                disconfirmation=args.disconfirmation or "",
+                replacement=args.replacement or "")
+        except OracleCaseError as exc:
+            print(f"oracle_runner: RETIRE REFUSED — {exc}", file=sys.stderr)
+            return 2
+        print(json.dumps(rec, ensure_ascii=False, indent=2, default=repr))
+        return 0
+
     if not cases_dir.is_dir():
         print(f"oracle_runner: no {cases_dir} — nothing to bless "
               f"(no status written)", file=sys.stderr)
@@ -718,8 +1005,10 @@ def main(argv: list[str] | None = None) -> int:
     report = run(cases_dir, client, mutation=args.mutation)
     write_status(ws, report)
     record_posteriors(ws, report)
-    print(json.dumps(report, ensure_ascii=False, indent=2) if args.json
-          else _human(report))
+    # default=repr (#146): forensics carry raw client values — a
+    # non-JSON-serializable client output must never crash the report face
+    print(json.dumps(report, ensure_ascii=False, indent=2, default=repr)
+          if args.json else _human(report))
     return 1 if report["counts"]["red"] else 0
 
 

--- a/tests/fixtures/golden/F-04/ws/claim-register.yaml
+++ b/tests/fixtures/golden/F-04/ws/claim-register.yaml
@@ -5,3 +5,4 @@ claims:
   evidence_tier_attempted: 0
   promotion_attempts: 3
   depends_on: []
+  answers_question: q1

--- a/tests/fixtures/golden/F-04/ws/oracle/cases/case-c-1.yaml
+++ b/tests/fixtures/golden/F-04/ws/oracle/cases/case-c-1.yaml
@@ -1,0 +1,2 @@
+id: case-c-1
+target_pq: q1

--- a/tests/fixtures/golden/F-04/ws/runs/posteriors.yaml
+++ b/tests/fixtures/golden/F-04/ws/runs/posteriors.yaml
@@ -1,0 +1,7 @@
+cases:
+  case-c-1:
+    alpha: 1.0
+    beta: 4.0
+    pending_entries: 0
+pqs: {}
+schema: posteriors-schema/1

--- a/tests/fixtures/golden/F-12/expected/stdout.txt
+++ b/tests/fixtures/golden/F-12/expected/stdout.txt
@@ -1,6 +1,6 @@
 === 1 claim(s) BLOCKED (failed attempt, no current analysis) ===
 
-=== BLOCKED: C-1 (status=OPEN, attempts=1) ===
+=== BLOCKED: C-1 (status=OPEN, red_settlements=1 over 1 linked case(s)) ===
 claim: 
 
 Before re-dispatching OR concluding NEGATIVE, answer three questions

--- a/tests/fixtures/golden/F-12/ws/claim-register.yaml
+++ b/tests/fixtures/golden/F-12/ws/claim-register.yaml
@@ -5,3 +5,4 @@ claims:
   evidence_tier_attempted: 0
   promotion_attempts: 1
   depends_on: []
+  answers_question: q1

--- a/tests/fixtures/golden/F-12/ws/oracle/cases/case-c-1.yaml
+++ b/tests/fixtures/golden/F-12/ws/oracle/cases/case-c-1.yaml
@@ -1,0 +1,2 @@
+id: case-c-1
+target_pq: q1

--- a/tests/fixtures/golden/F-12/ws/runs/posteriors.yaml
+++ b/tests/fixtures/golden/F-12/ws/runs/posteriors.yaml
@@ -1,0 +1,7 @@
+cases:
+  case-c-1:
+    alpha: 1.0
+    beta: 2.0
+    pending_entries: 0
+pqs: {}
+schema: posteriors-schema/1

--- a/tests/test_decide_regression_anchor.py
+++ b/tests/test_decide_regression_anchor.py
@@ -44,6 +44,7 @@ if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
 import convergence_check  # module under test (== baseline before #443 GREEN)
+import posteriors as po  # noqa: E402  (#146 arming fixture: settlement ledger)
 
 # 2026-09-06 SEMANTIC re-pin verification (#107 Thompson rebuild): the
 # owner ruling "探索和价值网络完全重构，之前的不要了" replaced the
@@ -88,6 +89,18 @@ ANCHOR_FILE = Path(__file__).parent / "decide_anchor_cabc7d9.json"
 # re-pin entry below). The oracle-blocking semantics themselves are
 # unanchored by construction (the matrix has no oracle-bearing DRAIN case);
 # covered by the #108 block in tests/test_decide_state_machine.py.
+# 2026-09-07 zero-drift verification (#146 failure-gate arming re-point):
+# failure_analysis_gate's arming moved from the never-written
+# promotion_attempts counter to settlement-derived case reds
+# (answers_question <-> target_pq linkage over runs/posteriors.yaml). The
+# four failure-gate matrix cases (sched_blocked_failure_due,
+# sched_failure_partial_artifacts, order_queue_beats_failure,
+# order_failure_beats_all_infra) were re-pointed at the live arming path in
+# their FIXTURES (answers_question + linked fail settlements); the frozen
+# outputs are unchanged — all 32 cases re-verified byte-identical after the
+# change, so NO re-pin was needed. The claim-register field itself remains
+# schema-valid (decide()'s own #497 ladder-exhaustion face still reads it);
+# only the gate stopped consuming it.
 # 2026-09-06 zero-drift verification (#98 DRAIN worker gates): the DRAIN
 # probe table gained STUCK_WORKERS_PRESENT + ACTIVE_WORKERS_PRESENT,
 # appended AFTER the frozen completion-transaction order (orphan >
@@ -249,6 +262,22 @@ def _blocker_files(ws: Path, names: list[str]) -> None:
 
 def _claim(cid: str, **fields) -> dict:
     return {"id": cid, "status": "OPEN", **fields}
+
+
+def _arm_red(ws: Path, cid: str, pq: str = "q1", reds: int = 1) -> None:
+    """#146 arming fixture: one oracle case linked to the claim's PQ
+    carrying `reds` fail settlements in the #106 posterior ledger
+    (beta = 1 + reds) — the gate's live arming path."""
+    cdir = ws / "oracle" / "cases"
+    cdir.mkdir(parents=True, exist_ok=True)
+    case_id = f"case-{cid.lower()}"
+    (cdir / f"{case_id}.yaml").write_text(
+        yaml.safe_dump({"id": case_id, "target_pq": pq}),
+        encoding="utf-8")
+    led = po.PosteriorLedger.load(ws)
+    led.cases[case_id] = po.CasePosterior(case_id, alpha=1.0,
+                                          beta=1.0 + reds)
+    led.save(ws)
 
 
 # ------------------------------------------------------------- the matrix
@@ -435,17 +464,22 @@ def _c_sched_unexpected_partials_no_slots(base: Path) -> Path:
 
 
 def _c_sched_blocked_failure_due(base: Path) -> Path:
-    """#495: failed attempt with NO analysis → failure artifacts due."""
+    """#495/#146: fail settlements on a target_pq-linked case with NO
+    analysis -> failure artifacts due (arming is settlement-derived)."""
     ws = _ws(base, "sched_blocked_failure_due")
-    _reg(ws, [_claim("C-1", promotion_attempts=2)])
+    _reg(ws, [_claim("C-1", promotion_attempts=2, answers_question="q1")])
+    _arm_red(ws, "C-1", reds=2)
     _ts(ws, _pq("[]"))
     return ws
 
 
 def _c_sched_failure_partial_artifacts(base: Path) -> Path:
-    """#495: analysis missing identified_obstacle → still BLOCKED."""
+    """#495/#146: analysis missing identified_obstacle → still BLOCKED
+    (arming via linked fail settlements — covers_attempt alone covers
+    nothing anymore)."""
     ws = _ws(base, "sched_failure_partial_artifacts")
-    _reg(ws, [_claim("C-1", promotion_attempts=1)])
+    _reg(ws, [_claim("C-1", promotion_attempts=1, answers_question="q1")])
+    _arm_red(ws, "C-1", reds=1)
     _ts(ws, _pq("[]"))
     _analysis(ws, "C-1", covers_attempt=1,
               validated_capability="frida bridge works",
@@ -516,7 +550,9 @@ def _c_order_opens_beat_partials(base: Path) -> Path:
 def _c_order_queue_beats_failure(base: Path) -> Path:
     """Order anchor: full queue (SATURATED) wins over failure artifacts due."""
     ws = _ws(base, "order_queue_beats_failure")
-    _reg(ws, [_claim("C-1"), _claim("C-2", promotion_attempts=1)])
+    _reg(ws, [_claim("C-1"),
+              _claim("C-2", promotion_attempts=1, answers_question="q1")])
+    _arm_red(ws, "C-2", reds=1)
     _ts(ws, _pq("[]"))
     _workers(ws, 3)
     return ws
@@ -524,7 +560,9 @@ def _c_order_queue_beats_failure(base: Path) -> Path:
 
 def _c_order_failure_beats_all_infra(base: Path) -> Path:
     ws = _ws(base, "order_failure_beats_all_infra")
-    _reg(ws, [_claim("C-1", promotion_attempts=2), _claim("C-2", blocked=True)])
+    _reg(ws, [_claim("C-1", promotion_attempts=2, answers_question="q1"),
+              _claim("C-2", blocked=True)])
+    _arm_red(ws, "C-1", reds=2)
     _ts(ws, _pq("[]"))
     return ws
 

--- a/tests/test_decide_regression_anchor.py
+++ b/tests/test_decide_regression_anchor.py
@@ -481,7 +481,7 @@ def _c_sched_failure_partial_artifacts(base: Path) -> Path:
     _reg(ws, [_claim("C-1", promotion_attempts=1, answers_question="q1")])
     _arm_red(ws, "C-1", reds=1)
     _ts(ws, _pq("[]"))
-    _analysis(ws, "C-1", covers_attempt=1,
+    _analysis(ws, "C-1", covers_settlements=1,
               validated_capability="frida bridge works",
               identified_obstacle="")
     return ws

--- a/tests/test_decide_state_machine.py
+++ b/tests/test_decide_state_machine.py
@@ -204,14 +204,18 @@ def test_failure_event_consumes_495_artifact_gate() -> None:
     Event = _surface("Event")
     base = Path(tempfile.mkdtemp(prefix="sm-495-"))
     partial = anchor._ws(base, "partial")
-    anchor._reg(partial, [anchor._claim("C-1", promotion_attempts=1)])
+    anchor._reg(partial, [anchor._claim("C-1", promotion_attempts=1,
+                                        answers_question="q1")])
+    anchor._arm_red(partial, "C-1", reds=1)  # #146: settlement-derived arming
     anchor._ts(partial, anchor._pq("[]"))
-    anchor._analysis(partial, "C-1", covers_attempt=1,
+    anchor._analysis(partial, "C-1", covers_settlements=1,
                      validated_capability="frida works", identified_obstacle="")
     full = anchor._ws(base, "full")
-    anchor._reg(full, [anchor._claim("C-1", promotion_attempts=1)])
+    anchor._reg(full, [anchor._claim("C-1", promotion_attempts=1,
+                                     answers_question="q1")])
+    anchor._arm_red(full, "C-1", reds=1)
     anchor._ts(full, anchor._pq("[]"))
-    anchor._analysis(full, "C-1", covers_attempt=1,
+    anchor._analysis(full, "C-1", covers_settlements=1,
                      validated_capability="frida works",
                      identified_obstacle="vm network blocked")
     assert PRED[Event.FAILURE_ARTIFACTS_DUE](_decide_inputs(partial)) is True

--- a/tests/test_decision_teeth.py
+++ b/tests/test_decision_teeth.py
@@ -221,8 +221,21 @@ class TestTop1Enforcement:
         reg = yaml.safe_load((ws / "claim-register.yaml").read_text(encoding="utf-8"))
         reg["claims"].append({"id": "C-4", "status": "OPEN",
                               "statement": "background work",
+                              "answers_question": "q4",
                               "promotion_attempts": 1})
         _write(ws / "claim-register.yaml", reg)
+        # #146: arm the failure-blocked slice the live way — a linked
+        # oracle case carrying a fail settlement in the #106 ledger.
+        import posteriors as po
+        cdir = ws / "oracle" / "cases"
+        cdir.mkdir(parents=True, exist_ok=True)
+        (cdir / "case-c-4.yaml").write_text(
+            yaml.safe_dump({"id": "case-c-4", "target_pq": "q4"}),
+            encoding="utf-8")
+        led = po.PosteriorLedger.load(ws)
+        led.cases["case-c-4"] = po.CasePosterior("case-c-4", alpha=1.0,
+                                                 beta=2.0)
+        led.save(ws)
         r = _run_gate(root, ws, "[T1 tools=grep] claim C-4 retry the failed")
         assert r.returncode == 0, (
             f"failure-blocked slice belongs to the #495 injection, not the "

--- a/tests/test_event_stream_adoption.py
+++ b/tests/test_event_stream_adoption.py
@@ -33,6 +33,8 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
+import posteriors as po  # noqa: E402  (#146 arming fixture: settlement ledger)
+
 # hook-level fixtures reuse the #496 suite's builders (same test dir is on
 # sys.path under pytest's rootdir collection; test_decide_state_machine.py
 # uses the same cross-test import convention).
@@ -373,8 +375,20 @@ class TestFailureAnalysisEmit:
         ws.mkdir(parents=True)
         (ws / "claim-register.yaml").write_text(yaml.safe_dump({"claims": [
             {"id": "C-1", "status": "OPEN",
+             "answers_question": "q1",
              "promotion_attempts": attempts}]}, sort_keys=False),
             encoding="utf-8")
+        # #146: arm the gate the live way — a linked case carrying red
+        # settlements (beta = 1 + reds in the #106 ledger).
+        cdir = ws / "oracle" / "cases"
+        cdir.mkdir(parents=True)
+        (cdir / "case-c-1.yaml").write_text(
+            yaml.safe_dump({"id": "case-c-1", "target_pq": "q1"}),
+            encoding="utf-8")
+        led = po.PosteriorLedger.load(ws)
+        led.cases["case-c-1"] = po.CasePosterior("case-c-1", alpha=1.0,
+                                                 beta=1.0 + attempts)
+        led.save(ws)
         return ws
 
     def test_record_success_emits_analysis_recorded(self, tmp, events):
@@ -415,20 +429,30 @@ class TestFailureAnalysisEmit:
         assert rows[-1].get("claim") == "C-1"
 
     def test_stale_coverage_blocked_keeps_failure_blocked(self, tmp, events):
-        """Split pin: BLOCKED because covers_attempt lags (artifacts all
-        present) keeps the pre-existing word failure_blocked — the word
-        carries the REASON, no double emission."""
+        """Split pin: BLOCKED because covers_settlements lags the red total
+        (artifacts all present) keeps the pre-existing word
+        failure_blocked — the word carries the REASON, no double emission."""
         import yaml
         import failure_analysis_gate as fag
         ws = tmp / "ws"
         ws.mkdir(parents=True)
         (ws / "claim-register.yaml").write_text(yaml.safe_dump({"claims": [
-            {"id": "C-1", "status": "OPEN", "promotion_attempts": 2}]},
+            {"id": "C-1", "status": "OPEN", "answers_question": "q1",
+             "promotion_attempts": 2}]},
             sort_keys=False), encoding="utf-8")
+        cdir = ws / "oracle" / "cases"
+        cdir.mkdir(parents=True)
+        (cdir / "case-c-1.yaml").write_text(
+            yaml.safe_dump({"id": "case-c-1", "target_pq": "q1"}),
+            encoding="utf-8")
+        led = po.PosteriorLedger.load(ws)
+        led.cases["case-c-1"] = po.CasePosterior("case-c-1", alpha=1.0,
+                                                 beta=3.0)  # 2 red settlements
+        led.save(ws)
         adir = ws / "analyses"
         adir.mkdir()
         (adir / "failure-C-1.yaml").write_text(yaml.safe_dump({
-            "claim": "C-1", "covers_attempt": 1,
+            "claim": "C-1", "covers_settlements": 1,   # lags the red total
             "validated_capability": "frida works",
             "identified_obstacle": "spawn timeout"}, sort_keys=False),
             encoding="utf-8")

--- a/tests/test_failure_analysis_transducer.py
+++ b/tests/test_failure_analysis_transducer.py
@@ -422,9 +422,9 @@ def test_blocked_lists_missing_artifacts(tmp_path):
     adir.mkdir()
     (adir / "failure-C-1.yaml").write_text(
         "claim: C-1\n"
-        "covers_attempt: 1\n"
-        "method_assumption: a\n"
-        "assumption_validity: not-justified\n"
+        "covers_settlements: 1\n"   # #146: coverage CURRENT (reds=1) ...
+        "method_assumption: a\n"      # ... so the BLOCKED below fires on
+        "assumption_validity: not-justified\n"  # the missing ARTIFACT tooth
         "next_method: b\n"
         "validated_capability: frida bridge works\n"
         "analyzed_at: 2026-08-19T00:00:00+00:00\n",

--- a/tests/test_failure_analysis_transducer.py
+++ b/tests/test_failure_analysis_transducer.py
@@ -32,21 +32,47 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import failure_analysis_gate as fag  # noqa: E402
+import posteriors as po  # noqa: E402  (#146 arming fixture: settlement ledger)
 import yaml  # noqa: E402
 
 
 # ---------- helpers ----------
 
+PQ = "q1"
+
+
 def _write_register(ws: Path, claims: list[dict]) -> None:
+    """Write the register and ARM the #146 way: every claim with
+    promotion_attempts > 0 gets a linked oracle case (target_pq == its
+    answers_question) carrying that many fail settlements in the #106
+    posterior ledger (beta = 1 + reds)."""
     (ws / "claim-register.yaml").write_text(
         yaml.safe_dump({"claims": claims}, allow_unicode=True, sort_keys=False),
         encoding="utf-8")
+    led = po.PosteriorLedger.load(ws)
+    for c in claims:
+        attempts = int(c.get("promotion_attempts") or 0)
+        if attempts <= 0:
+            continue
+        case_id = f"case-{str(c['id']).lower()}"
+        cdir = ws / "oracle" / "cases"
+        cdir.mkdir(parents=True, exist_ok=True)
+        (cdir / f"{case_id}.yaml").write_text(
+            yaml.safe_dump({"id": case_id,
+                            "target_pq": str(c.get("answers_question")
+                                              or PQ)},
+                           sort_keys=False),
+            encoding="utf-8")
+        led.cases[case_id] = po.CasePosterior(case_id, alpha=1.0,
+                                              beta=1.0 + attempts)
+    led.save(ws)
 
 
 def _claim(cid: str, attempts: int = 2, statement: str = "sample does X",
            **extra) -> dict:
     c = {"id": cid, "status": "OPEN", "boundary_type": "positive_observation",
          "evidence_tier_attempted": 1, "promotion_attempts": attempts,
+         "answers_question": PQ,
          "depends_on": [], "statement": statement}
     c.update(extra)
     return c

--- a/tests/test_failure_lessons.py
+++ b/tests/test_failure_lessons.py
@@ -26,20 +26,46 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import failure_analysis_gate as fag  # noqa: E402
+import posteriors as po  # noqa: E402  (#146 arming fixture: settlement ledger)
 import yaml  # noqa: E402
 
 
 # ---------- helpers ----------
 
+PQ = "q1"
+
+
 def _write_register(ws: Path, claims: list[dict]) -> None:
+    """Write the register and ARM the #146 way: every claim with
+    promotion_attempts > 0 gets a linked oracle case (target_pq == its
+    answers_question) carrying that many fail settlements in the #106
+    posterior ledger (beta = 1 + reds)."""
     (ws / "claim-register.yaml").write_text(
         yaml.safe_dump({"claims": claims}, allow_unicode=True, sort_keys=False),
         encoding="utf-8")
+    led = po.PosteriorLedger.load(ws)
+    for c in claims:
+        attempts = int(c.get("promotion_attempts") or 0)
+        if attempts <= 0:
+            continue
+        case_id = f"case-{str(c['id']).lower()}"
+        cdir = ws / "oracle" / "cases"
+        cdir.mkdir(parents=True, exist_ok=True)
+        (cdir / f"{case_id}.yaml").write_text(
+            yaml.safe_dump({"id": case_id,
+                            "target_pq": str(c.get("answers_question")
+                                              or PQ)},
+                           sort_keys=False),
+            encoding="utf-8")
+        led.cases[case_id] = po.CasePosterior(case_id, alpha=1.0,
+                                              beta=1.0 + attempts)
+    led.save(ws)
 
 
 def _claim(cid: str, attempts: int = 3, statement: str = "sample does X") -> dict:
     return {"id": cid, "status": "OPEN", "boundary_type": "positive_observation",
             "evidence_tier_attempted": 1, "promotion_attempts": attempts,
+            "answers_question": PQ,
             "depends_on": [], "statement": statement}
 
 
@@ -111,7 +137,7 @@ def test_record_outcome_writes_fields_and_preserves_prior(tmp_path):
     assert entry["assumption_validity"] == "not-justified"     # preserved
     assert entry["next_method"] == "runtime Frida hook"        # preserved
     assert entry["analyzed_at"] == prior_analyzed_at           # preserved
-    assert entry["covers_attempt"] == 3
+    assert entry["covers_settlements"] == 3
 
 
 def test_record_outcome_validation(tmp_path):
@@ -158,7 +184,7 @@ def test_record_legacy_fields_unchanged(tmp_path):
 
     # Assert
     assert set(r["entry"].keys()) == {
-        "claim", "covers_attempt", "method_assumption",
+        "claim", "covers_settlements", "method_assumption",
         "assumption_validity", "next_method",
         "next_method_source",               # #495 provenance
         "validated_capability", "identified_obstacle",   # #495 artifacts
@@ -400,7 +426,10 @@ def test_failure_blocked_parsing_backward_compatible(tmp_path):
     _write_register(ws, [_claim("C-10", attempts=2),       # no analysis -> BLOCKED
                          _claim("C-11", attempts=2)])      # analysis w/o outcome -> covered
     _record(ws, "C-11", assumption="a", validity="not-justified", next_method="b")
-    expected = {"C-10"}
+    # the default obstacle in _record promotes child C-12; it inherits
+    # answers_question, so the pq's red settlements arm it too (#146:
+    # arming follows the linkage, not the dispatch counter)
+    expected = {"C-10", "C-12"}
 
     # Act
     blocked_legacy = {b["claim_id"] for b in fag.scan_workspace(ws)}
@@ -414,7 +443,8 @@ def test_failure_blocked_parsing_backward_compatible(tmp_path):
 
     # Assert — unchanged: new fields do not alter the gate decision
     assert blocked_new == expected
-    assert fag._analysis_covers(fag._load_analysis(ws, "C-11"), _claim("C-11", attempts=2))
+    assert fag._analysis_covers(fag._load_analysis(ws, "C-11"),
+                                fag.linked_fail_settlements(ws, _claim("C-11")))
 
 
 # ---------- CLI wiring regression (orchestrator verification) ----------

--- a/tests/test_kunglao_core_loop.py
+++ b/tests/test_kunglao_core_loop.py
@@ -91,11 +91,23 @@ def test_convergence_check(tmp: Path) -> None:
     check("cc.saturated", d["decision"] == "SATURATED" and d["exit_code"] == 3, str(d))
 
     # Branch 4: BLOCKED (open but all blocked) — via failure_analysis_gate scan
-    make_claim_reg(ws, [{"id": "C-1", "status": "PROVEN"}, {"id": "C-2", "status": "OPEN", "attempts": 3}])
+    make_claim_reg(ws, [{"id": "C-1", "status": "PROVEN"},
+                        {"id": "C-2", "status": "OPEN", "attempts": 3,
+                         "extra": {"answers_question": "q1"}}])
     (ws / "runs" / "worker-status-w1.md").unlink()
     (ws / "runs" / "worker-status-w2.md").unlink()
     (ws / "runs" / "worker-status-w3.md").unlink()
-    # C-2 with promotion_attempts=3 triggers failure-analysis BLOCKED state
+    # C-2 arms via a fail settlement on a target_pq-linked oracle case
+    # (#146: settlement-derived arming — promotion_attempts is not a
+    # writer-backed signal)
+    import posteriors as po
+    cdir = ws / "oracle" / "cases"
+    cdir.mkdir(parents=True)
+    (cdir / "case-c-2.yaml").write_text(
+        "id: case-c-2\ntarget_pq: q1\n", encoding="utf-8")
+    led = po.PosteriorLedger.load(ws)
+    led.cases["case-c-2"] = po.CasePosterior("case-c-2", alpha=1.0, beta=2.0)
+    led.save(ws)
     d = cc.decide(ws)
     check("cc.blocked", d["decision"] == "BLOCKED" and d["exit_code"] == 4, str(d))
 

--- a/tests/test_lessons_nursery.py
+++ b/tests/test_lessons_nursery.py
@@ -297,6 +297,21 @@ def test_blocked_retrieval_tags_draft_lessons(tmp_path):
     ws = tmp_path / "ws"
     ws.mkdir()
     _write_register(ws, [_claim("C-7", attempts=3, statement="frida attach fails on vm")])
+    # #146: arm the gate the live way — a linked case carrying red
+    # settlements in the #106 ledger (the counter no longer arms).
+    import posteriors as po
+    cdir = ws / "oracle" / "cases"
+    cdir.mkdir(parents=True)
+    (cdir / "case-c-7.yaml").write_text(
+        "id: case-c-7\ntarget_pq: q1\n", encoding="utf-8")
+    led = po.PosteriorLedger.load(ws)
+    led.cases["case-c-7"] = po.CasePosterior("case-c-7", alpha=1.0, beta=4.0)
+    led.save(ws)
+    import yaml as _yaml
+    reg = _yaml.safe_load((ws / "claim-register.yaml").read_text(encoding="utf-8"))
+    reg["claims"][0]["answers_question"] = "q1"
+    (ws / "claim-register.yaml").write_text(
+        _yaml.safe_dump(reg, sort_keys=False), encoding="utf-8")
     lib = tmp_path / "lib"
     lib.mkdir()
     # seed 3 lessons that overlap the topic; all draft by default

--- a/tests/test_no_tracked_ignored_files.py
+++ b/tests/test_no_tracked_ignored_files.py
@@ -41,6 +41,10 @@ TRACKED_IGNORED_ALLOWLIST: dict[str, str] = {
         "golden fixture: F-03 replay input (runs/ rule over-matches depth)",
     "tests/fixtures/golden/F-06/ws/runs/worker-status-w1.md":
         "golden fixture: F-06 replay input (runs/ rule over-matches depth)",
+    "tests/fixtures/golden/F-04/ws/runs/posteriors.yaml":
+        "golden fixture: F-04 replay input (#146 settlement arming; runs/ rule over-matches depth)",
+    "tests/fixtures/golden/F-12/ws/runs/posteriors.yaml":
+        "golden fixture: F-12 replay input (#146 settlement arming; runs/ rule over-matches depth)",
     # .subagent-review/*.json (rule .gitignore:44) — committed review
     # receipts are deliberate Gate-5 execution evidence (devkit/quality_gates.py).
     # 2026-08-19-gate5.json is additionally pinned by

--- a/tests/test_orchestration_event_taxonomy.py
+++ b/tests/test_orchestration_event_taxonomy.py
@@ -201,13 +201,24 @@ def test_blockers_scanned_real_lifecycle(tmp_path):
 
 def test_gate_blocked_from_real_failure_analysis(tmp_path):
     """gate_blocked = failure_analysis_gate.scan_workspace BLOCKED entries —
-    a claim with a failed attempt (promotion_attempts > 0), non-terminal,
-    and no analyses/failure-<claim>.yaml (the source priority.py consumes)."""
+    a non-terminal claim with >=1 fail settlement on a target_pq-linked
+    oracle case and no analyses/failure-<claim>.yaml (#146: arming is
+    settlement-derived; the source priority.py consumes)."""
     ws = tmp_path
     (ws / "claim-register.yaml").write_text(
         "claims:\n"
-        "- id: C-G\n  status: OPEN\n  statement: x\n  promotion_attempts: 1\n",
+        "- id: C-G\n  status: OPEN\n  statement: x\n"
+        "  answers_question: q1\n  promotion_attempts: 1\n",
         encoding="utf-8")
+    cdir = ws / "oracle" / "cases"
+    cdir.mkdir(parents=True)
+    (cdir / "case-c-g.yaml").write_text(
+        "id: case-c-g\ntarget_pq: q1\n", encoding="utf-8")
+    (ws / "runs").mkdir(parents=True)
+    (ws / "runs" / "posteriors.yaml").write_text(
+        '{"schema": "posteriors-schema/1", "cases": '
+        '{"case-c-g": {"alpha": 1.0, "beta": 2.0, "pending_entries": 0}}, '
+        '"pqs": {}}', encoding="utf-8")
     counts = et.classify_workspace(ws)
     assert counts["gate_blocked"] == 1
 

--- a/tests/test_outcome_forensics_146.py
+++ b/tests/test_outcome_forensics_146.py
@@ -639,3 +639,64 @@ def test_bank_retrieval_unchanged_with_how(tmp_path):
     got = cb.retrieve(tmp_path, ["re"])
     assert [e["claim_id"] for e in got] == ["C-2", "C-1"]
     assert got[0]["how"]["mechanism"].startswith("key schedule")
+
+
+# ========== review r1 fixes: regression pins (findings 1-3, 5) ==========
+
+def test_version_wall_raises_not_silently_disarms(tmp_path):
+    """r1-1: a WRONG-schema posterior ledger must RAISE (the version
+    wall), never silently read as "no settlements" — that would un-arm
+    the gate exactly when the ledger is untrustworthy."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _write_register(ws, [_claim("C-1")])
+    _arm_red(ws, "CASE-1", reds=1)
+    (ws / "runs" / "posteriors.yaml").write_text(
+        "schema: posteriors-schema/999\ncases: {}\npqs: {}\n",
+        encoding="utf-8")
+    with pytest.raises(po.PosteriorSchemaError):
+        fag.linked_fail_settlements(ws, _claim("C-1"))
+
+
+def test_non_mapping_params_contained_as_case_error(tmp_path):
+    """r1-2: a non-mapping params is a per-case ERROR row (crash
+    containment), never a whole-run crash."""
+    ws = _mk_ws(tmp_path, [CASE_MAIN], GOOD_CLIENT)
+    case_file = ws / "oracle" / "cases" / "case-00.yaml"
+    doc = yaml.safe_load(case_file.read_text(encoding="utf-8"))
+    doc["params"] = "oops"
+    case_file.write_text(yaml.safe_dump(doc), encoding="utf-8")
+    cases = orun.load_cases(ws / "oracle" / "cases")
+    row = orun.check_case(cases[0], orun.load_client(ws / "oracle"
+                                                     / "client.py"))
+    assert row["status"] == "pending"
+    assert "dict" in (row["error"] or "")
+    assert row["forensics"]["params_used"] == {}
+
+
+MUTATING_CLIENT = '''def compute(params):
+    params["k"] = "MUTATED-BY-CLIENT"
+    return {"auth_algo": "hmac-sha256", "nonce_len": 2}
+'''
+
+
+def test_params_used_survives_client_mutation(tmp_path):
+    """r1-3: params_used is a SNAPSHOT taken before compute — a client
+    that mutates its input cannot corrupt the forensic record."""
+    ws = _mk_ws(tmp_path, [CASE_MAIN], MUTATING_CLIENT)
+    cases = orun.load_cases(ws / "oracle" / "cases")
+    row = orun.check_case(cases[0], orun.load_client(ws / "oracle"
+                                                     / "client.py"))
+    assert row["status"] == "pass"
+    assert row["forensics"]["params_used"] == {"user": "alice",
+                                               "nonce": 10}
+
+
+def test_retire_cli_empty_case_id_refuses(tmp_path, capsys):
+    """r1-5: `--retire ""` must refuse, never fall through to a run face."""
+    ws = _mk_ws(tmp_path, [CASE_MAIN], None)
+    rc = orun.main([str(ws), "--retire", "",
+                    "--attribution-class", "case-wrong",
+                    "--disconfirmation", "x", "--replacement", "y"])
+    assert rc == 2
+    assert "REFUSED" in capsys.readouterr().err

--- a/tests/test_outcome_forensics_146.py
+++ b/tests/test_outcome_forensics_146.py
@@ -1,0 +1,641 @@
+# -*- coding: utf-8 -*-
+"""tests/test_outcome_forensics_146.py — issue #146 outcome forensics.
+
+RED-first pins (the issue is the contract):
+
+  1. RED settlement carries the per-field mismatch vector — every
+     non-matching expected entry as {field, expected, actual} in the
+     row's forensics block (losses become attributable).
+  2. Stage-diff: when the client result carries a ``stages`` dict, the
+     runner diffs stage-wise against the case's expected stages and
+     records the divergence point (first stage whose output differs from
+     its expected-stage value, or an expected stage the client never
+     produced); no expected stages -> stages just recorded.
+  3. GREEN settlement carries derivation provenance {params_used} plus
+     the client's optional ``meta`` contract (absent -> empty).
+  4. Report/status schema intact — forensics fields are ADDITIVE
+     (runs/oracle-status.json keeps its exact convergence shape).
+  5. Failure-analysis gate arming is settlement-driven: >=1 fail
+     settlement on an oracle case linked via the claim's answers_question
+     <-> case target_pq (same linkage priority_ratio uses) ARMS the gate —
+     re-dispatch blocked until the three questions + artifacts are
+     recorded. promotion_attempts dead-arming is gone. A NEW red
+     settlement re-arms (per-attempt coverage derived from settlements).
+  6. Case-abandonment protocol: a case transitions to ``retired`` ONLY
+     with the structured justification {attribution_class in the closed
+     taxonomy, disconfirmation, replacement} — loud refusal otherwise;
+     the transition is append-only; retiring emits the coverage-drop WARN
+     event (registered word acceptance_coverage_decreased) and removes
+     the case from the acceptance net (runner skips it; its reds no
+     longer arm the gate).
+  7. Bank attribution upgrade: the case-bank entry schema gains an
+     OPTIONAL structured ``how`` field (the forensics block) — never
+     required, back-compat with banked rows, retrieval unchanged.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import case_bank as cb  # noqa: E402
+import event_taxonomy as et  # noqa: E402
+import failure_analysis_gate as fag  # noqa: E402
+import oracle_runner as orun  # noqa: E402
+import posteriors as po  # noqa: E402
+
+
+# ---------------------------------------------------------------- clients
+
+GOOD_CLIENT = '''def compute(params):
+    return {"auth_algo": "hmac-sha256", "nonce_len": len(str(params["nonce"]))}
+'''
+
+# Optional client contract: "meta" (derivation provenance) + "stages"
+# (intermediate derivation steps the runner diffs stage-wise).
+GOOD_META_STAGED_CLIENT = '''def compute(params):
+    return {"auth_algo": "hmac-sha256",
+            "nonce_len": len(str(params["nonce"])),
+            "meta": {"algo_path": "openssl EVP_sha256", "key_len": 32},
+            "stages": {"canon": "user=alice", "mac": "a1b2"}}
+'''
+
+BAD_CLIENT = '''def compute(params):
+    return {"auth_algo": len(str(params["nonce"])), "nonce_len": "hmac-sha256"}
+'''
+
+CRASH_CLIENT = '''def compute(params):
+    raise RuntimeError("instrumentation exploded")
+'''
+
+# Correct final fields but a wrong intermediate: the derivation diverged
+# at the mac stage even though the settlement is green.
+STAGE_DIVERGENT_CLIENT = '''def compute(params):
+    return {"auth_algo": "hmac-sha256",
+            "nonce_len": 2,
+            "stages": {"canon": "user=alice", "mac": "WRONG-MAC"}}
+'''
+
+STAGE_MISSING_CLIENT = '''def compute(params):
+    return {"auth_algo": "hmac-sha256", "nonce_len": 2,
+            "stages": {"canon": "user=alice"}}
+'''
+
+
+# ----------------------------------------------------------------- cases
+
+CASE_MAIN = {
+    "id": "auth-fields",
+    "channel": "device-trace",
+    "hypothesis_ref": "H-001",
+    "target_pq": "q1",
+    "update_map": {"green_up": ["H-001"], "red_up": ["H-002"]},
+    "params": {"user": "alice", "nonce": 10},
+    "expected": [
+        {"field": "auth_algo", "value": "hmac-sha256",
+         "evidence_refs": ["F001"]},
+        {"field": "nonce_len", "value": 2, "evidence_refs": ["F001"]},
+    ],
+    "mutations": [{"field": "auth_algo", "kind": "swap"}],
+}
+
+# Distinct signature from CASE_MAIN (#126: channel x competitor_group).
+CASE_STAGED = {
+    "id": "staged-auth",
+    "channel": "emulator-trace",
+    "hypothesis_ref": "H-002",
+    "target_pq": "q1",
+    "update_map": {"green_up": ["H-002"], "red_up": ["H-001"]},
+    "params": {"user": "alice", "nonce": 10},
+    "stages": {"canon": "user=alice", "mac": "a1b2"},  # expected stage values
+    "expected": [
+        {"field": "auth_algo", "value": "hmac-sha256",
+         "evidence_refs": ["F002"]},
+        {"field": "nonce_len", "value": 2, "evidence_refs": ["F002"]},
+    ],
+    "mutations": [{"field": "auth_algo", "kind": "change"}],
+}
+
+
+def _write_hypothesis(ws: Path, hyp_id: str, group: str) -> None:
+    p = ws / "hypotheses" / f"{hyp_id}.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        "---\n"
+        f"id: {hyp_id}\n"
+        "claim_id: C-001\n"
+        f"competitor_group: {group}\n"
+        "candidates: [AES, ChaCha20]\n"
+        "status: open\n"
+        "schema_rev: 1\n"
+        "---\n\npq:q1\n",
+        encoding="utf-8")
+
+
+def _mk_ws(tmp_path: Path, cases: list[dict],
+           client_src: str | None) -> Path:
+    ws = tmp_path / "ws"
+    (ws / "oracle" / "cases").mkdir(parents=True)
+    (ws / "facts").mkdir()
+    (ws / "facts" / "F001.md").write_text(
+        "# F001\n\nauth fields pinned (byte-anchored).\n", encoding="utf-8")
+    (ws / "facts" / "F002.md").write_text(
+        "# F002\n\nmagic bytes pinned (byte-anchored).\n", encoding="utf-8")
+    _write_hypothesis(ws, "H-001", "grp-live")
+    _write_hypothesis(ws, "H-002", "grp-live")
+    for i, case in enumerate(cases):
+        (ws / "oracle" / "cases" / f"case-{i:02d}.yaml").write_text(
+            yaml.safe_dump(case, allow_unicode=True, sort_keys=False),
+            encoding="utf-8")
+    if client_src is not None:
+        (ws / "oracle" / "client.py").write_text(client_src, encoding="utf-8")
+    return ws
+
+
+# ------------------------------------------------- gate fixture helpers
+
+PQ = "q1"
+
+
+def _claim(cid: str, pq: str | None = PQ, **extra) -> dict:
+    """A non-terminal claim; arming comes from settlements, so
+    promotion_attempts stays 0 — the dead counter must stay dead."""
+    c = {"id": cid, "status": "OPEN", "boundary_type": "positive_observation",
+         "evidence_tier_attempted": 1, "promotion_attempts": 0,
+         "depends_on": [], "statement": "sample does X"}
+    if pq is not None:
+        c["answers_question"] = pq
+    c.update(extra)
+    return c
+
+
+def _write_register(ws: Path, claims: list[dict]) -> None:
+    (ws / "claim-register.yaml").write_text(
+        yaml.safe_dump({"claims": claims}, allow_unicode=True,
+                       sort_keys=False),
+        encoding="utf-8")
+
+
+def _arm_red(ws: Path, case_id: str, pq: str = PQ, reds: int = 1) -> None:
+    """One oracle case linked to pq carrying `reds` fail settlements.
+
+    Settlement state = the runner's posterior ledger (runs/posteriors.yaml,
+    #106: each red run is beta+1 over the Beta(1,1) prior) — the same
+    ledger #132's cadence hook records into."""
+    cdir = ws / "oracle" / "cases"
+    cdir.mkdir(parents=True, exist_ok=True)
+    (cdir / f"{case_id.lower()}.yaml").write_text(
+        yaml.safe_dump({"id": case_id, "target_pq": pq},
+                       sort_keys=False),
+        encoding="utf-8")
+    led = po.PosteriorLedger.load(ws)
+    led.cases[case_id] = po.CasePosterior(case_id, alpha=1.0,
+                                          beta=1.0 + float(reds))
+    led.save(ws)
+
+
+def _bump_red(ws: Path, case_id: str, reds: int) -> None:
+    led = po.PosteriorLedger.load(ws)
+    led.cases[case_id] = po.CasePosterior(case_id, alpha=1.0,
+                                          beta=1.0 + float(reds))
+    led.save(ws)
+
+
+def _record(ws: Path, cid: str, **kw) -> dict:
+    lib = kw.pop("library", None) or _empty_lib(ws)
+    return fag.record_analysis(
+        ws, cid, kw.get("assumption", ""), kw.get("validity", ""),
+        kw.get("next_method", ""), kw.get("outcome"), kw.get("what_happened"),
+        validated_capability=kw.get("capability"),
+        identified_obstacle=kw.get("obstacle"),
+        source=kw.get("source"), library=lib)
+
+
+def _empty_lib(ws: Path) -> Path:
+    lib = ws.parent / "lessons-lib"
+    lib.mkdir(parents=True, exist_ok=True)
+    return lib
+
+
+def _retire_kw() -> dict:
+    return {"attribution_class": "case-wrong",
+            "disconfirmation": "single-green on the salted client and red "
+                               "here matches no implementation split — the "
+                               "expected value pins a pre-salt layout",
+            "replacement": "re-derive expected from F003 and re-admit as "
+                           "auth-fields-v2"}
+
+
+def _log_rows(ws: Path) -> list[dict]:
+    out: list[dict] = []
+    logs = ws / "runs" / "logs"
+    if not logs.is_dir():
+        return out
+    for p in sorted(logs.glob("kunglao-*.jsonl")):
+        for line in p.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict):
+                    out.append(row)
+    return out
+
+
+# ================ 1. red settlement: per-field mismatch vector =========
+
+def test_red_settlement_carries_per_field_mismatch_vector(tmp_path):
+    """A FAIL row's forensics block names EVERY non-matching expected
+    entry as {field, expected, actual} — the loss is attributable."""
+    ws = _mk_ws(tmp_path, [CASE_MAIN], None)
+    cases = orun.load_cases(ws / "oracle" / "cases")
+    bad_src = ws / "oracle" / "bad.py"
+    bad_src.write_text(BAD_CLIENT, encoding="utf-8")
+    row = orun.check_case(cases[0], orun.load_client(bad_src))
+    assert row["status"] == "fail"
+    assert row["forensics"]["mismatches"] == [
+        {"field": "auth_algo", "expected": "hmac-sha256", "actual": 2},
+        {"field": "nonce_len", "expected": 2, "actual": "hmac-sha256"},
+    ]
+
+
+def test_run_report_rows_carry_the_mismatch_vector(tmp_path):
+    """run() report rows carry the same forensics (the report is what the
+    settlement hook consumes)."""
+    ws = _mk_ws(tmp_path, [CASE_MAIN], BAD_CLIENT)
+    report = orun.run(ws / "oracle" / "cases",
+                      ws / "oracle" / "client.py")
+    assert report["counts"]["red"] == 1
+    assert report["cases"]["auth-fields"]["forensics"]["mismatches"][0] == {
+        "field": "auth_algo", "expected": "hmac-sha256", "actual": 2}
+
+
+def test_green_row_has_no_mismatches(tmp_path):
+    ws = _mk_ws(tmp_path, [CASE_MAIN], GOOD_CLIENT)
+    cases = orun.load_cases(ws / "oracle" / "cases")
+    row = orun.check_case(cases[0], orun.load_client(ws / "oracle"
+                                                     / "client.py"))
+    assert row["status"] == "pass"
+    assert row["forensics"]["mismatches"] == []
+
+
+# ===================== 2. stage diff + divergence point ================
+
+def test_stage_divergence_point_recorded(tmp_path):
+    """A client-exposed stages dict is diffed against the case's expected
+    stage values; the first differing stage is the divergence point —
+    even when the final settlement is green."""
+    ws = _mk_ws(tmp_path, [CASE_STAGED], STAGE_DIVERGENT_CLIENT)
+    cases = orun.load_cases(ws / "oracle" / "cases")
+    row = orun.check_case(cases[0], orun.load_client(ws / "oracle"
+                                                     / "client.py"))
+    assert row["status"] == "pass"
+    assert row["forensics"]["stages"] == {"canon": "user=alice",
+                                          "mac": "WRONG-MAC"}
+    assert row["forensics"]["divergence_point"] == "mac"
+
+
+def test_stage_missing_from_client_is_divergence(tmp_path):
+    """An expected stage the client never produced is itself the
+    divergence (missing output differs from its expected value)."""
+    ws = _mk_ws(tmp_path, [CASE_STAGED], STAGE_MISSING_CLIENT)
+    cases = orun.load_cases(ws / "oracle" / "cases")
+    row = orun.check_case(cases[0], orun.load_client(ws / "oracle"
+                                                     / "client.py"))
+    assert row["forensics"]["divergence_point"] == "mac"
+
+
+def test_stages_without_expected_values_just_recorded(tmp_path):
+    """No expected stage values in the case -> the stages are recorded and
+    no divergence point is claimed (nothing to differ from)."""
+    ws = _mk_ws(tmp_path, [CASE_MAIN], GOOD_META_STAGED_CLIENT)
+    cases = orun.load_cases(ws / "oracle" / "cases")
+    row = orun.check_case(cases[0], orun.load_client(ws / "oracle"
+                                                     / "client.py"))
+    assert row["status"] == "pass"
+    assert row["forensics"]["stages"] == {"canon": "user=alice",
+                                          "mac": "a1b2"}
+    assert row["forensics"]["divergence_point"] is None
+
+
+def test_no_stages_divergence_stays_none(tmp_path):
+    ws = _mk_ws(tmp_path, [CASE_MAIN], BAD_CLIENT)
+    cases = orun.load_cases(ws / "oracle" / "cases")
+    row = orun.check_case(cases[0], orun.load_client(ws / "oracle"
+                                                     / "client.py"))
+    assert row["status"] == "fail"
+    assert row["forensics"]["stages"] == {}
+    assert row["forensics"]["divergence_point"] is None
+
+
+# ============== 3. green settlement: derivation provenance =============
+
+def test_green_settlement_carries_params_and_meta(tmp_path):
+    """params_used is the derivation's input record; a client ``meta``
+    key is surfaced verbatim (optional contract)."""
+    ws = _mk_ws(tmp_path, [CASE_MAIN], GOOD_META_STAGED_CLIENT)
+    cases = orun.load_cases(ws / "oracle" / "cases")
+    row = orun.check_case(cases[0], orun.load_client(ws / "oracle"
+                                                     / "client.py"))
+    assert row["status"] == "pass"
+    assert row["forensics"]["params_used"] == {"user": "alice",
+                                               "nonce": 10}
+    assert row["forensics"]["meta"] == {"algo_path": "openssl EVP_sha256",
+                                        "key_len": 32}
+
+
+def test_meta_absent_is_empty(tmp_path):
+    ws = _mk_ws(tmp_path, [CASE_MAIN], GOOD_CLIENT)
+    cases = orun.load_cases(ws / "oracle" / "cases")
+    row = orun.check_case(cases[0], orun.load_client(ws / "oracle"
+                                                     / "client.py"))
+    assert row["forensics"]["meta"] == {}
+
+
+def test_crash_and_no_client_forensics_shape(tmp_path):
+    """Unknown is not pass: a crashed client keeps params_used (compute
+    was invoked), no client -> all forensics empty, nothing invented."""
+    ws = _mk_ws(tmp_path, [CASE_MAIN], CRASH_CLIENT)
+    cases = orun.load_cases(ws / "oracle" / "cases")
+    row = orun.check_case(cases[0], orun.load_client(ws / "oracle"
+                                                     / "client.py"))
+    assert row["status"] == "pending"
+    assert row["forensics"]["params_used"] == {"user": "alice",
+                                               "nonce": 10}
+    assert row["forensics"]["mismatches"] == []
+
+    ws2 = _mk_ws(tmp_path / "b", [CASE_MAIN], None)
+    row2 = orun.check_case(orun.load_cases(ws2 / "oracle" / "cases")[0],
+                           None)
+    assert row2["status"] == "pending"
+    assert row2["forensics"] == {"params_used": {}, "meta": {},
+                                 "mismatches": [], "stages": {},
+                                 "divergence_point": None}
+
+
+# =============== 4. report/status schema intact (additive only) ========
+
+def test_report_and_status_schema_intact(tmp_path):
+    """Forensics fields are ADDITIVE: every pre-existing report key and
+    status-file field survives unchanged."""
+    ws = _mk_ws(tmp_path, [CASE_MAIN], BAD_CLIENT)
+    report = orun.run(ws / "oracle" / "cases",
+                      ws / "oracle" / "client.py")
+    assert set(report) >= {"schema", "cases_dir", "client", "cases",
+                           "counts", "mutation"}
+    row = report["cases"]["auth-fields"]
+    assert set(row) >= {"status", "pending_entries", "instrumented",
+                        "failures", "error"}
+
+    orun.write_status(ws, report)
+    doc = json.loads((ws / "runs" / "oracle-status.json")
+                     .read_text(encoding="utf-8"))
+    assert doc["schema"] == "oracle-status/1"
+    assert set(doc["cases"]["auth-fields"]) == {"status", "pending_entries",
+                                                "instrumented"}
+    assert set(doc) == {"schema", "cases", "low_discriminativity", "counts"}
+
+
+# ====== 5. failure-analysis gate: settlement-driven arming =============
+
+def test_fail_settlement_arms_gate(tmp_path):
+    """>=1 fail settlement on a target_pq-linked case ARMS the gate —
+    with promotion_attempts at 0 (the dead counter stays dead)."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _write_register(ws, [_claim("C-1")])
+    _arm_red(ws, "CASE-1", reds=1)
+
+    blocked = fag.scan_workspace(ws)
+    assert [b["claim_id"] for b in blocked] == ["C-1"]
+    assert blocked[0]["state"] == "BLOCKED"
+    # the derived settlement face replaces the dead counter
+    assert "promotion_attempts" not in blocked[0]
+    assert blocked[0]["red_settlements"] == {"CASE-1": 1}
+
+
+def test_recorded_analysis_unblocks(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _write_register(ws, [_claim("C-1")])
+    _arm_red(ws, "CASE-1", reds=1)
+
+    r = _record(ws, "C-1", assumption="spawn keeps the app alive",
+                validity="not-justified",
+                next_method="switch to listen mode",
+                capability="frida JNI bridge works",
+                obstacle="spawn times out under selinux",
+                source="lesson-hit")
+    assert r["recorded"] is True
+    assert r["entry"]["covers_settlements"] == 1
+    assert fag.check_claim(ws, "C-1")["state"] == "OK_COVERED"
+
+
+def test_new_red_settlement_re_arms(tmp_path):
+    """A NEW fail settlement after a covering analysis re-arms the gate —
+    each failed attempt needs its own analysis (coverage now derives from
+    settlements instead of the unwritten counter)."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _write_register(ws, [_claim("C-1")])
+    _arm_red(ws, "CASE-1", reds=1)
+    _record(ws, "C-1", assumption="a", validity="not-justified",
+            next_method="b", capability="c", obstacle="o",
+            source="lesson-hit")
+    assert fag.check_claim(ws, "C-1")["state"] == "OK_COVERED"
+
+    _bump_red(ws, "CASE-1", reds=2)
+    assert fag.check_claim(ws, "C-1")["state"] == "BLOCKED"
+
+
+def test_no_linkage_no_arming(tmp_path):
+    """Reds on a case whose target_pq does not match the claim's
+    answers_question arm nothing (the priority_ratio linkage)."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _write_register(ws, [_claim("C-1", pq=None),
+                         _claim("C-2", pq="other-pq")])
+    _arm_red(ws, "CASE-1", pq="q1", reds=2)
+
+    assert fag.scan_workspace(ws) == []
+    assert fag.check_claim(ws, "C-1")["state"] == "OK_NO_PRIOR_FAILURE"
+    assert fag.check_claim(ws, "C-2")["state"] == "OK_NO_PRIOR_FAILURE"
+
+
+def test_gate_does_not_arm_on_attempts_counter_alone(tmp_path):
+    """promotion_attempts > 0 with zero fail settlements arms NOTHING —
+    the dead-arming path is removed, not patched."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _write_register(ws, [_claim("C-1", promotion_attempts=3)])
+    assert fag.scan_workspace(ws) == []
+    assert fag.check_claim(ws, "C-1")["state"] == "OK_NO_PRIOR_FAILURE"
+
+
+def test_retired_case_reds_stop_arming(tmp_path):
+    """A retired case has left the acceptance net: its red settlements no
+    longer arm the gate (retirement is the way to silence a case)."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _write_register(ws, [_claim("C-1")])
+    _arm_red(ws, "CASE-1", reds=1)
+    assert fag.scan_workspace(ws), "pre-condition: armed"
+
+    orun.retire_case(ws, "CASE-1", **_retire_kw())
+    assert fag.scan_workspace(ws) == []
+    assert fag.check_claim(ws, "C-1")["state"] == "OK_NO_PRIOR_FAILURE"
+
+
+# ================ 6. case-abandonment protocol =========================
+
+def test_retire_refuses_incomplete_justification(tmp_path):
+    """Every justification field is required; an unknown attribution
+    class is refused; nothing is written on refusal."""
+    ws = _mk_ws(tmp_path, [CASE_MAIN], None)
+    case_file = ws / "oracle" / "cases" / "case-00.yaml"
+    before = case_file.read_text(encoding="utf-8")
+    full = _retire_kw()
+    for missing in ("attribution_class", "disconfirmation", "replacement"):
+        kw = dict(full)
+        kw[missing] = "   "
+        with pytest.raises(orun.OracleCaseError, match=missing):
+            orun.retire_case(ws, "auth-fields", **kw)
+    with pytest.raises(orun.OracleCaseError, match="attribution_class"):
+        orun.retire_case(ws, "auth-fields",
+                         attribution_class="it-felt-wrong",
+                         disconfirmation="x", replacement="y")
+    assert case_file.read_text(encoding="utf-8") == before
+
+
+def test_retire_refuses_unknown_case_and_rerun(tmp_path):
+    ws = _mk_ws(tmp_path, [CASE_MAIN], None)
+    with pytest.raises(orun.OracleCaseError, match="no case"):
+        orun.retire_case(ws, "no-such-case", **_retire_kw())
+    orun.retire_case(ws, "auth-fields", **_retire_kw())
+    with pytest.raises(orun.OracleCaseError, match="already"):
+        orun.retire_case(ws, "auth-fields", **_retire_kw())
+
+
+def test_retire_full_justification_append_only(tmp_path):
+    """Retirement keeps the case in its file (append-only): the original
+    expected entries survive and status/retirement are ADDED."""
+    ws = _mk_ws(tmp_path, [CASE_MAIN], None)
+    rec = orun.retire_case(ws, "auth-fields", **_retire_kw())
+    assert rec["case_id"] == "auth-fields"
+    assert rec["armed_cases_after"] == rec["armed_cases_before"] - 1
+
+    doc = yaml.safe_load(
+        (ws / "oracle" / "cases" / "case-00.yaml").read_text(encoding="utf-8"))
+    assert doc["status"] == "retired"
+    assert doc["retirement"]["attribution_class"] == "case-wrong"
+    assert doc["retirement"]["disconfirmation"] == \
+        _retire_kw()["disconfirmation"]
+    assert doc["retirement"]["replacement"] == _retire_kw()["replacement"]
+    assert doc["retirement"]["retired_at"]
+    assert doc["expected"] == CASE_MAIN["expected"]  # nothing deleted
+
+
+def test_retire_emits_coverage_decreased_warn(tmp_path):
+    """Retiring shrinks the acceptance net — the WARN fires with the
+    registered event word, naming the case and the armed count."""
+    ws = _mk_ws(tmp_path, [CASE_MAIN], None)
+    orun.retire_case(ws, "auth-fields", **_retire_kw())
+    drops = [r for r in _log_rows(ws)
+             if r.get("action") == "acceptance_coverage_decreased"]
+    assert drops, f"no coverage WARN in {_log_rows(ws)}"
+    assert "auth-fields" in (drops[-1].get("detail") or "")
+
+
+def test_retired_case_leaves_the_run(tmp_path):
+    """The runner stops judging retired cases: they are reported, not
+    run — the remaining cases keep their verdicts."""
+    ws = _mk_ws(tmp_path, [CASE_MAIN, CASE_STAGED], BAD_CLIENT)
+    orun.retire_case(ws, "staged-auth", **_retire_kw())
+    report = orun.run(ws / "oracle" / "cases",
+                      ws / "oracle" / "client.py")
+    assert report["retired"] == ["staged-auth"]
+    assert set(report["cases"]) == {"auth-fields"}
+    assert report["counts"] == {"red": 1, "green": 0, "pending": 0}
+
+
+def test_retire_cli_refuses_and_accepts(tmp_path, capsys):
+    """CLI face: --retire without the justification exits 2 loudly; the
+    full justification exits 0."""
+    ws = _mk_ws(tmp_path, [CASE_MAIN], None)
+    rc = orun.main([str(ws), "--retire", "auth-fields"])
+    assert rc == 2
+    assert "REFUSED" in capsys.readouterr().err
+
+    rc = orun.main([str(ws), "--retire", "auth-fields",
+                    "--attribution-class", "case-wrong",
+                    "--disconfirmation", "expected pins a pre-salt layout",
+                    "--replacement", "re-derive from F003 as auth-fields-v2"])
+    assert rc == 0
+    doc = yaml.safe_load(
+        (ws / "oracle" / "cases" / "case-00.yaml").read_text(encoding="utf-8"))
+    assert doc["status"] == "retired"
+
+
+def test_coverage_word_is_registered(tmp_path):
+    """The coverage-drop WARN word sits in the controlled vocabulary
+    (#459: an emit literal outside EMIT_ACTIONS turns the suite red)."""
+    assert "acceptance_coverage_decreased" in et.EMIT_ACTIONS
+
+
+# ================ 7. bank attribution upgrade: optional `how` ==========
+
+def _bank_entry(**kw):
+    base = dict(claim_id="C-1", method="ghidra-light",
+                context_tags=["re", "vm"],
+                intent_uncertainty="which config builder runs first",
+                outcome_observed={"verdict": "passes"},
+                roi_class="POSITIVE")
+    base.update(kw)
+    return base
+
+
+def test_bank_entry_carries_optional_how(tmp_path):
+    """`how` is the structured forensics block — stored verbatim, never
+    required (back-compat with banked rows)."""
+    how = {"mismatch_class": "field-transpose",
+           "mechanism": "auth_algo carried the nonce length — the two "
+                        "signed fields were built in swapped order"}
+    stored = cb.append(tmp_path, _bank_entry(how=how))
+    assert stored["how"] == how
+    rows = cb.read_entries(tmp_path)
+    assert rows[0]["how"] == how
+
+    plain = cb.append(tmp_path, _bank_entry(claim_id="C-2"))
+    assert plain["how"] is None  # absent -> None, nothing invented
+
+
+def test_bank_refuses_non_dict_how(tmp_path):
+    """`how` is structured or nothing: free text is refused (a label is
+    not a lesson)."""
+    with pytest.raises(cb.CaseBankError, match="how"):
+        cb.append(tmp_path, _bank_entry(how="wrong field order"))
+
+
+def test_bank_retrieval_unchanged_with_how(tmp_path):
+    """Retrieval contract untouched: failures first, newest first, tag
+    intersection — `how` rides along but never reorders."""
+    cb.append(tmp_path, _bank_entry(
+        claim_id="C-1", roi_class="POSITIVE", how={"mismatch_class": "x"}))
+    cb.append(tmp_path, _bank_entry(
+        claim_id="C-2", roi_class="NEGATIVE",
+        attribution="guessed OEP; verify-by-replay next time",
+        how={"mismatch_class": "wrong-constant",
+             "mechanism": "key schedule off by one round"}))
+    got = cb.retrieve(tmp_path, ["re"])
+    assert [e["claim_id"] for e in got] == ["C-2", "C-1"]
+    assert got[0]["how"]["mechanism"].startswith("key schedule")

--- a/tests/test_recall_inject.py
+++ b/tests/test_recall_inject.py
@@ -251,8 +251,20 @@ def test_failure_gate_blocked_output_recalls_failure_modes(tmp_path, capsys):
         yaml.safe_dump({"claims": [{
             "id": "C-50", "status": "OPEN", "boundary_type": "observation",
             "evidence_tier_attempted": 1, "promotion_attempts": 1,
+            "answers_question": "q1",
             "depends_on": [], "statement": "sample does X",
         }]}, allow_unicode=True, sort_keys=False), encoding="utf-8")
+    # #146: arm the gate the live way — a linked case carrying a red
+    # settlement in the #106 ledger (the counter no longer arms).
+    import posteriors as po
+    cdir = ws / "oracle" / "cases"
+    cdir.mkdir(parents=True)
+    (cdir / "case-c-50.yaml").write_text(
+        "id: case-c-50\ntarget_pq: q1\n", encoding="utf-8")
+    led = po.PosteriorLedger.load(ws)
+    led.cases["case-c-50"] = po.CasePosterior("case-c-50", alpha=1.0,
+                                              beta=2.0)
+    led.save(ws)
 
     import failure_analysis_gate as fag
     r = fag.check_claim(ws, "C-50")

--- a/tests/test_scorer_authority.py
+++ b/tests/test_scorer_authority.py
@@ -89,6 +89,16 @@ def _authority_ws(path: Path, *, failure_case: bool = False) -> Path:
                        "answers_question": "PQ-8", "promotion_attempts": 1})
         claims.append({"id": "C-E", "status": "OPEN", "statement": "background work"})
         depends_on["C-E"] = ["C-F"]
+        # #146: arm the gate the live way — a linked case carrying a fail
+        # settlement in the #106 ledger (the counter no longer arms).
+        cdir = path / "oracle" / "cases"
+        cdir.mkdir(parents=True)
+        (cdir / "case-c-f.yaml").write_text(
+            '{"id": "case-c-f", "target_pq": "PQ-8"}', encoding="utf-8")
+        (path / "runs" / "posteriors.yaml").write_text(
+            '{"schema": "posteriors-schema/1", "cases": '
+            '{"case-c-f": {"alpha": 1.0, "beta": 2.0, "pending_entries": 0}}, '
+            '"pqs": {}}', encoding="utf-8")
     reg = {"claims": claims}
     deps = {
         "depends_on": depends_on,

--- a/tests/test_trajectory_replay.py
+++ b/tests/test_trajectory_replay.py
@@ -125,7 +125,9 @@ def _trajectory1_ws(root: Path) -> Path:
     led.cases["case-c-1"] = po.CasePosterior("case-c-1", alpha=1.0, beta=3.0)
     led.save(ws)
     _write(ws / "analyses" / "failure-C-1.yaml", {
-        "claim": "C-1", "covers_attempt": 2,
+        "claim": "C-1", "covers_settlements": 2,  # coverage CURRENT so the
+        # death declaration is blocked by the MISSING-ARTIFACT tooth (#495),
+        # not incidentally by stale coverage (review r1-4)
         "method_assumption": "spawn mode keeps the app alive long enough",
         "assumption_validity": "justified-adequate",
         "next_method": "method was adequate",

--- a/tests/test_trajectory_replay.py
+++ b/tests/test_trajectory_replay.py
@@ -101,17 +101,29 @@ def _fag(ws: Path, *extra: str) -> subprocess.CompletedProcess:
 # ===========================================================================
 
 def _trajectory1_ws(root: Path) -> Path:
-    """The v0.1.1 trajectory-1 shape: C-1 attempted twice (spawn-timeout
-    class transient failures), a failure analysis that answers the three
-    questions in prose but records NONE of the #495 artifacts."""
+    """The v0.1.1 trajectory-1 shape: C-1 carries two fail settlements on a
+    target_pq-linked oracle case (spawn-timeout class transient failures),
+    a failure analysis that answers the three questions in prose but
+    records NONE of the #495 artifacts."""
     ws = root / "ws"
     _write(ws / "claim-register.yaml", {"claims": [
         {"id": "C-1", "status": "OPEN",
          "boundary_type": "positive_observation",
          "evidence_tier_attempted": 1, "promotion_attempts": 2,
+         "answers_question": "q1",
          "depends_on": [], "statement":
          "app calls badger.a under real Context (frida spawn path)"}]})
     _write(ws / "task_spec.yaml", {"primary_questions": []})
+    # #146: arm the gate the live way — linked case + red settlements in
+    # the #106 posterior ledger (the dispatch counter no longer arms).
+    import posteriors as po
+    cdir = ws / "oracle" / "cases"
+    cdir.mkdir(parents=True)
+    (cdir / "case-c-1.yaml").write_text(
+        "id: case-c-1\ntarget_pq: q1\n", encoding="utf-8")
+    led = po.PosteriorLedger.load(ws)
+    led.cases["case-c-1"] = po.CasePosterior("case-c-1", alpha=1.0, beta=3.0)
+    led.save(ws)
     _write(ws / "analyses" / "failure-C-1.yaml", {
         "claim": "C-1", "covers_attempt": 2,
         "method_assumption": "spawn mode keeps the app alive long enough",

--- a/tests/test_xml_injection_55.py
+++ b/tests/test_xml_injection_55.py
@@ -225,14 +225,23 @@ def test_dispatch_gate_must_stop_verdict_wrapped(tmp_path, capsys):
 
 
 def _failure_blocked_ws(root: Path) -> Path:
-    """Workspace whose claim C-1 was attempted (promotion_attempts > 0) but
-    has no failure_analysis -> dispatch_gate's #495 corrective injection."""
+    """Workspace whose claim C-1 carries a fail settlement on a
+    target_pq-linked oracle case but no failure_analysis -> dispatch_gate's
+    #495 corrective injection (#146: arming is settlement-derived)."""
     ws = root / "malware-analysis-workspace"
     ws.mkdir(parents=True)
     (ws / "claim-register.yaml").write_text(yaml.safe_dump(
         {"claims": [{"id": "C-1", "status": "OPEN", "statement": "x",
-                     "promotion_attempts": 1}]},
+                     "answers_question": "q1", "promotion_attempts": 1}]},
         allow_unicode=True, sort_keys=False), encoding="utf-8")
+    import posteriors as po
+    cdir = ws / "oracle" / "cases"
+    cdir.mkdir(parents=True)
+    (cdir / "case-c-1.yaml").write_text(
+        "id: case-c-1\ntarget_pq: q1\n", encoding="utf-8")
+    led = po.PosteriorLedger.load(ws)
+    led.cases["case-c-1"] = po.CasePosterior("case-c-1", alpha=1.0, beta=2.0)
+    led.save(ws)
     write_hook_state(ws, active_hooks=["dispatch_gate"])
     return ws
 


### PR DESCRIPTION
Closes #146.

## What lands

**1. Runner forensics — settlements record HOW they were won/lost** (scripts/oracle_runner.py)

Every case row in the report gains an ADDITIVE `forensics` block (all prior report fields keep their shape; the status file stays narrowed to the convergence trio):

- RED: per-field mismatch vector `[{field, expected, actual}]` for every non-matching expected entry — losses become attributable.
- GREEN: derivation provenance `params_used` + the client's optional `meta` return key surfaced verbatim (optional client contract; absent -> `{}`).
- Stage-diff: when the client result carries a `stages` dict, it is diffed against the case's optional `stages:` expected mapping; `divergence_point` = the first stage whose output differs from its expected value, or an expected stage the client never produced.
- CLI `--json` hardened (`default=repr`) so exotic client values can't crash the report face.

**2. Failure-analysis arming fixed** (scripts/failure_analysis_gate.py)

The `promotion_attempts > 0` arming was DEAD in production (audit: only init seeds 0, retract resets 0 — no live writer). Arming is now settlement-driven: >=1 fail settlement on an oracle case linked via the claim's `answers_question` <-> case `target_pq` (the same linkage `priority_ratio._load_oracle_cases` uses), counted from the #106 posterior ledger (`beta - Beta(1,1)` prior = red count). Coverage is settlement-versioned: the analysis records `covers_settlements` (the red total at record time); a NEW red settlement re-arms the gate — each failed attempt needs its own analysis, derived instead of counted. Retired cases arm nothing. The three questions + three artifacts + `next_method_source` provenance contract is untouched; BLOCKED output/events name `red_settlements` instead of the dead counter.

**3. Bank attribution upgrade** (scripts/case_bank.py)

Entry schema gains OPTIONAL structured `how` (the forensics block: `mismatch_class` / `mechanism`) — a mapping when present, `CaseBankError` otherwise (a label is not a lesson); never required, banked rows read back with `how=None`. Retrieval unchanged (failures first, newest first, tag intersection); the CLI hint line surfaces the mechanism. Producer wiring of `how` at settle time rides the #132 cadence hook — outcome_capture.py is untouched by this branch.

**4. Case-abandonment protocol** (scripts/oracle_runner.py, with the case files)

`retire_case` refuses loudly (`OracleCaseError`) without the structured justification `{attribution_class ∈ {implementation-wrong, case-wrong, client-wrong, channel-wrong, capture-obsolete}, disconfirmation, replacement}`; the transition is append-only (the case keeps its expected entries; `status: retired` + `retirement` block are ADDED); re-retirement is refused. Retired cases skip admission lints (a retired case must never refuse the set because its hypothesis went terminal) and leave the run (reported in the report's `retired` list). The armed-count drop emits the registered WARN event `acceptance_coverage_decreased`. CLI: `--retire CASE --attribution-class ... --disconfirmation ... --replacement ...`, exit 2 on refusal. `event_taxonomy.EMIT_ACTIONS` registers the word; `kunglao_log.LEGACY_ACTORS` registers the `oracle_runner` actor.

## TDD

tests/test_outcome_forensics_146.py committed RED first (25 failing pins), then GREEN: mismatch vector, stage diff/divergence point, provenance+meta, report/status schema intact, gate arming/unblocking/re-arming/no-linkage/counter-dead/retired-silent, retirement refusals + append-only + coverage WARN + CLI, bank `how` round-trip/refusal/retrieval.

## Fixture migration + anchor

All suites that armed the gate via the dead counter now arm via linked red settlements (transducer, lessons, decide state machine, decision teeth, event-stream adoption, nursery, trajectory-1 replay, xml-injection guidance, core-loop, scorer authority, recall inject, orchestration taxonomy, golden F-04/F-12). Anchor: the four failure-gate matrix cases were re-pointed in their FIXTURES; all 32 frozen `decide()` outputs re-verified byte-identical — zero drift, no re-pin (header entry appended to the precedent chain).

## Checks

- `env -u KUNGLAO_VALUE_ALGO python3 -m pytest tests/ -q`: green except the 5 pre-existing bare-base reds (verified identical on pristine 8e17741): `test_env_check::test_all_pass_exit_0` + 4x `test_hypothesis_loop_integration_111` (its case fixtures predate the #126 admission lint — separate pre-existing breakage, untouched per report-don't-fix).
- ruff: clean on every touched file; repo-wide baseline of 5 pre-existing findings (hooks/dispatch_gate.py:790, tests/test_claudemd_conditional_919.py:37, tests/test_contracts_drift_102.py:36+40, tests/test_docsync_589_563.py:17) unchanged.
- `deploy_manifest.py --write && --verify`: green (389 entries).

## Deviations / notes

- Issue acceptance "green settlement carries discriminativeness verdict; multi-green flags vacuous": the cross-candidate outcome record does not exist on this base (one client per run; per-candidate outcomes arrive with #132's cadence settlement stream). The forensics block + bank `how` field are the hooks it will read; the multi-green flag itself lands with #132's separation observation.
- The #132 cadence hook (outcome_capture) is NOT touched; the enriched report and the bank `how` field are additive to what it consumes.

## Review

One code-reviewer subagent pass over the full branch diff (r1-146-forensics): FAIL round 1 with 5 findings (1 HIGH: PosteriorSchemaError swallow silently un-arming the gate; 2-3 MEDIUM: params crash-containment regression + params_used aliasing the client-mutable dict; 4 MEDIUM: three fixtures blocking via stale coverage instead of the artifact tooth; 5 LOW: `--retire ""` fall-through). All five fixed in 04bfacf and pinned by four new regression tests (31/31 in the #146 suite); anchor re-verified byte-identical. Reviewer evidence: `.subagent-review/r1-146-forensics.md`, minted via `review_gate.py mint` against the full branch diff (diff_sha256 17ee98ed...).

## Follow-up noted (out of scope here)

`priority_ratio._load_oracle_cases` does not skip retired cases, so a retired case's frozen posterior keeps contributing a Thompson sample to dispatch ranking. #146 scopes retirement to the runner/gate/coverage face; the ranking-side leak deserves its own card.
