### PR TITLE
feat(#157): algorithm event log — rank_feeds / posterior_update / observation through the unified log

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -343,7 +343,7 @@ files:
   - src: scripts/event_taxonomy.py
     dest: .claude/scripts/event_taxonomy.py
     kind: scaffold
-    sha256: fdbb487ed6c40b4743386620d32b76f0a773cd60eb1086b9a3260b061d811f90
+    sha256: 5e462856bb61dc3ba915e921cdff1fa63ed13a48d723ef076c11ad9d33dac237
   - src: scripts/external_kicker.py
     dest: .claude/scripts/external_kicker.py
     kind: scaffold
@@ -591,7 +591,7 @@ files:
   - src: scripts/oracle_runner.py
     dest: .claude/scripts/oracle_runner.py
     kind: scaffold
-    sha256: 4c9bc8a3e7d2b024bcd0bd09991a99b83ceb44b8999587d7cdbfb7379aa9b1bb
+    sha256: 57055afc4ba6b6c535afed6cd560de6a0caa398be3ac8f21c61f255c5ad2455e
   - src: scripts/outcome_capture.py
     dest: .claude/scripts/outcome_capture.py
     kind: scaffold
@@ -627,7 +627,7 @@ files:
   - src: scripts/priority_ratio.py
     dest: .claude/scripts/priority_ratio.py
     kind: scaffold
-    sha256: 547ce5740c537082bd0422b036d554ed13a6f5a247f2fa8461d0488e62f18326
+    sha256: 2f1d1890c9b0f0aac2a878871c7a088e1093bf4233a617d2c1504d6e05b7feca
   - src: scripts/progress_report.py
     dest: .claude/scripts/progress_report.py
     kind: scaffold

--- a/scripts/event_taxonomy.py
+++ b/scripts/event_taxonomy.py
@@ -221,14 +221,17 @@ EMIT_ACTIONS = [
     "mission_stall",      # #634 mission-level stall fingerprint (ΔV_m flat × K)
     "must_ask",
     "must_stop",
+    "observation",        # #157 oracle_runner per-case result row (id/status + #146 forensics summary class) — the reward signal's event face
     "oracle_cadence_warn",  # #132 settlement-cadence loud faces: broken client (all-red) / missing registered client / case-set refusal / runner failure — never a silent skip
     "orchestrator_mcp_reject",  # #601 main-agent direct MCP host-channel REJECT face (orchestrator_tool_guard)
     "orchestrator_tool_violation",  # #608 orchestrator Bash-face analysis-binary WARN (emitted since #608; registered late — its literal hides behind a parenthesized emit arg)
     "plan_drift_crashed",  # #102 dispatch_gate: plan_drift --auto crash face (fail-open, observed)
     "plan_review",        # #822 stage-plan review ritual: maintain/adjust/replan verdict face
     "plan_stall",
+    "posterior_update",  # #157 record_posteriors per-verdict Bernoulli delta (alpha/beta before->after + report-hash trigger) — belief evolution as an event stream
     "priority_deviation",
     "proven_waiver_used",  # #819 justified waiver consumed by the PROVEN evidence gate
+    "rank_feeds",        # #157 priority_ratio per-RUN Thompson feeds + input fingerprint (claims/evidence hashes + rng base draw) — replayable ranking
     "recall_injected",    # #814 recall hook injected knowledge files
     "recall_skip",        # #814 recall hook pass-through with attribution
     "redo_leak_warn",     # #772 dispatch_gate redo-prompt value-overlap WARN face

--- a/scripts/oracle_runner.py
+++ b/scripts/oracle_runner.py
@@ -740,6 +740,11 @@ def run(cases_dir, client_path, *, mutation: bool = False) -> dict:
     for row in rows.values():
         counts[{"fail": "red", "pass": "green",
                 "pending": "pending"}[row["status"]]] += 1
+    # #157: one observation event per case result row (post-verdict, silent
+    # fail-open) — <ws> is the load_cases root (<ws>/oracle/cases).
+    ws = cases_dir.parent.parent
+    for cid, row in rows.items():
+        _emit_observation(ws, cid, row)
     return {
         "schema": SCHEMA_ID,
         "cases_dir": str(cases_dir),
@@ -774,11 +779,81 @@ def write_status(ws, report: dict) -> Path:
     return path
 
 
+# -------------------------- #157 algorithm event log -----------------------
+
+def _report_fingerprint(report: dict) -> str:
+    """#157 posterior_update trigger fingerprint: the hash of the report
+    that produced the observation — WHICH run moved the belief.
+
+    Client ``meta``/``stages`` ride the report verbatim (review r1-157
+    HIGH), so sort_keys can hit mixed-type mapping keys — degrade to
+    insertion-order serialization (still deterministic for a given report
+    object) instead of raising into the caller."""
+    try:
+        payload = json.dumps(report, sort_keys=True, ensure_ascii=False,
+                             default=repr)
+    except (TypeError, ValueError):
+        payload = json.dumps(report, ensure_ascii=False, default=repr)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _emit_posterior_update(ws, case_id: str, before: tuple,
+                           after: tuple, report: dict) -> None:
+    """#157: one ``posterior_update`` event per REAL verdict — alpha/beta
+    BEFORE -> AFTER plus the trigger fingerprint (the report hash), so
+    belief evolution is replayable from the event tail. SILENT FAIL-OPEN:
+    the fingerprint build AND the emit both live inside the try — a crash
+    here never touches the state write (record_posteriors's contract is
+    unchanged — the emit is additive)."""
+    try:
+        from kunglao_log import emit
+        trigger = _report_fingerprint(report)
+        emit(ws, actor="oracle_runner", action="posterior_update",
+             detail=json.dumps(
+                 {"case_id": case_id,
+                  "alpha_before": before[0], "beta_before": before[1],
+                  "alpha_after": after[0], "beta_after": after[1],
+                  "trigger_fingerprint": trigger},
+                 sort_keys=True, ensure_ascii=False))
+    except Exception:  # noqa: BLE001 — observability never disturbs reward
+        pass
+
+
+def _emit_observation(ws, case_id: str, row: dict) -> None:
+    """#157: one ``observation`` event per case result row — case_id/status
+    + the #146 forensics summary class (mismatch field names for fail,
+    derivation presence for pass). The reward signal's event face: whether
+    the observation layer fired AT ALL is auditable. SILENT FAIL-OPEN."""
+    try:
+        from kunglao_log import emit
+        fore = row.get("forensics") or {}
+        mismatches = fore.get("mismatches") or []
+        payload = {
+            "case_id": case_id,
+            "status": row.get("status"),
+            "forensics": {
+                "mismatch_fields": [m.get("field") for m in mismatches
+                                    if isinstance(m, dict)],
+                "has_derivation": bool(fore.get("stages")),
+                "divergence_point": fore.get("divergence_point"),
+            },
+        }
+        emit(ws, actor="oracle_runner", action="observation",
+             detail=json.dumps(payload, sort_keys=True, ensure_ascii=False,
+                               default=repr))
+    except Exception:  # noqa: BLE001 — observability never disturbs the run
+        pass
+
+
 def record_posteriors(ws, report: dict) -> Path | None:
     """#106 reuse: a REAL verdict (pass/fail) is one Bernoulli observation on
     the case's CasePosterior (green -> alpha+1 / red -> beta+1). Pending is
     not an observation — no update, no ledger touch. Missing/unreadable
-    ledger degrades per posteriors.py's fail-open load contract."""
+    ledger degrades per posteriors.py's fail-open load contract.
+
+    #157: each update additionally emits one ``posterior_update`` event
+    (alpha/beta before -> after + the trigger fingerprint). ADDITIVE ONLY —
+    the ledger delta and the return value are exactly the pre-#157 ones."""
     import posteriors as po
     updates = {cid: row["status"] == "pass"
                for cid, row in report["cases"].items()
@@ -788,8 +863,10 @@ def record_posteriors(ws, report: dict) -> Path | None:
     led = po.PosteriorLedger.load(ws)
     for cid, passed in updates.items():
         cp = led.cases.get(cid) or po.CasePosterior(cid)
+        before = (cp.alpha, cp.beta)
         cp.update(passed)
         led.cases[cid] = cp
+        _emit_posterior_update(ws, cid, before, (cp.alpha, cp.beta), report)
     return led.save(ws)
 
 

--- a/scripts/priority_ratio.py
+++ b/scripts/priority_ratio.py
@@ -561,6 +561,57 @@ def posterior_rng(ws) -> random.Random:
     return random.Random(case_face_seed(ledger))
 
 
+# ---------- #157 algorithm event log: rank_feeds (one emit per RUN) --------
+
+def _evidence_digest(evidence: EvidenceView) -> str:
+    """Canonical digest of the ranking-relevant evidence view (#157 input
+    fingerprint component): the terminal-fact set (candidate filter), the
+    verified count, and the #759 worth weights — only what the rank actually
+    consumed, not the whole index."""
+    doc = {
+        "terminal_fact_claims": sorted(evidence.terminal_fact_claims),
+        "verified_fact_count": evidence.verified_fact_count,
+        "value_class_weights": dict(sorted(
+            evidence.value_class_weights.items())),
+        "value_claim_overrides": dict(sorted(
+            evidence.value_claim_overrides.items())),
+    }
+    payload = json.dumps(doc, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _emit_rank_feeds(ws, claims: list[dict], evidence: EvidenceView,
+                     rng_base: int, actions: list[Action]) -> None:
+    """#157: ONE ``rank_feeds`` event per priority_ratio() run — the
+    per-claim Thompson feeds + the input fingerprint (claims hash,
+    evidence-view digest, rng base draw). Given the seed, the ranking is
+    exactly replayable from the event tail. SILENT FAIL-OPEN (the
+    decide_fail_open contract, #569): a crash in payload build or emit
+    never reaches the ranking result."""
+    try:
+        claims_hash = hashlib.sha256(json.dumps(
+            claims, sort_keys=True, ensure_ascii=False, default=repr)
+            .encode("utf-8")).hexdigest()
+        evidence_hash = _evidence_digest(evidence)
+        fp_doc = {"claims_hash": claims_hash,
+                  "evidence_hash": evidence_hash,
+                  "rng_base": rng_base}
+        fingerprint = hashlib.sha256(json.dumps(
+            fp_doc, sort_keys=True, ensure_ascii=False)
+            .encode("utf-8")).hexdigest()
+        payload = {
+            "feeds": {a.claim_id: dict(a.feeds) for a in actions},
+            "scores": {a.claim_id: a.score for a in actions},
+            "ranked_order": [a.claim_id for a in actions],
+            "input_fingerprint": dict(fp_doc, fingerprint=fingerprint),
+        }
+        kunglao_log.emit(ws, actor="priority_ratio", action="rank_feeds",
+                         detail=json.dumps(payload, sort_keys=True,
+                                           ensure_ascii=False))
+    except Exception:  # noqa: BLE001 — observability never disturbs the rank
+        pass
+
+
 def priority_ratio(claims: list[dict], deps: dict, evidence: EvidenceView,
                    rng: random.Random | None = None) -> list[Action]:
     """#107 Thompson ranking (purely mechanical, zero LLM).
@@ -672,6 +723,13 @@ def priority_ratio(claims: list[dict], deps: dict, evidence: EvidenceView,
         ))
     # #107 spec sort: Thompson sample descending, stable tie-break claim_id.
     actions.sort(key=lambda a: (-a.score, a.claim_id))
+    # #157: one rank_feeds event per RUN (post-decision, silent fail-open).
+    # The emit consumes the ALREADY-BUILT actions — a crash inside it can
+    # never change the ranking result (pinned by
+    # tests/test_algorithm_event_log_157.py). No ws -> pure in-memory
+    # surface, nothing to log to (bare-EvidenceView calls stay pure).
+    if evidence.ws is not None:
+        _emit_rank_feeds(evidence.ws, claims, evidence, base, actions)
     return actions
 
 

--- a/tests/test_algorithm_event_log_157.py
+++ b/tests/test_algorithm_event_log_157.py
@@ -1,0 +1,361 @@
+# -*- coding: utf-8 -*-
+"""tests/test_algorithm_event_log_157.py — algorithm event log (#157).
+
+The value loop's three algorithm faces become event streams through the
+unified kunglao_log (#157 contract: "every agent-consumed algorithm state
+must be event-logged" — the dual of the display principle):
+
+  1. rank_feeds       priority_ratio(), ONE emit per RUN (not per claim):
+                      per-claim Thompson feeds + input fingerprint
+                      (claims hash, evidence-view hash, rng base draw) —
+                      every ranking decision exactly replayable.
+  2. posterior_update record_posteriors(), per case observation:
+                      alpha/beta BEFORE -> AFTER + trigger fingerprint
+                      (the report hash) — belief evolution replayable.
+  3. observation      oracle_runner.run(), per case result row:
+                      case_id/status + the #146 forensics summary class
+                      (mismatch field names for fail, derivation presence
+                      for pass) — the reward signal's event face.
+
+All three: silent fail-open (an emit crash never blocks the algorithm —
+same contract as decide_fail_open, #569), structured JSON payloads riding
+detail, words registered in event_taxonomy.EMIT_ACTIONS (#459 controlled
+vocabulary).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import event_taxonomy as et  # noqa: E402
+import kunglao_log  # noqa: E402
+import oracle_runner as orun  # noqa: E402
+import posteriors as po  # noqa: E402
+import priority_ratio as pr  # noqa: E402
+
+# oracle-runner fixture builders reuse the #108 suite's shaped constants
+# (same test dir is on sys.path under pytest's rootdir collection; the
+# cross-test import convention of test_event_stream_adoption.py).
+from test_oracle_runner_108 import (  # noqa: E402
+    BAD_CLIENT,
+    CASE_GOOD,
+    GOOD_CLIENT,
+    _mk_ws,
+    _write_client,
+)
+
+
+# ---------- shared seam: capture kunglao_log.emit in-process ----------
+
+@pytest.fixture
+def events(monkeypatch):
+    """Capture every kunglao_log.emit call made in-process after this point
+    (module-attribute patch — both producers resolve emit at call time)."""
+    calls: list[dict] = []
+
+    def _fake(ws, actor, action, **kw):
+        calls.append({"ws": ws, "actor": actor, "action": action, **kw})
+
+    monkeypatch.setattr(kunglao_log, "emit", _fake)
+    return calls
+
+
+def _rows(calls: list[dict], word: str) -> list[dict]:
+    out = []
+    for c in calls:
+        if c["action"] != word:
+            continue
+        row = dict(c)
+        row["payload"] = json.loads(c["detail"])
+        out.append(row)
+    return out
+
+
+# ---------- rank fixtures (test_priority_ratio conventions) ----------
+
+def _claim(cid, status="OPEN", answers_question=None, eta=0, attempts=0):
+    c = {"id": cid, "status": status, "evidence_tier_attempted": eta,
+         "promotion_attempts": attempts, "statement": cid}
+    if answers_question is not None:
+        c["answers_question"] = answers_question
+    return c
+
+
+def _deps():
+    return {"depends_on": {}, "competitor_groups": {}}
+
+
+def _rank_ws(base, cases=(), pqs=None):
+    """Workspace with runs/posteriors.yaml + oracle/cases/*.yaml (the
+    lenient ranker-side case face: id + target_pq)."""
+    ws = base / "ws"
+    (ws / "runs").mkdir(parents=True)
+    (ws / "oracle" / "cases").mkdir(parents=True)
+    led = {"schema": "posteriors-schema/1", "cases": {}, "pqs": pqs or {}}
+    for case_id, target_pq, a, b in cases:
+        led["cases"][case_id] = {"alpha": a, "beta": b, "pending_entries": 0}
+        (ws / "oracle" / "cases" / f"{case_id}.yaml").write_text(
+            yaml.safe_dump({"id": case_id, "target_pq": target_pq}),
+            encoding="utf-8")
+    (ws / "runs" / "posteriors.yaml").write_text(
+        yaml.safe_dump(led, allow_unicode=True), encoding="utf-8")
+    return ws
+
+
+def _evidence(ws):
+    return pr.EvidenceView(
+        terminal_fact_claims=frozenset({"C-1"}), verified_fact_count=1,
+        ws=Path(ws))
+
+
+def _rank_inputs(ws):
+    claims = [_claim("C-1", answers_question="pq-a"), _claim("C-2")]
+    return claims, _deps(), _evidence(ws)
+
+
+# ---------- ① rank_feeds: one emit per run, feeds + fingerprint ----------
+
+def test_rank_feeds_registered_word():
+    assert "rank_feeds" in et.EMIT_ACTIONS
+    assert "posterior_update" in et.EMIT_ACTIONS
+    assert "observation" in et.EMIT_ACTIONS
+
+
+def test_rank_feeds_one_emit_per_run_with_feeds_and_fingerprint(
+        tmp_path, events):
+    ws = _rank_ws(tmp_path, cases=[("CASE-A", "pq-a", 3.0, 1.0)],
+                  pqs={"pq-a": {"candidates": {"x": 1.0, "y": 1.0}}})
+    claims, deps, ev = _rank_inputs(ws)
+    actions = pr.priority_ratio(claims, deps, ev)
+
+    rows = _rows(events, "rank_feeds")
+    assert len(rows) == 1, "ONE rank_feeds per RUN, not per claim"
+    row = rows[0]
+    assert row["actor"] == "priority_ratio"
+    payload = row["payload"]
+
+    # per-claim feeds ride the payload, byte-equal to the Action.feeds
+    by_id = {a.claim_id: a for a in actions}
+    assert set(payload["feeds"]) == set(by_id)
+    for cid, action in by_id.items():
+        assert payload["feeds"][cid] == dict(action.feeds)
+    assert payload["ranked_order"] == [a.claim_id for a in actions]
+
+    # input fingerprint: claims hash + evidence-view hash + rng base draw,
+    # replayable from the payload components alone
+    fp = payload["input_fingerprint"]
+    assert {"claims_hash", "evidence_hash", "rng_base",
+            "fingerprint"} <= set(fp)
+    canon = json.dumps({"claims_hash": fp["claims_hash"],
+                        "evidence_hash": fp["evidence_hash"],
+                        "rng_base": fp["rng_base"]},
+                       sort_keys=True, ensure_ascii=False)
+    assert fp["fingerprint"] == hashlib.sha256(
+        canon.encode("utf-8")).hexdigest()
+    assert fp["claims_hash"] == hashlib.sha256(json.dumps(
+        claims, sort_keys=True, ensure_ascii=False, default=repr)
+        .encode("utf-8")).hexdigest()
+
+
+def test_rank_feeds_replay_same_seed_same_payload(tmp_path, events):
+    """The replay proof: same rng seed + same inputs -> identical feeds
+    payload (thompson draws, fingerprint), i.e. every rank decidable from
+    the event tail alone."""
+    ws = _rank_ws(tmp_path, cases=[("CASE-A", "pq-a", 3.0, 1.0)])
+    claims, deps, ev = _rank_inputs(ws)
+    pr.priority_ratio(claims, deps, ev, rng=random.Random(20260907))
+    pr.priority_ratio(claims, deps, ev, rng=random.Random(20260907))
+    rows = _rows(events, "rank_feeds")
+    assert len(rows) == 2
+    assert rows[0]["payload"] == rows[1]["payload"]
+
+
+def test_rank_feeds_fingerprint_moves_with_seed_and_inputs(tmp_path, events):
+    ws_a = _rank_ws(tmp_path / "a", cases=[("CASE-A", "pq-a", 3.0, 1.0)])
+    ws_b = _rank_ws(tmp_path / "b", cases=[("CASE-A", "pq-a", 5.0, 1.0)])
+    claims, deps, ev_a = _rank_inputs(ws_a)
+    pr.priority_ratio(claims, deps, ev_a, rng=random.Random(1))
+    _, _, ev_b = _rank_inputs(ws_b)
+    pr.priority_ratio(claims, deps, ev_b, rng=random.Random(2))
+    rows = _rows(events, "rank_feeds")
+    assert len(rows) == 2
+    fp_a, fp_b = (r["payload"]["input_fingerprint"] for r in rows)
+    # posterior state enters through the seed derivation: different seed ->
+    # different base draw -> different fingerprint
+    assert fp_a["fingerprint"] != fp_b["fingerprint"]
+    assert fp_a["rng_base"] != fp_b["rng_base"]
+    # a different evidence VIEW (worth weights) moves the evidence component
+    pr.priority_ratio(
+        claims, deps,
+        pr.EvidenceView(terminal_fact_claims=frozenset({"C-1"}),
+                        verified_fact_count=1, ws=Path(ws_a),
+                        value_class_weights={"rce": 2.0}),
+        rng=random.Random(1))
+    fp_c = _rows(events, "rank_feeds")[2]["payload"]["input_fingerprint"]
+    assert fp_c["evidence_hash"] != fp_a["evidence_hash"]
+    assert fp_c["fingerprint"] != fp_a["fingerprint"]
+
+
+def test_rank_feeds_silent_when_no_ws(events):
+    """Bare EvidenceView (no ws) = pure in-memory call surface — nothing to
+    log to, nothing emitted (the older suites' construction stays pure)."""
+    claims = [_claim("C-1")]
+    ev = pr.EvidenceView()
+    pr.priority_ratio(claims, _deps(), ev)
+    assert _rows(events, "rank_feeds") == []
+
+
+# ---------- ② posterior_update: before/after + trigger fingerprint ----------
+
+def _oracle_report(ws, client_src):
+    _write_client(ws, client_src, name="client")
+    return orun.run(ws / "oracle" / "cases", ws / "oracle" / "client.py")
+
+
+def test_posterior_update_before_after_matches_ledger_delta(tmp_path, events):
+    ws = _mk_ws(tmp_path, [CASE_GOOD], None)
+    report = _oracle_report(ws, GOOD_CLIENT)
+    before = {cid: (cp.alpha, cp.beta)
+              for cid, cp in po.PosteriorLedger.load(ws).cases.items()} \
+        or {}
+    orun.record_posteriors(ws, report)
+
+    rows = _rows(events, "posterior_update")
+    assert len(rows) == 1, "one event per REAL verdict (pass/fail), not pending"
+    row = rows[0]
+    assert row["actor"] == "oracle_runner"
+    payload = row["payload"]
+    assert payload["case_id"] == "auth-fields"
+    prior = before.get("auth-fields", (1.0, 1.0))
+    assert (payload["alpha_before"], payload["beta_before"]) == prior
+    # the delta matches the posteriors.yaml state the write produced
+    cp = po.PosteriorLedger.load(ws).cases["auth-fields"]
+    assert (payload["alpha_after"], payload["beta_after"]) == (cp.alpha,
+                                                               cp.beta)
+    assert cp.alpha == pytest.approx(prior[0] + 1.0)  # green -> alpha+1
+    # trigger fingerprint = the report hash; recomputable, report-sensitive
+    canon = json.dumps(report, sort_keys=True, ensure_ascii=False,
+                       default=repr)
+    assert payload["trigger_fingerprint"] == hashlib.sha256(
+        canon.encode("utf-8")).hexdigest()
+
+
+# ---------- ③ observation: per case result row ----------
+
+def test_observation_rows_per_case_with_forensics_summary(tmp_path, events):
+    # fail face: mismatch field names ride the summary
+    ws_bad = _mk_ws(tmp_path / "bad", [CASE_GOOD], None)
+    report = _oracle_report(ws_bad, BAD_CLIENT)
+    assert report["counts"]["red"] == 1
+    rows = _rows(events, "observation")
+    assert len(rows) == 1
+    assert rows[0]["actor"] == "oracle_runner"
+    payload = rows[0]["payload"]
+    assert payload["case_id"] == "auth-fields"
+    assert payload["status"] == "fail"
+    assert "auth_algo" in payload["forensics"]["mismatch_fields"]
+
+    # pass face: derivation presence rides the summary
+    events.clear()
+    ws_good = _mk_ws(tmp_path / "good", [CASE_GOOD], None)
+    report = _oracle_report(ws_good, GOOD_CLIENT)
+    assert report["counts"]["green"] == 1
+    payload = _rows(events, "observation")[0]["payload"]
+    assert payload["status"] == "pass"
+    assert payload["forensics"]["mismatch_fields"] == []
+    assert payload["forensics"]["has_derivation"] is False  # no stages pinned
+
+    # pending face (no client): rows still emitted — the honest unknown is
+    # an observation ABOUT the channel, never silence
+    events.clear()
+    ws_none = _mk_ws(tmp_path / "none", [CASE_GOOD], None)
+    report = orun.run(ws_none / "oracle" / "cases", None)
+    assert report["counts"]["pending"] == 1
+    payload = _rows(events, "observation")[0]["payload"]
+    assert payload["status"] == "pending"
+
+
+# ---------- silent fail-open pins (the #569 contract, three faces) ------
+
+def _boom(*args, **kwargs):
+    raise RuntimeError("emit exploded")
+
+
+def test_rank_feeds_emit_crash_fail_open(tmp_path, monkeypatch):
+    ws = _rank_ws(tmp_path, cases=[("CASE-A", "pq-a", 3.0, 1.0)])
+    claims, deps, ev = _rank_inputs(ws)
+    baseline = pr.priority_ratio(claims, deps, ev, rng=random.Random(0))
+    monkeypatch.setattr(kunglao_log, "emit", _boom)
+    result = pr.priority_ratio(claims, deps, ev, rng=random.Random(0))
+    assert [(a.claim_id, a.score, dict(a.feeds)) for a in result] == \
+        [(a.claim_id, a.score, dict(a.feeds)) for a in baseline]
+
+
+def test_posterior_update_emit_crash_fail_open(tmp_path, monkeypatch):
+    ws = _mk_ws(tmp_path, [CASE_GOOD], None)
+    report = _oracle_report(ws, GOOD_CLIENT)
+    monkeypatch.setattr(kunglao_log, "emit", _boom)
+    path = orun.record_posteriors(ws, report)
+    assert path is not None and Path(path).exists()
+    cp = po.PosteriorLedger.load(ws).cases["auth-fields"]
+    assert cp.alpha == pytest.approx(2.0)  # the state write survived
+
+
+MIXED_KEY_CLIENT = '''def compute(params):
+    # review r1-157 HIGH repro: a client meta dict with mixed-type keys
+    # rides the report verbatim — no fail-open face may choke on it
+    return {"auth_algo": "hmac-sha256",
+            "nonce_len": len(str(params["nonce"])),
+            "meta": {1: "x", "name": "y"}}
+'''
+
+
+def test_posterior_update_survives_unsortable_report_keys(tmp_path, events):
+    """review r1-157 HIGH: the trigger fingerprint (json.dumps sort_keys)
+    must never escape record_posteriors — a mixed-key client meta used to
+    raise TypeError BEFORE the ledger save, losing the posterior delta."""
+    ws = _mk_ws(tmp_path, [CASE_GOOD], None)
+    report = _oracle_report(ws, MIXED_KEY_CLIENT)
+    assert report["counts"]["green"] == 1
+    path = orun.record_posteriors(ws, report)  # must not raise
+    assert path is not None and Path(path).exists()
+    cp = po.PosteriorLedger.load(ws).cases["auth-fields"]
+    assert cp.alpha == pytest.approx(2.0)
+    # the event still carries a trigger fingerprint — the insertion-order
+    # fallback serialization (deterministic per report object)
+    payload = _rows(events, "posterior_update")[0]["payload"]
+    canon = json.dumps(report, ensure_ascii=False, default=repr)
+    assert payload["trigger_fingerprint"] == hashlib.sha256(
+        canon.encode("utf-8")).hexdigest()
+
+
+def test_posterior_update_emit_crash_fail_open_and_unsortable(tmp_path,
+                                                               monkeypatch):
+    """The belt holds even when BOTH the fingerprint fallback and the emit
+    would blow up: the state write is untouchable."""
+    ws = _mk_ws(tmp_path, [CASE_GOOD], None)
+    report = _oracle_report(ws, MIXED_KEY_CLIENT)
+    monkeypatch.setattr(kunglao_log, "emit", _boom)
+    path = orun.record_posteriors(ws, report)
+    assert path is not None and Path(path).exists()
+
+
+def test_run_emit_crash_fail_open(tmp_path, monkeypatch):
+    ws = _mk_ws(tmp_path, [CASE_GOOD], None)
+    _write_client(ws, GOOD_CLIENT, name="client")
+    baseline = orun.run(ws / "oracle" / "cases", ws / "oracle" / "client.py")
+    monkeypatch.setattr(kunglao_log, "emit", _boom)
+    report = orun.run(ws / "oracle" / "cases", ws / "oracle" / "client.py")
+    assert json.dumps(report, sort_keys=True, default=repr) == \
+        json.dumps(baseline, sort_keys=True, default=repr)


### PR DESCRIPTION
Closes #157.

## What

The value loop's three algorithm faces become event streams through the existing `kunglao_log` unified log — decisions, beliefs, and rewards are now auditable event tails, not just state writes ("every agent-consumed algorithm state must be event-logged" — the dual of the display principle):

1. **`rank_feeds`** — `scripts/priority_ratio.py`, ONE emit per `priority_ratio()` run (not per claim), emitted after the sort from the already-built actions: per-claim Thompson feeds + scores + `ranked_order` + `input_fingerprint` {claims_hash, evidence_hash, rng_base, fingerprint}. Same seed + same inputs → byte-identical payload (replay test pinned): every ranking decision is exactly replayable from the event tail.
2. **`posterior_update`** — `scripts/oracle_runner.record_posteriors`, one event per REAL verdict: alpha/beta BEFORE -> AFTER + `trigger_fingerprint` (the report hash). ADDITIVE only — the ledger delta and return path are byte-identical to pre-change (#146 untouched).
3. **`observation`** — `scripts/oracle_runner.run`, one event per case result row: case_id/status + the #146 forensics summary class (mismatch field names for fail, derivation presence for pass, honest-pending rows included).

All three: **silent fail-open** (payload build + emit fully contained — an emit crash can never reach the ranking result, the ledger write, or the run report; same contract as `decide_fail_open`, #569) and structured JSON payloads riding `detail` (the `result_digest` precedent).

Words registered in `scripts/event_taxonomy.py` `EMIT_ACTIONS` (#459 controlled vocabulary): `observation`, `posterior_update`, `rank_feeds`. Actors use the adopted legacy forms `priority_ratio` / `oracle_runner` (the issue text's hyphenated variants would fail the #879 `scan_actor_literals` anchor — both underscore forms are the modules' existing emitters).

## Notes

- Round-1 review found one HIGH: the trigger fingerprint sat outside the fail-open wrap — a client `meta`/`stages` dict with mixed-type keys made `json.dumps(sort_keys=True)` raise `TypeError` before the ledger save. Fixed: fingerprint serialization degrades to insertion-order on `TypeError`/`ValueError`, and the call moved inside the emit's try — `record_posteriors` again has zero new fallible top-level calls. Pinned by a RED-first repro test (MIXED_KEY_CLIENT).
- Consumers: #156 curves / #135 calibration / #129 windows / retro replay can build series purely from `observation` / `posterior_update` / `rank_feeds` rows.

## Test plan

- [x] `tests/test_algorithm_event_log_157.py` — 12 tests: one emit per run (not per claim) with per-claim feeds + recomputable input fingerprint; replay determinism (same seed -> identical payload); fingerprint moves with seed and evidence view; bare-EvidenceView purity (no ws -> no emit); posterior_update before/after matches the posteriors.yaml delta + report-hash trigger; observation rows for fail/pass/pending incl. forensics summary classes; words registered; emit-crash fail-open pinned on all three faces; unsortable-report-keys repro.
- [x] RED confirmed before implementation (6 failed -> GREEN), and the review-fix repro was RED before its fix (2 failed -> GREEN).
- [x] Full suite: `env -u KUNGLAO_VALUE_ALGO uv run --project . python -m pytest tests/ -q` -> **6100 passed, 10 skipped, 0 failed** (the 4 pre-existing bare-python3 environmental reds — jinja2 / machine toolchain — pass under the uv env).
- [x] ruff clean on all touched files; `deploy_manifest.py --write` + `--verify` OK (396 entries).
- [x] Decide regression anchor: zero drift (emits are post-decision), pinned suites green (priority_ratio / oracle_runner 108+132+146 / event_stream_adoption / decide anchor).
