### PR TITLE
docs: ida lane surface — py_eval session semantics + queue-serial contract (#179)

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -879,7 +879,7 @@ files:
   - src: references/_INDEX.yaml
     dest: .claude/references/_INDEX.yaml
     kind: asset
-    sha256: 02948e8c11c458f042cc93934b8e58ec2e68ff0b92eadabafee0eefc71abf663
+    sha256: 614ce6d4eba73834d56238533be4ae6cc34ea4c4fbbc05c609c043cb620dc08b
   - src: references/_index-anti-analysis.md
     dest: .claude/references/_index-anti-analysis.md
     kind: asset
@@ -1063,7 +1063,7 @@ files:
   - src: references/re-library/ida-scripting-overlays.md
     dest: .claude/references/re-library/ida-scripting-overlays.md
     kind: asset
-    sha256: 884a61d3950cf15e7fc6df99fe283c5ecfc9760404c85b5a3bb00f16aa8b0b59
+    sha256: d3164eead81acef178e715504f7b2241a6c05570916bee4abcb30e2e4b788d93
   - src: references/re-library/jsvmp-triage.md
     dest: .claude/references/re-library/jsvmp-triage.md
     kind: asset
@@ -1383,7 +1383,7 @@ files:
   - src: tools/_index-static.md
     dest: .claude/tools/_index-static.md
     kind: asset
-    sha256: 5ce840235a1de71e328dd06ddacca607276c951fbb27e56d740e609901b325ef
+    sha256: 52e5458182ac82dc747990a0b4296defc24f53d956ffc464ac0722f0122e88f6
   - src: tools/_index-web.md
     dest: .claude/tools/_index-web.md
     kind: asset

--- a/references/_INDEX.yaml
+++ b/references/_INDEX.yaml
@@ -47,7 +47,7 @@ files:
   references/re-library/dynamic-observation-ladders.md: 42b5d229ef4fdef82c3f0b49213b2250b7ca1f7823284e58f69210e1882a6532
   references/re-library/falsifier-library.md: 6a7ceb5a83418c1c78fb075cf796b2bcf23466baa07036e252ae9cfed44a2c81
   references/re-library/field-notes.md: 8afaff77a88e61173f7981aa421e775c7ca6447825fcdb41bebb722ef2a18436
-  references/re-library/ida-scripting-overlays.md: 884a61d3950cf15e7fc6df99fe283c5ecfc9760404c85b5a3bb00f16aa8b0b59
+  references/re-library/ida-scripting-overlays.md: d3164eead81acef178e715504f7b2241a6c05570916bee4abcb30e2e4b788d93
   references/re-library/jsvmp-triage.md: f0fe8eb740b1f4a742bac6b913c22e0d6a30058a814dd925a1ccd052bcf35a8d
   references/re-library/kunglao-toolshelf.md: 6ffccd0d3008c086e9109779a09337914e36ea48a4199b9bb9fb87cfeae7bb41
   references/re-library/languages-compiled.md: 2b995c280ea34211a326545828b4bda2639a2a39e53539667ed395ea0ee55780

--- a/references/re-library/ida-scripting-overlays.md
+++ b/references/re-library/ida-scripting-overlays.md
@@ -6,14 +6,16 @@ description: Correction overlays for driving IDA programmatically — the headle
 # IDA Scripting Correction Overlays (headless analysis-wait discipline + Hex-Rays failure channels)
 
 Consumer: the agent driving the IDA lane (`tools/_index-static.md`, the
-ida-decompile row) — today through the lane's bridge-discovery and decompile
-calls, and through any scripting-grade execution surface (arbitrary Python
-evaluated inside the IDA process) when the environment exposes one. The
-behavior change this card causes: the agent waits for autoanalysis before
-trusting any query result, and guards both Hex-Rays failure channels instead
-of one — so an empty list reads as a diagnosis (analysis not drained) rather
-than as absence of data, and a decompile failure names its code before the
-next move is chosen.
+ida-decompile row) — through the lane's bridge-discovery and decompile
+calls, and through the lane's scripting-grade execution surface (arbitrary
+Python evaluated inside the IDA process). That surface is live now: the
+environment exposes one, so the earlier conditional ("when the environment
+exposes one") is resolved and the eval face is a first-class consumer of
+this card. The behavior change this card causes: the agent waits for
+autoanalysis before trusting any query result, and guards both Hex-Rays
+failure channels instead of one — so an empty list reads as a diagnosis
+(analysis not drained) rather than as absence of data, and a decompile
+failure names its code before the next move is chosen.
 
 These are CORRECTION overlays, not a tutorial. Core iteration/xref/byte/decompile
 patterns are training-rich and are not repeated here — a generic prior is
@@ -111,6 +113,18 @@ for fva in idautils.Functions():
     print(hex(fva), idc.get_func_name(fva), args)
 idc.qexit(0)                              # overlay 1: batch scripts must exit
 ```
+
+## Session-persistence note: the eval face is a stateful REPL
+
+Prior-sparse face: a model does not know that an MCP Python-eval call is a
+stateful REPL — the generic prior treats every programmatic call as
+stateless (fresh interpreter, fresh globals). Wrong on this lane: state
+carries across the lane's Python-eval calls. Locals persist from call to
+call (Jupyter-style), so a name bound in an earlier call is still live
+later; only an explicit fresh-locals reset wipes them, and the pre-imported
+globals are rebuilt fresh per call. Plan sessions accordingly: build state
+once and reuse it, do not re-derive it per call; after a reset, re-bind
+before relying on any name.
 
 ## Closure summary
 

--- a/tests/decide_anchor_cabc7d9.json
+++ b/tests/decide_anchor_cabc7d9.json
@@ -7,13 +7,13 @@
       {
         "claim_id": "C-001",
         "fact_id": "F001",
-        "score": 0.9151923616961527,
+        "score": 0.9146375594738315,
         "top_dimension": "lexical"
       },
       {
         "claim_id": "C-002",
         "fact_id": "F002",
-        "score": 0.9070134793597304,
+        "score": 0.9064861460957179,
         "top_dimension": "lexical"
       }
     ],
@@ -430,13 +430,13 @@
       {
         "claim_id": "C-001",
         "fact_id": "F001",
-        "score": 0.9151923616961527,
+        "score": 0.9146375594738315,
         "top_dimension": "lexical"
       },
       {
         "claim_id": "C-002",
         "fact_id": "F002",
-        "score": 0.9070134793597304,
+        "score": 0.9064861460957179,
         "top_dimension": "lexical"
       }
     ],

--- a/tests/test_decide_regression_anchor.py
+++ b/tests/test_decide_regression_anchor.py
@@ -89,6 +89,7 @@ ANCHOR_FILE = Path(__file__).parent / "decide_anchor_cabc7d9.json"
 # re-pin entry below). The oracle-blocking semantics themselves are
 # unanchored by construction (the matrix has no oracle-bearing DRAIN case);
 # covered by the #108 block in tests/test_decide_state_machine.py.
+# 2026-09-08 corpus re-pin (#179): the ida-scripting-overlays card body edit shifts lexical rarity in the anomaly baseline (4 anomaly score floats across the 2 contradiction cases, all else byte-equal; score-only verified, re-captured via capture_current()).
 # 2026-09-08 corpus re-pin (#165 course distillation — DATA drift, not
 # semantics): two re-library cards joined the references corpus
 # (unidbg-env-filling, signature-check-bypass), shifting lexical rarity in

--- a/tools/_index-static.md
+++ b/tools/_index-static.md
@@ -21,7 +21,7 @@
 | `call-site-args` | Call-site argument extraction from disassembly text (x64/x86) | Read when extracting call-site arguments from disassembly text; for precise dataflow use ghidra-recon/emulated execution |
 | `c-normalize` | Decompiled-C normalization (modulo idioms/dead stores) | Read to normalize before a worker reads Ghidra decompiled C; for semantic deobfuscation use opaque-pred |
 | `opaque-pred` | Opaque predicate/MBA equivalence decision (z3) | Read when statically resolving opaque predicates/proving MBA equivalences; not when z3 is absent or the task is not expression-level |
-| `ida-decompile` | Native IDA decompilation over the ida-pro-vm MCP bridge (`ida:decompile` sole) | Read when a function-level decompile must come from IDA's analyzer and ghidra is unavailable/insufficient; not for bulk whole-binary disassembly (ghidra-decompile-functions) |
+| `ida-decompile` | IDA lane tool family over the ida-pro-vm MCP bridge (`ida:decompile` sole + `ida-py-eval` scripting face; typed surfaces: analyze_funcs/xrefs_to/find_bytes class; queue-serial, stateful REPL) | Read when a function-level decompile must come from IDA's analyzer (ghidra unavailable/insufficient) or scripting-grade in-process IDA execution is needed; not for bulk whole-binary disassembly (ghidra-decompile-functions) or dynamic-lane (x64dbg/frida) questions |
 | `yara-scan` | YARA rule scanning (built-in crypto-tables) | Read for rule-based byte scanning (family/IOC evidence); not when yara-python is missing |
 | `yara-gen` | YARA rule text generation from analysis findings | Read when generating detection rules from hex/string traits; not without a rule-generation need |
 | `jadx-decompile` | DEX-to-Java decompiler (jadx; android:java-source high) | Read when java-like source is needed AND the apk_mem_gate verdict is jadx-ok/targeted-jadx; not for 1:1 bytecode truth (baksmali-xref) |
@@ -216,15 +216,20 @@
 
 ### ida-decompile
 
-- **Purpose**: Native IDA Pro decompilation over the `ida-pro-vm` MCP bridge (http transport) — the ghidra-alternative path when IDA's analyzer is authoritative (OOL/ELF edge cases, FLIRT-signed libs, existing .idb analysis state).
+> MCP-channel tool family (like the dynamic domain): the faces are `mcp__ida-pro-vm__*` calls, not local .py scripts — the `_INDEX.yaml` `ida-decompile` entry is the routing/catalog anchor only. Registration is env-side (`ida-pro-vm` in `~/.claude.json` / `.mcp.json`, owner's local registration of upstream ida-pro-mcp); the toolshelf never auto-installs IDA.
+
+- **Purpose**: IDA lane tool family: `ida-decompile` (native Hex-Rays decompilation — the ghidra-alternative path when IDA's analyzer is authoritative: OOL/ELF edge cases, FLIRT-signed libs, existing .idb analysis state) + `ida-py-eval` (scripting-grade Python executed inside the IDA process) + typed-surface pointers reachable through the eval face (analyze_funcs / xrefs_to / find_bytes class).
 - **Usage**:
   ```bash
   mcp__ida-pro-vm__decompile_function   # bridge discovery first: mcp__ida-pro-vm__list_functions / mcp__ida-pro-vm__get_function_by_name
+  mcp__ida-pro-vm__py_eval              # scripting face: arbitrary Python inside the IDA process (session semantics below)
   ```
-- **Inputs**: Function address(es)/name(s) in the .i64/.idb opened by the bridge (the workspace sample must be loaded in the remote IDA instance).
-- **Outputs**: Decompiled pseudocode + disassembly context per function — quote verbatim into `facts/Fxxx.md`.
-- **exit code**: 0 pseudocode returned / 2 error (bridge unreachable — verify `ida-pro-vm` MCP registration in `~/.claude.json` / `.mcp.json`; the toolshelf never auto-installs IDA).
-- **when_not**: Not when ghidra is available and sufficient — use ghidra-decompile-functions; not for bulk whole-binary disassembly (IDA licenses are seat-bound; keep the bridge for targeted function claims).
+- **Inputs**: Function address(es)/name(s) — or Python source for the eval face — against the .i64/.idb opened by the bridge (the workspace sample must be loaded in the remote IDA instance).
+- **Outputs**: Decompiled pseudocode + disassembly context per function; eval-face returns the AST last-expression value plus captured stdout/stderr — quote verbatim into `facts/Fxxx.md`.
+- **exit code**: 0 pseudocode/eval result returned / 2 error (bridge unreachable — verify the env-side `ida-pro-vm` registration; the toolshelf never auto-installs IDA).
+- **Queue-serial contract (design, not a constraint)**: all calls to the lane enqueue and execute in order — this is the design, not a limitation to work around. Parallel/concurrent invocation is channel misuse and freezes IDA. One call at a time, always; never fan out simultaneous lane calls across workers.
+- **py_eval session semantics (stateful REPL)**: locals persist across calls (Jupyter-style) — state carries from call to call; an explicit `new_locals=True` reset wipes them; the exec globals (all `ida_*` modules pre-imported) are rebuilt per call. The eval surface is `@unsafe`-classed upstream — treat its source with shell-grade care, not as a read-only query.
+- **when_not**: Not when ghidra is available and sufficient — use ghidra-decompile-functions; not for bulk whole-binary disassembly (IDA licenses are seat-bound; keep the bridge for targeted function claims); not for dynamic-lane (x64dbg/frida) questions — those tools own runtime state, this lane is static only.
 
 ### yara-scan
 


### PR DESCRIPTION
## Deliverables (issue #179)

- [x] **1. tools/_index-static.md — ida row/section rewritten to the MCP+VM tool-family shape** (pattern: `_index-dynamic.md` x64dbg/frida rows): `ida-decompile` + `ida-py-eval` faces + typed-surface pointers (analyze_funcs / xrefs_to / find_bytes class). Carries the **queue-serial contract** (all calls enqueue and execute in order — this is the design, not a constraint; parallel/concurrent invocation is channel misuse and freezes IDA), **py_eval session semantics** (locals persist across calls Jupyter-style; `new_locals=True` reset; exec globals rebuilt per call), the `@unsafe` class note, and when_not boundaries (not for dynamic-lane x64dbg/frida questions; registration is env-side). `_INDEX.yaml` registry untouched (39 tools stable — the MCP faces are channel tools, the registered entry stays the routing anchor).
- [x] **2. references/re-library/ida-scripting-overlays.md — consumer line resolved**: the #163 conditional ("when the environment exposes one (scripting-grade execution surface)") is RESOLVED — the lane is scripting-grade via the eval face; the eval face is now a first-class consumer of the card. ONE session-persistence note added (state carries across the lane's Python-eval calls — prior-sparse: models do not know MCP eval faces are stateful REPLs). Both overlays' substance untouched. Note names the face, not the upstream tool literal, per the card's CORPUS_BANNED test contract (#163, still active).
- [x] **3. #167 closes** with this (documented surface replaces the stale decompile-only claim).

Resolves #167. Closes #179.

## Regen + verification

- Dependency order kept: `re_pin_references` -> `ext-scan` -> `deploy_manifest --write` LAST. Determinism x2 byte-stable; `ext-scan --check` green (ext index unchanged — card frontmatter desc untouched); `deploy_manifest --verify` green (405 entries).
- **Decide-anchor re-pin (score-only, precedent entry)**: the card body edit shifts lexical rarity in the anomaly baseline corpus — programmatic diff verified SCORE-ONLY before re-pin (4 anomaly score floats across the same 2 contradiction cases, zero structural drift, all other cases byte-equal); anchor re-captured via `capture_current()`; one-line precedent entry in the header chain.
- Full suite: 6262 passed / 10 skipped / 0 failed; ruff zero new (5 pre-existing, untouched).
- Docs + index regen only; zero product-code changes.