### PR TITLE
feat: init intake elicits goal + success criterion + verification method (oracle-grade entry anchors)

### DIFF
--- a/agents/kunglao-init-worker.md
+++ b/agents/kunglao-init-worker.md
@@ -2,7 +2,9 @@
 name: kunglao-init-worker
 description: 'INIT-WORKER for the kunglao-agent orchestrator. Runs needs-first workspace initialization:
   task-requirements intake FIRST (primary_questions / scope / constraints / depth / success_criteria into
-  task_spec.yaml BEFORE any environment decision; env = f(task_spec): constraints.dynamic_re=forbidden,
+  task_spec.yaml BEFORE any environment decision; PLUS the three REQUIRED oracle anchors — goal_verbatim /
+  success_criterion / verification_method (reproduction|replay-evidence|static|manual) — blank anchors refuse
+  analysis entry; env = f(task_spec): constraints.dynamic_re=forbidden,
   static-only, downgrades the windows/linux VM checks from HARD to WARN, unreadable fields stay HARD)
   -> target alignment as script intake step 0 (analysis target -> target_object for containers -> project
   type; undecided items exit 8 with a structured pending list on stdout, the agent collects answers via
@@ -67,6 +69,15 @@ type-aware initialization + toolchain readiness.
    gate runs — kunglao-init reads it to derive the environment layers
    (static-only: `constraints.dynamic_re: forbidden` drops the VM checks
    to WARN; absent/unreadable fields stay HARD).
+   The same round MUST also collect the three REQUIRED oracle anchors and
+   write them as first-class `task_spec.yaml` fields: `goal_verbatim`
+   (the user's goal VERBATIM), `success_criterion` (what counts as done),
+   `verification_method` (one of reproduction | replay-evidence | static |
+   manual). Blank anchors refuse analysis entry (`kunglao analysis` exit 7)
+   — never guess or default one. Phrasing help for folk asks: the README
+   section "How to state the task". `reproduction`/`replay-evidence` arm
+   the controlled-comparison oracle for every primary question (byte-matched
+   pairs become admission/verdict requirements).
 2. **Never mid-iteration questions**: decide + record reasoning + continue.
    If you cannot collect a pending answer, create a blocker with root-cause
    attribution — do not guess a target or type.

--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -95,7 +95,7 @@ files:
   - src: agents/kunglao-init-worker.md
     dest: .claude/agents/kunglao-init-worker.md
     kind: agent
-    sha256: 0dc914340dc10ea3084b643e70da4b2349f78d85e262992921f6a818f0457d1c
+    sha256: 8951be6a55027caa787736b7ad1f764f868040ca7847a6642c78c7677e888d81
   - src: agents/kunglao-redteam.md
     dest: .claude/agents/kunglao-redteam.md
     kind: agent
@@ -463,7 +463,7 @@ files:
   - src: scripts/kunglao-init.py
     dest: .claude/scripts/kunglao-init.py
     kind: scaffold
-    sha256: 5632ab6c230c23f4d09f4eb11bd53d5e7cdb8d2bd893c82c7b48f2f2f6836cbf
+    sha256: 7d31d5a7a885a84fad4f6e5a934b015890a7f65513f99ec0ced98f535605b221
   - src: scripts/kunglao-monitor.py
     dest: .claude/scripts/kunglao-monitor.py
     kind: scaffold
@@ -483,7 +483,7 @@ files:
   - src: scripts/kunglao.py
     dest: .claude/scripts/kunglao.py
     kind: scaffold
-    sha256: 76fb95aace97add75ced3cc66452ab51912ace5f23cacfa03ee0973e6a2ab289
+    sha256: a9b47adbf0cf52a8cc33c868db27c5e12b8c454792f04d46b3657f442a28b396
   - src: scripts/kunglao_eval.py
     dest: .claude/scripts/kunglao_eval.py
     kind: scaffold
@@ -511,7 +511,7 @@ files:
   - src: scripts/kunglao_upgrade.py
     dest: .claude/scripts/kunglao_upgrade.py
     kind: scaffold
-    sha256: 1bb0750f0bb37e095d10fcf39455ee83f8a4f160a33e0e17f29ce5f28fa139d5
+    sha256: 819714c4a0171591bbf192a69fccc47d8b500cd0f66ce9a1a2da504766ff1784
   - src: scripts/kunglao_verify.py
     dest: .claude/scripts/kunglao_verify.py
     kind: scaffold
@@ -592,6 +592,10 @@ files:
     dest: .claude/scripts/obligation_discovery.py
     kind: scaffold
     sha256: dd94e5003639701888eaa908965ddab413a62e159cd1275e89cc5973fc3103e7
+  - src: scripts/oracle_anchors.py
+    dest: .claude/scripts/oracle_anchors.py
+    kind: scaffold
+    sha256: a89a95296bf4840145cf6d04bac159267ba45eb2c96d486528ce436cbedcfc45
   - src: scripts/oracle_cadence.py
     dest: .claude/scripts/oracle_cadence.py
     kind: scaffold
@@ -699,7 +703,7 @@ files:
   - src: scripts/replay_equivalence.py
     dest: .claude/scripts/replay_equivalence.py
     kind: scaffold
-    sha256: f2a48dd645e7c938163950ba2f67083fe3814b21b5ab1ed2bda2e7cb7acb627b
+    sha256: 10e04a6f7fa2af96198bd642fdf68ed8ec7c442ada03e7987e839339e8657762
   - src: scripts/report_consistency_check.py
     dest: .claude/scripts/report_consistency_check.py
     kind: scaffold
@@ -1347,7 +1351,7 @@ files:
   - src: templates/state/task_spec.yaml
     dest: .claude/templates/state/task_spec.yaml
     kind: asset
-    sha256: f2625490e5d6957293b80f1db85278a230d99728106f515237ec93325f4d5670
+    sha256: b24ebd1e5da8d24eddf942f56eaca045a802ce0bc0e01e074e37c7bd3ea1cdfe
   - src: templates/unidbg/harness.java.tmpl
     dest: .claude/templates/unidbg/harness.java.tmpl
     kind: asset

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -252,6 +252,7 @@ scripts (count in parens) · `tests` = exercised by tests/ only.
 | `intake_one.py` | single manifest entry immediate validation (sha256/first_seen/sources/pq lists) | CLI |
 | `intake_promise.py` | Phase 0 预扫描 promise 块 (#813) — apkid/DIE 探测状态显式记录 + 混淆先验(apkid.json 同源提取) + java 可达性判定(#807 死胡同面)；task_spec `promise:` 键合并 / runs 降级 | kunglao-init, CLI, tests; 下游 enforcement consumer 未接线(#53 裁定: 休眠保留, 消费面=#54 Android-lighting, 不在此 fake-wire) |
 | `difficulty_calibration.py` | #15 样本内在难度标定 (easy/medium/hard/max) — 纯函数组合既有扫描器证据(die.json/apkid.json)为 per-factor 评分 + 多正面 MAX 发现规则；缺证据 → easy+evidence_gap(缺失永不计为难度)；evidence/difficulty.json + task_spec `difficulty:` 键(#16 开环输入) | kunglao-init, CLI, tests |
+| `oracle_anchors.py` | task_spec 三个必答 oracle 锚点 (goal_verbatim / success_criterion / verification_method: reproduction\|replay-evidence\|static\|manual) — fail-closed 校验(空白/越界枚举=缺失，绝不猜默认)；merge 写入 task_spec(不覆盖既有答案)；analysis 入口拒绝面(kunglao analysis rc=7) + init 提醒行；replay_equivalence 消费枚举作 declared-bit 武装 | kunglao-init, kunglao(analysis gate), replay_equivalence, tests |
 | `difficulty_thresholds.py` | #16 难度分档成功阈值 — per-tier 策略表(独立验证数 1/1/2/2、red-team 轮数 1/1/1/2、关联任务一致性 F/F/T/T、heuristic-first F/F/T/T) + 查询 API(get_thresholds/thresholds_for_workspace/count_verifications)；缺 difficulty.json → fail-closed hard(绝不静默降 easy)；PROVEN 深度闸门(kunglao_record + hooks backstop) + 心跳红队 guidance 行 | kunglao_record, hooks/worker_budget_gates, heartbeat_loop_prompt, CLI, tests |
 
 ## Release & CI support

--- a/scripts/kunglao-init.py
+++ b/scripts/kunglao-init.py
@@ -136,6 +136,7 @@ import toolchain  # noqa: E402  # #304: type-aware toolchain probes (check-befor
 import intake_promise  # noqa: E402  # #813: Phase 0 prescan promise (apkid/DIE/混淆先验/java 可达性显式落盘)
 import difficulty_calibration  # noqa: E402  # #15: sample difficulty calibration (intrinsic factors -> evidence/difficulty.json + task_spec difficulty: 键)
 import init_channel_default  # noqa: E402  # #727 channel resolution (local fallback)
+import oracle_anchors  # noqa: E402  # the three required intake answers (task_spec first-class fields)
 # #408: ask-then-install — interactive install prompts + MCP registration +
 # re-probe (graceful degrade on decline; --assume-yes for CI/headless).
 # #455: the interactive consent channel is gone (no stdin); ask_then_install
@@ -2424,20 +2425,35 @@ ORACLE_BACKFILL_MARKER = "pending-user-input-backfill"
 ORACLE_FILE = "task-oracle.yaml"
 
 
-def write_task_oracle_skeleton(ws: Path) -> bool:
+def write_task_oracle_skeleton(ws: Path,
+                               task_text: str | None = None) -> bool:
     """#473: write the workspace task-oracle.yaml skeleton. Returns True when
     written; an existing non-empty oracle is never clobbered (Phase-0
-    backfill survives re-inits); empty/corrupt remnants are replaced."""
+    backfill survives re-inits); empty/corrupt remnants are replaced.
+    `task_text` pre-fills the verbatim goal when the init interview already
+    collected it (task_spec.yaml goal_verbatim) — the completion gate then
+    judges a real anchor from the first tick instead of the backfill
+    marker; None keeps the marker (the orchestrator backfills at Phase 1)."""
     target = ws / ORACLE_FILE
     if target.exists() and target.read_text(encoding="utf-8").strip():
         return False
+    if task_text and str(task_text).strip():
+        task_line = f"task_text: {json.dumps(str(task_text), ensure_ascii=False)}\n"
+        backfill_note = (
+            "# task_text came from the init intake (task_spec.yaml\n"
+            "# goal_verbatim); the orchestrator restates it at the delivery\n"
+            "# receipt.\n")
+    else:
+        task_line = f"task_text: {ORACLE_BACKFILL_MARKER}\n"
+        backfill_note = (
+            "# Skeleton written by kunglao-init; the orchestrator backfills\n"
+            "# task_text with the user's verbatim task at Phase 1 (SKILL.md)\n"
+            "# before the first dispatch.\n")
     text = (
         "# task-oracle.yaml — pre-registered completion anchor (#55, #473).\n"
-        "# Skeleton written by kunglao-init; the orchestrator backfills\n"
-        "# task_text with the user's verbatim task at Phase 1 (SKILL.md)\n"
-        "# before the first dispatch.\n"
-        f"task_text: {ORACLE_BACKFILL_MARKER}\n"
-        "open_items: []\n"
+        + backfill_note
+        + task_line
+        + "open_items: []\n"
         "deferrals: []\n"
         "adjudication:\n"
         "  stop_hook_active:\n"
@@ -2537,10 +2553,25 @@ def initialize(ws: Path, hooks_json: Path | None,
     # (SKILL.md). Idempotent: a pre-existing oracle is never clobbered, and
     # the file is deliberately OUTSIDE the state-hash inputs (it is a
     # workspace artifact, not scaffold state).
-    oracle_written = write_task_oracle_skeleton(ws)
+    # The verbatim goal, when the init interview already collected it,
+    # lands in the completion anchor at scaffold time; the reminder line
+    # keeps a not-yet-answered interview visible without blocking init
+    # (the analysis-entry gate owns the refusal).
+    _anchor_view = oracle_anchors.load(ws)
+    _goal = _anchor_view.get("goal_verbatim")
+    _has_goal = isinstance(_goal, str) and bool(_goal.strip())
+    oracle_written = write_task_oracle_skeleton(
+        ws, task_text=_goal if _has_goal else None)
     if oracle_written:
-        print("kunglao-init: task-oracle.yaml skeleton registered "
-              "(task_text pending Phase-0 backfill by the orchestrator)")
+        if _has_goal:
+            print("kunglao-init: task-oracle.yaml registered "
+                  "(task_text pre-filled from the intake goal)")
+        else:
+            print("kunglao-init: task-oracle.yaml skeleton registered "
+                  "(task_text pending Phase-0 backfill by the orchestrator)")
+        _reminder = oracle_anchors.reminder(ws)
+        if _reminder:
+            print(_reminder)
 
     # #412: the exit message lists what init did (scaffold + env + type) and
     # does NOT summarize sample content (no sample= in the output).
@@ -2678,6 +2709,45 @@ def run(ws: Path | None, force: bool = False, hooks_json: Path | None = None,
         text = reg.read_text(encoding="utf-8")
         if MARKER in text:
             if is_init_complete(ws):
+                # Anchor repair re-entry: the intake answers fill ONLY the
+                # missing required fields — existing answers and all
+                # analysis state are untouched. A bad method value fails
+                # closed (never written); the analysis-entry gate keeps
+                # refusing until every anchor is present.
+                _repair = {k: answers[k] for k in oracle_anchors.FIELDS
+                           if answers.get(k) is not None
+                           and str(answers[k]).strip()}
+                if _repair:
+                    # An unreadable contract is NOT repairable in place:
+                    # the merge would see an empty document and replace the
+                    # whole intake record with the three anchors. Same
+                    # posture as the upgrade backfill — refuse, name the
+                    # full re-init, write nothing.
+                    _view, _state = oracle_anchors.read_state(ws)
+                    if _state == oracle_anchors.STATE_CORRUPT:
+                        print("kunglao-init: ERROR anchor repair refused - "
+                              + oracle_anchors.refusal_hint(
+                                  oracle_anchors.missing(_view), _state),
+                              file=sys.stderr)
+                        return RC_ERROR
+                    try:
+                        oracle_anchors.validate_values(_repair)
+                    except ValueError as exc:
+                        print(f"kunglao-init: ERROR anchor repair refused: "
+                              f"{exc}", file=sys.stderr)
+                        return RC_ERROR
+                    oracle_anchors.apply(ws, _repair)
+                    _remaining = oracle_anchors.missing(
+                        oracle_anchors.load(ws))
+                    if _remaining:
+                        print(f"kunglao-init: anchor repair applied but "
+                              f"still missing: {', '.join(_remaining)} "
+                              f"(analysis entry refuses until collected)",
+                              file=sys.stderr)
+                    else:
+                        print("kunglao-init: anchor repair complete - "
+                              "analysis entry re-run will pass the anchor "
+                              "gate")
                 # #461: resume is also an exit-0 path — re-arm the observer
                 # spine (idempotent bootstrap) before reporting resume.
                 rc = bootstrap_observability(ws, hooks_json=hooks_json,

--- a/scripts/kunglao.py
+++ b/scripts/kunglao.py
@@ -54,6 +54,12 @@ RC_STALE_WORKSPACE = 5
 # refusal to its exact remediation.
 RC_HEARTBEAT_VERIFY_FAIL = 6
 
+# The required intake answers (goal verbatim / success criterion /
+# verification method) are missing from task_spec.yaml — analysis entry
+# refuses until the init interview collects them. Never a guessed default:
+# a blank field or an out-of-enum method is missing.
+RC_ORACLE_ANCHORS_MISSING = 7
+
 
 def cmd_decide(args) -> int:
     ws = Path(args.workspace).resolve()
@@ -290,9 +296,17 @@ def cmd_resume(args) -> int:
     trails the skill version, refuse with RC=5 and direct the operator to
     `/kunglao-agent:upgrade <workspace>` (user must explicitly act —
     no auto-fix per #748 user ruling 2026-08-26).
+
+    The required intake answers gate resume the same way they gate
+    analysis entry: no anchorless reasoning after a crash — repair the
+    anchors (in place, or full re-init on an unreadable contract) and
+    re-run.
     """
     ws = Path(args.workspace).resolve()
     rc = _gate_stale_workspace(ws)
+    if rc != 0:
+        return rc
+    rc = _gate_oracle_anchors(ws)
     if rc != 0:
         return rc
     import kunglao_resume as kresume
@@ -373,12 +387,33 @@ def _gate_heartbeat_rearm(ws: Path) -> int:
     return 0
 
 
+def _gate_oracle_anchors(ws: Path) -> int:
+    """Analysis entry AND resume refuse while the required intake answers
+    are missing. Two states, two remedies:
+
+    - answers missing on a parseable contract -> repair IN PLACE (the
+      intake re-entry fills ONLY the missing fields; analysis state is
+      preserved);
+    - contract unreadable -> not repairable in place: full re-init (the
+      register is backed up first).
+    The loop never reasons without its anchors, and never guesses one.
+    """
+    import oracle_anchors
+    ok, gaps, state = oracle_anchors.inspect(ws)
+    if ok:
+        return 0
+    print(f"kunglao: entry refused - "
+          f"{oracle_anchors.refusal_hint(gaps, state)}", file=sys.stderr)
+    return RC_ORACLE_ANCHORS_MISSING
+
+
 def cmd_analysis(args) -> int:
     """#754 T3: the /kunglao-agent:analysis ENTRY gate chain — run once
     before entering the convergence loop (SKILL.md contract):
 
       1. _gate_stale_workspace (#748, same mount-point pattern as resume);
-      2. _gate_heartbeat_rearm (#754): durable-loop aging rebuild +
+      2. _gate_oracle_anchors (the required intake answers);
+      3. _gate_heartbeat_rearm (#754): durable-loop aging rebuild +
          continuous-tick verify; rc=6 maps to the re-arm hint.
 
     Pure gate/checker surface: entering the loop remains the orchestrator's
@@ -386,6 +421,9 @@ def cmd_analysis(args) -> int:
     """
     ws = Path(args.workspace).resolve()
     rc = _gate_stale_workspace(ws)
+    if rc != 0:
+        return rc
+    rc = _gate_oracle_anchors(ws)
     if rc != 0:
         return rc
     return _gate_heartbeat_rearm(ws)
@@ -416,7 +454,11 @@ def main() -> int:
             "version) — run /kunglao-agent:upgrade <ws> first\n"
             "  6 = heartbeat verify failed (analysis entry) — run "
             "/kunglao-agent:resume for re-arm guidance\n"
-            "(resume/check-stale return 5; analysis entry returns 5 or 6)"
+            "  7 = required intake answers missing (analysis entry) — fill "
+            "goal_verbatim / success_criterion / verification_method in "
+            "task_spec.yaml (init intake; README 'How to state the task')\n"
+            "(resume/check-stale return 5; analysis entry and resume return "
+            "5 or 7; analysis entry additionally returns 6)"
         ),
     )
     sub = ap.add_subparsers(dest="cmd", required=True)

--- a/scripts/kunglao_upgrade.py
+++ b/scripts/kunglao_upgrade.py
@@ -98,6 +98,12 @@ RC_UNKNOWN_ORIGIN = 3
 RC_IRON_RULE = 4
 RC_DIRTY_WORKSPACE = 6
 RC_INCOMPLETE = 7
+# The required intake answers are missing and no --resolve answers were
+# supplied: the pending-decision JSON rode stdout (flow=kunglao-upgrade);
+# the agent collects the answers and re-enters with --resolve. Same
+# structured channel as the init intake (exit 8 + machine-parseable
+# stdout).
+RC_ANCHORS_PENDING = 8
 
 # #758 G1a/G1b: advisory interpreter-pin echo of .python-version=3.11.
 PYTHON_PIN = (3, 11)
@@ -1472,8 +1478,100 @@ def _item_skill_staleness_check(ws: Path, dry: bool) -> str:
 # driver
 # --------------------------------------------------------------------------
 
+def _anchor_backfill(ws: Path, dry_run: bool, resolve: dict | None,
+                     items_out: list | None) -> tuple[int, dict | None]:
+    """Detect missing required intake answers in task_spec.yaml and elicit
+    them through the structured interview channel (pending JSON on stdout,
+    exit 8; answers re-enter via --resolve). A backfill writes ONLY the
+    missing fields: task_spec is the workspace's input contract (scaffold
+    class, template-refresh job), NOT one of the user-data dirs — the
+    user-data invariance check is untouched. An unreadable contract is not
+    backfillable: one stderr line directs to full re-init, the upgrade
+    itself stays successful.
+
+    Returns (rc, pending_doc) — pending_doc is the JSON document to print
+    LAST on stdout when rc == RC_ANCHORS_PENDING.
+    """
+    import oracle_anchors
+    _record = (lambda action, detail: items_out.append(
+        {"name": "oracle_anchor_backfill", "action": action,
+         "detail": detail}) if items_out is not None else None)
+    ok, gaps, state = oracle_anchors.inspect(ws)
+    if ok:
+        print("kunglao-upgrade: anchors: complete")
+        _record("noop", "anchors: complete")
+        return RC_OK, None
+    if state == oracle_anchors.STATE_CORRUPT:
+        _warn_line("kunglao-upgrade: WARN — anchors: task_spec unreadable, "
+                   "backfill impossible, full re-init required "
+                   "(kunglao-init <ws> --force --type <type>)")
+        _record("noop", "anchors: task_spec unreadable (full re-init)")
+        return RC_OK, None
+    answers = {}
+    for name in oracle_anchors.FIELDS:
+        value = (resolve or {}).get(name)
+        if isinstance(value, str) and value.strip():
+            answers[name] = value
+    if answers:
+        try:
+            oracle_anchors.validate_values(answers)
+        except ValueError as exc:
+            print(f"kunglao-upgrade: ERROR anchor backfill refused: {exc}",
+                  file=sys.stderr)
+            _record("noop", f"backfill refused: {exc}")
+            return RC_INCOMPLETE, None
+        oracle_anchors.apply(ws, answers)
+        ok, gaps, _state = oracle_anchors.inspect(ws)
+        if ok:
+            print("kunglao-upgrade: anchors: backfilled via interview")
+            _record("applied", "anchors: backfilled via interview")
+            return RC_OK, None
+    if dry_run:
+        print(f"kunglao-upgrade: anchors: pending interview "
+              f"(missing: {', '.join(gaps)})")
+        _record("noop", f"anchors: pending interview ({len(gaps)} missing)")
+        return RC_OK, None
+    pending = build_anchor_pending_doc(ws, gaps)
+    _record("noop", "anchors: pending interview")
+    return RC_ANCHORS_PENDING, pending
+
+
+def build_anchor_pending_doc(ws: Path, gaps: list[str]) -> dict:
+    """The structured interview for the missing answers — same schema,
+    same flow, same re-entry contract as the init intake."""
+    import decision_pending as dp
+    import oracle_anchors
+    questions = {
+        "goal_verbatim": ("Your goal for this workspace, restated "
+                          "verbatim — what do you want?"),
+        "success_criterion": ("What counts as done — the checkable "
+                              "end-state the result is judged against?"),
+        "verification_method": ("How is the result verified?"),
+    }
+    decisions = []
+    for name in gaps:
+        if name == "verification_method":
+            decisions.append(dp.PendingDecision(
+                decision_id=name, question=questions[name],
+                kind=dp.KIND_CHOICE,
+                options=tuple(oracle_anchors.METHOD_OPTIONS),
+                default=None))
+        else:
+            decisions.append(dp.PendingDecision(
+                decision_id=name, question=questions[name],
+                kind=dp.KIND_VALUE, options=(), default=None))
+    doc = dp.build_pending_doc(
+        flow="kunglao-upgrade", workspace=str(ws),
+        guidance=dp.GUIDANCE_TEMPLATE, decisions=decisions)
+    doc["guidance"] = doc["guidance"] + (
+        " These answers are the workspace's required oracle anchors; "
+        "analysis entry and resume refuse until they are collected.")
+    return doc
+
+
 def upgrade(ws: Path, dry_run: bool = False,
-           items_out: list | None = None) -> int:
+           items_out: list | None = None,
+           resolve: dict | None = None) -> int:
     ws = Path(ws)
     origin = template_version.read_workspace_version(ws)
     if origin is None:
@@ -1541,6 +1639,12 @@ def upgrade(ws: Path, dry_run: bool = False,
         # references (mis-wired by a pre-fix tool) — sweep applies here too.
         sweep = _install_reference_sweep(ws)
         _emit(ws, "install_reference_scan", _sweep_detail(sweep))
+        anchor_rc, anchor_pending = _anchor_backfill(
+            ws, dry_run, resolve, items_out)
+        if anchor_rc != RC_OK:
+            if anchor_pending is not None:
+                print(json.dumps(anchor_pending, ensure_ascii=False))
+            return anchor_rc
         return RC_OK
 
     if dry_run:
@@ -1551,6 +1655,9 @@ def upgrade(ws: Path, dry_run: bool = False,
                 if items_out is not None:
                     items_out.append({"name": item, "action": "noop",
                                        "detail": "dry-run"})
+        # the required intake answers: report their state in the plan,
+        # write nothing (the dry run never pends)
+        _anchor_backfill(ws, dry_run=True, resolve=resolve, items_out=items_out)
         # #752 D6: planned sweep surfaces in the dry-run plan, writes nothing
         stale_n = sum(len(v) for v in
                       install_reference.scan_workspace(
@@ -1622,6 +1729,10 @@ def upgrade(ws: Path, dry_run: bool = False,
         # the item above already emitted the one WARN this run needs.
         _guarded_stamp_refresh(ws, version=target, warn=False)
         _emit_event("stamp", "ok", f"version={target}")
+        # required intake answers: backfill BEFORE the post-state commit so
+        # the write rides the snapshot layer (the tree stays clean)
+        anchor_rc, anchor_pending = _anchor_backfill(
+            ws, dry_run=False, resolve=resolve, items_out=items_out)
         _emit(ws, "upgrade", f"{origin}->{target} items={applied}")
         print(f"kunglao-upgrade: {origin} -> {target} "
               f"({applied} item(s), snapshot {snap_path.name})")
@@ -1680,6 +1791,10 @@ def upgrade(ws: Path, dry_run: bool = False,
         # slash-commands/hooks up only after a plugin reload.
         print("kunglao-upgrade: skill package updated — run /reload-plugins "
               "in Claude Code to activate")
+        if anchor_rc != RC_OK:
+            if anchor_pending is not None:
+                print(json.dumps(anchor_pending, ensure_ascii=False))
+            return anchor_rc
     except Exception as exc:  # noqa: BLE001 — incomplete, not silent success
         tail_error = f"{type(exc).__name__}: {exc}"
         _emit_event("summary", "fail", tail_error)
@@ -1702,11 +1817,26 @@ def main(argv: list[str] | None = None) -> int:
                    help="emit a single JSON envelope on stdout (status, rc, "
                         "items, iron_rule_hash, started_at, ended_at); "
                         "the human-readable plan still goes to stderr")
+    p.add_argument("--resolve", metavar="PATH", default=None,
+                   help="answers JSON for the required-intake-answer "
+                        "interview (goal_verbatim / success_criterion / "
+                        "verification_method); re-entry after a pending "
+                        "exit 8")
     a = p.parse_args(argv)
     _warn_python_version()
     started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     items_out: list = []
-    rc = upgrade(Path(a.workspace), a.dry_run, items_out)
+    resolve_answers: dict | None = None
+    if a.resolve:
+        try:
+            loaded = json.loads(Path(a.resolve).read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            print(f"kunglao-upgrade: ERROR --resolve unreadable: {exc}",
+                  file=sys.stderr)
+            return 1
+        resolve_answers = loaded if isinstance(loaded, dict) else {}
+    rc = upgrade(Path(a.workspace), a.dry_run, items_out,
+                 resolve=resolve_answers)
     ended_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     if a.json:
         status = {
@@ -1716,6 +1846,7 @@ def main(argv: list[str] | None = None) -> int:
             RC_IRON_RULE: "iron-rule-violation",
             RC_DIRTY_WORKSPACE: "refused-dirty",
             RC_INCOMPLETE: "incomplete",
+            RC_ANCHORS_PENDING: "anchors-pending",
         }
         # pick first matching key
         chosen = "ok"

--- a/scripts/oracle_anchors.py
+++ b/scripts/oracle_anchors.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""oracle_anchors.py — the three REQUIRED intake answers in task_spec.yaml.
+
+The init interview collects, after the existing needs-first questions, the
+three oracle-grade elements the whole loop steers by:
+
+    goal_verbatim        the user's goal, restated verbatim (never
+                         paraphrased — the verbatim form is what the
+                         completion oracle judges)
+    success_criterion    what counts as done (the completion anchor)
+    verification_method  how the result is verified — reproduction |
+                         replay-evidence | static | manual
+
+Every field is required: a blank field, a non-string value, or a method
+outside the enum is a MISSING answer. Missing answers refuse analysis
+entry (the `kunglao analysis` gate chain) — the loop never starts on a
+guessed anchor, and the script layer never invents one.
+
+Consumers:
+  kunglao-init      pre-fills the completion-oracle task_text from the
+                    verbatim goal and prints a reminder while answers are
+                    missing
+  kunglao analysis  refuses entry (rc=7) while any answer is missing
+  replay_equivalence.declared_reproduction_qids
+                    arms the declared-question set from the method answer
+                    (reproduction / replay-evidence arm the
+                    controlled-comparison face)
+
+stdlib only.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+FIELDS: tuple[str, ...] = (
+    "goal_verbatim",
+    "success_criterion",
+    "verification_method",
+)
+
+# The method enum mirrors the declared-bit vocabulary of the controlled-
+# comparison oracle: reproduction / replay-evidence arm its face; static
+# and manual are different verification modes and arm nothing there.
+METHOD_OPTIONS: tuple[str, ...] = (
+    "reproduction",
+    "replay-evidence",
+    "static",
+    "manual",
+)
+
+REPLAY_ORACLE_METHODS: tuple[str, ...] = ("reproduction", "replay-evidence")
+
+TASK_SPEC_FILENAME = "task_spec.yaml"
+
+
+def _valid_method(value) -> bool:
+    return isinstance(value, str) and value in METHOD_OPTIONS
+
+
+def _answerable(value) -> bool:
+    """A non-blank string answer; anything else is not an answer."""
+    return isinstance(value, str) and bool(value.strip())
+
+
+def missing(task_spec: dict) -> list[str]:
+    """Ordered names of the required answers the spec fails to give.
+
+    Fail-closed: a blank value, a non-string, or an out-of-enum method is
+    reported missing — callers must never adopt a default for any of them.
+    """
+    spec = task_spec if isinstance(task_spec, dict) else {}
+    out: list[str] = []
+    if not _answerable(spec.get("goal_verbatim")):
+        out.append("goal_verbatim")
+    if not _answerable(spec.get("success_criterion")):
+        out.append("success_criterion")
+    if not _valid_method(spec.get("verification_method")):
+        out.append("verification_method")
+    return out
+
+
+def load(ws) -> dict:
+    """The anchor view of <ws>/task_spec.yaml.
+
+    {} when the file is absent or unparseable — callers treat an unreadable
+    contract as unanswered (the analysis-entry gate refuses; the init
+    reminder prints). Non-mapping files are {} for the same reason.
+    """
+    path = Path(ws) / TASK_SPEC_FILENAME
+    if not path.exists():
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, OSError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {name: data.get(name) for name in FIELDS}
+
+
+def check_ws(ws) -> tuple[bool, list[str]]:
+    """(ok, missing) for the analysis-entry gate."""
+    return _check(missing(load(ws)))
+
+
+# ------------------------------------------- state-aware inspection (gate)
+
+STATE_ABSENT = "absent"          # no task_spec.yaml — intake never landed
+STATE_CORRUPT = "corrupt"        # unreadable / non-mapping — not repairable
+STATE_INCOMPLETE = "incomplete"  # parseable but answers missing
+STATE_COMPLETE = "complete"
+
+_CORRUPT_HINT = (
+    "task_spec.yaml unreadable - not repairable in place: full re-init "
+    "required (kunglao-init <ws> --force --type <type>; the register is "
+    "backed up first), analysis entry stays refused until then")
+
+_INCOMPLETE_HINT = (
+    "workspace anchors incomplete (%s) - engineering damage or incomplete "
+    "init; repair in place, analysis state preserved: "
+    "kunglao-init <ws> --resolve <answers.json> (the answers carry the "
+    "three anchors; ONLY missing fields are filled, existing answers and "
+    "all analysis state untouched)")
+
+
+def read_state(ws) -> tuple[dict, str]:
+    """(anchor view, state) — the state-aware contract read.
+
+    state: STATE_ABSENT (no file) / STATE_CORRUPT (unreadable or a
+    non-mapping document) / else the parseable view plus whether the
+    required answers are present (STATE_COMPLETE / STATE_INCOMPLETE).
+    """
+    path = Path(ws) / TASK_SPEC_FILENAME
+    if not path.exists():
+        return {}, STATE_ABSENT
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, OSError):
+        return {}, STATE_CORRUPT
+    if not isinstance(data, dict):
+        return {}, STATE_CORRUPT
+    view = {name: data.get(name) for name in FIELDS}
+    return view, (STATE_COMPLETE if not missing(view)
+                  else STATE_INCOMPLETE)
+
+
+def inspect(ws) -> tuple[bool, list[str], str]:
+    """(ok, missing, state) — the boundary-gate face."""
+    view, state = read_state(ws)
+    return (state == STATE_COMPLETE, missing(view), state)
+
+
+def refusal_hint(gaps: list[str], state: str) -> str:
+    """Remediation text: repair-in-place for missing answers, full re-init
+    for an unreadable contract. Never a guessed default."""
+    if state == STATE_CORRUPT:
+        return _CORRUPT_HINT
+    return _INCOMPLETE_HINT % ", ".join(gaps)
+
+
+def validate_values(values: dict) -> None:
+    """Fail-closed pre-write validation for repair values: a non-blank
+    ``verification_method`` outside the enum raises ValueError (a bad
+    answer never lands in the contract)."""
+    method = values.get("verification_method")
+    if _answerable(method) and not _valid_method(method):
+        raise ValueError(
+            f"verification_method must be one of "
+            f"{' | '.join(METHOD_OPTIONS)}; got {method!r}")
+
+
+def _check(gaps: list[str]) -> tuple[bool, list[str]]:
+    return (not gaps, gaps)
+
+
+def apply(ws, values: dict) -> Path:
+    """Merge the anchor answers into <ws>/task_spec.yaml.
+
+    Creates the file when absent; existing user keys survive untouched and
+    an existing non-blank answer is never clobbered (the interview only
+    fills blanks). Values must be pre-validated by missing()/the caller.
+    """
+    path = Path(ws) / TASK_SPEC_FILENAME
+    doc: dict = {}
+    if path.exists():
+        try:
+            loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (yaml.YAMLError, OSError):
+            loaded = None
+        if isinstance(loaded, dict):
+            doc = loaded
+    for name in FIELDS:
+        value = values.get(name)
+        if _answerable(value) and not _answerable(doc.get(name)):
+            doc[name] = value
+    text = yaml.safe_dump(doc, allow_unicode=True, sort_keys=False,
+                          default_flow_style=False)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def reminder(ws) -> str:
+    """The init stdout line while answers are missing; "" when complete."""
+    ok, gaps, state = inspect(ws)
+    if ok:
+        return ""
+    return "kunglao-init: NOTE " + refusal_hint(gaps, state)

--- a/scripts/replay_equivalence.py
+++ b/scripts/replay_equivalence.py
@@ -46,6 +46,8 @@ import json
 import sys
 from pathlib import Path
 
+import oracle_anchors  # noqa: E402  — the intake method enum (single source)
+
 SCHEMA_ID = "replay-equivalence/1"
 ARTIFACT_GLOB = "replay-*.json"
 DEFAULT_STRENGTH = 2
@@ -397,10 +399,25 @@ def mutation_face(pairs: list[dict], evaluate=evaluate_pairs) -> None:
 # ---------------------------------------------------- declared faces -----
 
 def declared_reproduction_qids(task_spec: dict) -> set[str]:
-    """Question ids carrying the declared ``reproduction: true`` bit."""
+    """Question ids carrying the declared ``reproduction: true`` bit.
+
+    The workspace-level ``verification_method`` answer arms the set too:
+    when the intake collected reproduction / replay-evidence as the
+    verification method, EVERY primary question is declared — the
+    controlled-comparison face applies to the whole engagement, not only
+    to individually flagged questions. static / manual (or an absent
+    answer) leave the per-question bits as the sole source.
+    """
+    spec = task_spec or {}
     out: set[str] = set()
-    for q in (task_spec or {}).get("primary_questions") or []:
-        if isinstance(q, dict) and q.get("reproduction") is True \
+    questions = [q for q in spec.get("primary_questions") or []
+                 if isinstance(q, dict)]
+    if str(spec.get("verification_method") or "") in \
+            oracle_anchors.REPLAY_ORACLE_METHODS:
+        out.update(q["id"] for q in questions
+                   if isinstance(q.get("id"), str) and q["id"].strip())
+    for q in questions:
+        if q.get("reproduction") is True \
                 and isinstance(q.get("id"), str) and q["id"].strip():
             out.add(q["id"])
     return out

--- a/skills/analysis/SKILL.md
+++ b/skills/analysis/SKILL.md
@@ -72,6 +72,14 @@ reconcile → continuous-tick verify. Exit contract (never proceed on failure):
   re-arm guidance` — monitoring is NOT verifiably alive (a lone registration
   tick counts as dead: that was the blind spot). Direct to
   `/kunglao-agent:resume`; do not hand-wave a dispatch through.
+- `rc=7` + stderr `analysis entry refused - oracle anchors missing ...` —
+  the required intake answers are not in `task_spec.yaml`
+  (`goal_verbatim` / `success_criterion` / `verification_method`, the
+  latter one of reproduction | replay-evidence | static | manual). Route
+  back to the init intake: collect the three answers (never guess or
+  default one), write them into `task_spec.yaml`, re-run this gate. For
+  phrasing help, point the user at the README section "How to state the
+  task".
 
 The durable reconcile inside this command is idempotent: if Claude Code's
 7-day durable-schedule cap expired and removed the entry, it is re-created

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -30,6 +30,26 @@ analysis; a workspace that is not initialized is refused work.
    WARN; every field the task_spec does not answer stays HARD
    (conservative default — an absent task_spec is byte-identical to a
    VM-required workspace).
+
+   **Oracle anchors (REQUIRED — same round)** — after the needs-first
+   questions, ask the three answers that steer the whole loop, and write
+   them as first-class `task_spec.yaml` fields (blank in the template):
+   1. `goal_verbatim` — the user's goal, restated VERBATIM (never
+      paraphrased; the verbatim form is what the completion oracle
+      judges, and init pre-fills `task-oracle.yaml` `task_text` from it).
+   2. `success_criterion` — what counts as done, stated as a checkable
+      end-state (the completion anchor).
+   3. `verification_method` — how the result is verified, one of:
+      `reproduction` / `replay-evidence` (either arms the
+      controlled-comparison oracle: byte-matched pairs become admission
+      and verdict requirements for every primary question) / `static` /
+      `manual`.
+   While any anchor is blank the analysis entry refuses
+   (`kunglao analysis` exit 7) — collect all three or the workspace
+   cannot enter the loop; never guess or default an anchor. For help
+   turning a folk ask ("我要纯算") into these answers, point the user at
+   the README section **"How to state the task"**
+   (`README.md`, anchor `#how-to-state-the-task`).
 1. **Target alignment ** — run
    `python <SKILL_DIR>/scripts/kunglao-init.py <workspace>` FIRST; undecided
    intake items (workspace path -> analysis target -> project type) exit 8

--- a/skills/kunglao-agent/SKILL.md
+++ b/skills/kunglao-agent/SKILL.md
@@ -105,7 +105,7 @@ Run the steps in order; any FAIL blocks the next step.
 
 5. **Workspace resolution + path reachability**: resolve the GIVEN workspace (an explicit argument, or a cwd candidate the operator confirmed in the guided prompt). Confirm cwd = project root; resolve every state file by cwd-relative path (`claim-register.yaml`, not absolute paths); if `Bash cd` to a deep path times out, read state via `Read` with cwd-relative paths. Any failure → cold-start NOT complete → log a `B1a` blocker, not "best guess".
 
-**Input contract (3 required)**: ① sample — `bins/<sha>`, sha256 verified ② `task_spec.yaml` — primary_questions / scope / constraints / depth / success_criteria (template: `templates/state/task_spec.yaml`) ③ existing artifacts — CTI/evidence/fact base, READ-ONLY, never re-query.
+**Input contract (3 required)**: ① sample — `bins/<sha>`, sha256 verified ② `task_spec.yaml` — primary_questions / scope / constraints / depth / success_criteria + the three REQUIRED oracle anchors (goal_verbatim / success_criterion / verification_method: reproduction|replay-evidence|static|manual — blank anchors refuse analysis entry) (template: `templates/state/task_spec.yaml`) ③ existing artifacts — CTI/evidence/fact base, READ-ONLY, never re-query.
 
 ## Arguments
 

--- a/skills/upgrade/SKILL.md
+++ b/skills/upgrade/SKILL.md
@@ -40,12 +40,25 @@ must be initialized first with `/kunglao-agent:init`.
 | `4` | iron-rule violation — user data drifted | "user-data drift detected, snapshot at `<workspace>/.kunglao-upgrade-pre-snapshot/` kept on disk; restore from snapshot" |
 | `6` | dirty owned-repo — migration needs a clean rollback anchor | "refused: commit or stash first (commands on stderr), then re-run" |
 | `7` | incomplete — migration applied but the finish sequence aborted; re-run upgrade | "warning: re-run /kunglao-agent:upgrade to complete" |
+| `8` | anchors pending — the required intake answers (goal_verbatim / success_criterion / verification_method) are missing from `task_spec.yaml`; the interview rode stdout as pending-decision JSON (flow `kunglao-upgrade`), collect via AskUserQuestion and re-run with `--resolve <answers.json>` | "collect the three anchors, re-run with --resolve" |
+
+The upgrade completion report states anchor status explicitly: `anchors:
+complete` (nothing asked, gates will pass) or `anchors: backfilled via
+interview` (the answers were collected and written this run) — so the user
+knows the analysis-entry and resume gates will pass before they start. A
+legacy workspace (initialized before the anchors existed) is backfilled
+here instead of deadlocking: analysis entry and resume both refuse on
+missing anchors, and a full re-init would destroy analysis state — the
+upgrade interview is the sanctioned repair. Only the missing fields are
+written; existing answers are never clobbered.
 
 ## CLI
 
 ```bash
 uv run --project . kunglao upgrade <workspace>            # migrate
 uv run --project . kunglao upgrade <workspace> --dry-run  # print plan only
+uv run --project . kunglao upgrade <workspace> --resolve <answers.json>
+                                 # anchor interview re-entry (after exit 8)
 ```
 
 JSON envelope (when `--json` lands in a future commit):
@@ -53,8 +66,9 @@ JSON envelope (when `--json` lands in a future commit):
 ```json
 {
   "status": "ok" | "dry-run" | "already-current" | "refused"
-          | "refused-dirty" | "iron-rule-violation" | "incomplete",
-  "rc": 0 | 3 | 4 | 6 | 7,
+          | "refused-dirty" | "iron-rule-violation" | "incomplete"
+          | "anchors-pending",
+  "rc": 0 | 3 | 4 | 6 | 7 | 8,
   "items": [{"name": "hooks_rewire", "action": "applied" | "noop" | "skipped", "detail": "..."}],
   "iron_rule_hash": {"pre": "...", "post": "..."},
   "started_at": "ISO-8601",

--- a/templates/state/task_spec.yaml
+++ b/templates/state/task_spec.yaml
@@ -1,6 +1,18 @@
 # task_spec.yaml — kunglao-agent input contract (Phase 0.4 fills this).
 # See DESIGN §2. The user's requirements drive the orchestrator's value function.
 
+# Oracle anchors — REQUIRED. The init interview collects all three after
+# the needs-first questions; while any is blank, analysis entry refuses
+# (`kunglao analysis`, exit 7). For help turning a folk ask into these
+# answers, see the README section "How to state the task".
+goal_verbatim: ""            # the user's goal, VERBATIM — never paraphrased
+success_criterion: ""        # what counts as done (the completion anchor)
+verification_method: ""      # reproduction | replay-evidence | static | manual
+                             #   reproduction / replay-evidence arm the
+                             #   controlled-comparison oracle for every
+                             #   primary question (byte-matched pairs
+                             #   required); static / manual do not
+
 primary_questions:            # MUST answer — convergence hard conditions C0/C0b
   - id: q1
     q: "<the question, e.g. does the sample belong to the Vidar family?>"

--- a/tests/_factories.py
+++ b/tests/_factories.py
@@ -129,6 +129,23 @@ def seed_bins(ws: Path, *, name: str = "sample.exe",
     return target
 
 
+def seed_oracle_anchors(ws: Path, *, goal: str = "legacy goal",
+                        criterion: str = "legacy criterion",
+                        method: str = "manual") -> Path:
+    """Write an anchor-complete task_spec.yaml (the three REQUIRED intake
+    answers). For tests that pin semantics OTHER than the anchor
+    interview: the analysis-entry and resume gates refuse a workspace
+    whose contract lacks these, so fixture workspaces that exercise the
+    loop machinery carry a completed interview."""
+    path = ws / "task_spec.yaml"
+    if not path.exists():
+        path.write_text(
+            f"goal_verbatim: {goal}\n"
+            f"success_criterion: {criterion}\n"
+            f"verification_method: {method}\n", encoding="utf-8")
+    return path
+
+
 def write_worker_status(ws: Path, name: str, status: str,
                         age_min: float | None = None) -> Path:
     """#915 item 8: the ONE runs/worker-status-<name>.md seeding shape.

--- a/tests/test_canonical_chain_752.py
+++ b/tests/test_canonical_chain_752.py
@@ -40,6 +40,8 @@ from pathlib import Path
 
 import pytest
 
+from _factories import seed_oracle_anchors
+
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / "scripts"
 if str(SCRIPTS) not in sys.path:
@@ -502,6 +504,7 @@ def _make_ws(tmp_path: Path, name: str, stamp_version: str | None) -> Path:
     body = f"# kunglao_template_version: {stamp_version}\nclaims: []\n" \
         if stamp_version else "claims: []\n"
     (ws / "claim-register.yaml").write_text(body, encoding="utf-8")
+    seed_oracle_anchors(ws)
     return ws
 
 
@@ -580,6 +583,7 @@ def test_clean_workspace_gets_no_sweep_noise(tmp_path, monkeypatch, capsys):
     (ws / ".claude" / "settings.json").write_text("{}", encoding="utf-8")
     (ws / "claim-register.yaml").write_text(
         f"# kunglao_template_version: {cur}\nclaims: []\n", encoding="utf-8")
+    seed_oracle_anchors(ws)
     pre_md = (ws / "CLAUDE.md").read_bytes()
     assert up.main([str(ws)]) == 0
     captured = capsys.readouterr()
@@ -617,6 +621,7 @@ def test_upgrade_sweep_is_rename_invariant(tmp_path, monkeypatch):
     (ws / ".claude").mkdir(exist_ok=True)
     (ws / ".claude" / "settings.json").write_text(json.dumps({"hooks": {}}),
                                                   encoding="utf-8")
+    seed_oracle_anchors(ws)
     rc = up.main([str(ws)])
     assert rc == 0
     md = (ws / "CLAUDE.md").read_text(encoding="utf-8")

--- a/tests/test_claudemd_pending_merge_5.py
+++ b/tests/test_claudemd_pending_merge_5.py
@@ -42,7 +42,7 @@ SCRIPTS = REPO / "scripts"
 KUNGLAO_PY = SCRIPTS / "kunglao.py"
 
 import template_version as tv  # noqa: E402
-from _factories import seed_bins  # noqa: E402
+from _factories import seed_bins, seed_oracle_anchors  # noqa: E402
 
 CUR_VERSION = tv.read_skill_version()
 STAMP_KEY = tv.STAMP_KEY
@@ -117,6 +117,9 @@ def _refusing_ws(tmp: Path) -> Path:
     (ws / "runs").mkdir()
     (ws / "runs" / "worker-status-C001.txt").write_text("status line",
                                                         encoding="utf-8")
+    # the required intake answers (this file pins merge semantics, not the
+    # anchor interview)
+    seed_oracle_anchors(ws)
     return ws
 
 

--- a/tests/test_deploy_lifecycle_783.py
+++ b/tests/test_deploy_lifecycle_783.py
@@ -108,6 +108,12 @@ def _deployed_ws(tmp_path: Path, *, stamp: str | None = None,
     (ws / "CLAUDE.md").write_text(
         tv.stamp_line(stamp or tv.read_skill_version()) + "\n",
         encoding="utf-8")
+    # the three required intake answers (present: these tests pin
+    # deployment-lifecycle semantics, not the anchor interview)
+    (ws / "task_spec.yaml").write_text(
+        "goal_verbatim: lifecycle goal\n"
+        "success_criterion: lifecycle criterion\n"
+        "verification_method: manual\n", encoding="utf-8")
     return ws
 
 
@@ -380,6 +386,12 @@ def test_lifecycle_init_drift_upgrade_current(tmp_path: Path):
     tamper -> check-stale deploy-drift -> same-version upgrade restores ->
     check-stale current + zero skill-install paths -> init idempotent."""
     ws = _init_ws(tmp_path)
+    # the needs-first intake answers (SKILL flow: they land in task_spec
+    # ahead of init; this test pins the deploy lifecycle, not the interview)
+    (ws / "task_spec.yaml").write_text(
+        "goal_verbatim: lifecycle goal\n"
+        "success_criterion: lifecycle criterion\n"
+        "verification_method: manual\n", encoding="utf-8")
 
     # 1. init materialized the deployment + carrier + inverted registration
     hooks_dir = ws / ".claude" / "hooks"

--- a/tests/test_deploy_surface_755.py
+++ b/tests/test_deploy_surface_755.py
@@ -31,7 +31,7 @@ if str(SCRIPTS) not in sys.path:
 
 import template_version as tv  # noqa: E402
 from event_taxonomy import EMIT_ACTIONS  # noqa: E402
-from _factories import seed_bins
+from _factories import seed_bins, seed_oracle_anchors
 
 
 # ---------------------------------------------------------------- #143 home isolation
@@ -80,6 +80,7 @@ def _fixture_ws(tmp_path: Path) -> Path:
     (ws / ".claude").mkdir()
     (ws / ".claude" / "settings.json").write_text("{}", encoding="utf-8")
     (ws / "runs").mkdir()
+    seed_oracle_anchors(ws)
     return ws
 
 
@@ -631,6 +632,7 @@ class TestT6Registry:
         (ws / "notes" ).mkdir()
         (ws / "notes" / "keep.md").write_text("precious bytes",
                                               encoding="utf-8")
+        seed_oracle_anchors(ws)
         return ws
 
     @staticmethod

--- a/tests/test_heartbeat_autonomy_754.py
+++ b/tests/test_heartbeat_autonomy_754.py
@@ -27,6 +27,8 @@ import json
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
+
+from _factories import seed_oracle_anchors  # noqa: E402
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -438,6 +440,7 @@ def _stamped_ws(tmp_path: Path) -> Path:
     ws.mkdir(parents=True)
     (ws / "CLAUDE.md").write_text("# kunglao_template_version: 9.9.9\n", encoding="utf-8")
     (ws / "runs").mkdir()
+    seed_oracle_anchors(ws)
     return ws
 
 

--- a/tests/test_kunglao_resume.py
+++ b/tests/test_kunglao_resume.py
@@ -71,8 +71,13 @@ def _armed_ws(tmp_path: Path, *, name: str = "ws",
                 if k != "id":
                     lines.append(f"  {k}: {v}")
         (ws / "claim-register.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        # the three required intake answers ride the contract (these tests
+        # pin resume delegation, not the anchor interview)
         (ws / "task_spec.yaml").write_text(
-            "primary_questions:\n  - q1: sample family\n", encoding="utf-8")
+            "primary_questions:\n  - q1: sample family\n"
+            "goal_verbatim: legacy goal\n"
+            "success_criterion: legacy criterion\n"
+            "verification_method: manual\n", encoding="utf-8")
 
     # #748: stamp the workspace template version so the stale-workspace
     # gate (RC=5) passes — these tests are about resume's delegation

--- a/tests/test_kunglao_upgrade_726.py
+++ b/tests/test_kunglao_upgrade_726.py
@@ -102,6 +102,12 @@ def synth_v012_ws(tmp: Path) -> Path:
     write_hook_state(ws, active_hooks=["active_intervention"],
                      phase="IDLE", user_override={},
                      extra={"state": "active"})
+    # the three required intake answers (present: the tests below pin
+    # migration semantics, not the anchor interview)
+    (ws / "task_spec.yaml").write_text(
+        "goal_verbatim: legacy goal\n"
+        "success_criterion: legacy criterion\n"
+        "verification_method: manual\n", encoding="utf-8")
     return ws
 
 

--- a/tests/test_oracle_anchors.py
+++ b/tests/test_oracle_anchors.py
@@ -1,0 +1,580 @@
+# -*- coding: utf-8 -*-
+"""Contract tests for the oracle-anchor intake fields in task_spec.yaml.
+
+The init interview must collect three REQUIRED answers — the verbatim goal,
+the success criterion, and the verification method — and land them as
+first-class task_spec.yaml fields. Enforced faces:
+
+- validation is fail-closed: a blank field or an out-of-enum method is a
+  missing answer, never a guessed default;
+- the verification-method answer arms the replay-equivalence oracle's
+  declared-question set (the controlled-comparison admission/verdict face);
+- analysis entry refuses while any answer is missing;
+- a collected verbatim goal pre-fills the completion oracle's task_text.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import oracle_anchors as oa  # noqa: E402
+import replay_equivalence as req  # noqa: E402
+import template_version  # noqa: E402
+from _hooks_path import load_module_by_path  # noqa: E402
+from _factories import seed_bins  # noqa: E402
+
+kunglao_init = load_module_by_path("kunglao_init_oracle_anchors",
+                                   SCRIPTS / "kunglao-init.py")
+
+
+def _spec(**over) -> dict:
+    """A complete three-answer task_spec (primary_questions included so the
+    arming tests exercise real question ids)."""
+    doc = {
+        "primary_questions": [
+            {"id": "q1", "q": "does the sample decrypt the config?",
+             "need": "yes_no_with_evidence"},
+            {"id": "q2", "q": "which routine computes the checksum?",
+             "need": "yes_no_with_evidence"},
+        ],
+        "goal_verbatim": "recover the config decryption routine",
+        "success_criterion": "a standalone client replays every captured "
+                             "(input -> plaintext) pair byte-exact",
+        "verification_method": "reproduction",
+    }
+    doc.update(over)
+    return doc
+
+
+# ------------------------------------------------ required-field validation
+
+class TestRequiredValidation:
+    def test_empty_spec_reports_all_three(self):
+        assert oa.missing({}) == ["goal_verbatim", "success_criterion",
+                                  "verification_method"]
+
+    def test_blank_values_are_missing(self):
+        spec = _spec(goal_verbatim="   ", success_criterion="",
+                     verification_method="")
+        assert oa.missing(spec) == ["goal_verbatim", "success_criterion",
+                                    "verification_method"]
+
+    def test_non_string_values_are_missing(self):
+        spec = _spec(goal_verbatim=42, verification_method=["reproduction"])
+        assert oa.missing(spec) == ["goal_verbatim", "verification_method"]
+
+    def test_out_of_enum_method_is_missing(self):
+        """An unknown method is not an answer — the entry gate refuses rather
+        than adopting a silent default."""
+        assert oa.missing(_spec(verification_method="vibes")) == \
+            ["verification_method"]
+
+    def test_complete_spec_reports_nothing(self):
+        assert oa.missing(_spec()) == []
+
+    def test_method_options_are_the_four_declared_values(self):
+        assert oa.METHOD_OPTIONS == ("reproduction", "replay-evidence",
+                                     "static", "manual")
+        assert oa.FIELDS == ("goal_verbatim", "success_criterion",
+                             "verification_method")
+
+
+# --------------------------------------------------------- spec round-trip
+
+class TestTaskSpecRoundTrip:
+    def test_apply_writes_the_three_fields(self, tmp_path):
+        ws = tmp_path
+        (ws / "task_spec.yaml").write_text(
+            yaml.safe_dump(_spec()), encoding="utf-8")
+        oa.apply(ws, _spec())
+        doc = yaml.safe_load((ws / "task_spec.yaml").read_text(
+            encoding="utf-8"))
+        for field in oa.FIELDS:
+            assert doc[field] == _spec()[field]
+
+    def test_apply_preserves_existing_user_keys(self, tmp_path):
+        ws = tmp_path
+        (ws / "task_spec.yaml").write_text(
+            yaml.safe_dump(_spec()), encoding="utf-8")
+        oa.apply(ws, _spec())
+        doc = yaml.safe_load((ws / "task_spec.yaml").read_text(
+            encoding="utf-8"))
+        assert [q["id"] for q in doc["primary_questions"]] == ["q1", "q2"]
+
+    def test_apply_creates_task_spec_when_absent(self, tmp_path):
+        ws = tmp_path
+        path = oa.apply(ws, _spec())
+        assert path == ws / "task_spec.yaml"
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert doc["verification_method"] == "reproduction"
+
+    def test_apply_never_clobbers_existing_answers(self, tmp_path):
+        ws = tmp_path
+        (ws / "task_spec.yaml").write_text(
+            yaml.safe_dump(_spec()), encoding="utf-8")
+        oa.apply(ws, _spec(goal_verbatim="a DIFFERENT goal"))
+        doc = yaml.safe_load((ws / "task_spec.yaml").read_text(
+            encoding="utf-8"))
+        assert doc["goal_verbatim"] == "recover the config decryption routine"
+
+    def test_load_view_tolerates_absent_and_corrupt_spec(self, tmp_path):
+        assert oa.load(tmp_path) == {}
+        (tmp_path / "task_spec.yaml").write_text(
+            "primary_questions: [ unclosed\n", encoding="utf-8")
+        assert oa.load(tmp_path) == {}
+        (tmp_path / "task_spec.yaml").write_text(
+            yaml.safe_dump(_spec()), encoding="utf-8")
+        assert oa.load(tmp_path)["goal_verbatim"] == \
+            "recover the config decryption routine"
+
+    def test_check_ws_reflects_the_workspace(self, tmp_path):
+        ok, missing = oa.check_ws(tmp_path)
+        assert not ok
+        assert missing == list(oa.FIELDS)
+        (tmp_path / "task_spec.yaml").write_text(
+            yaml.safe_dump(_spec()), encoding="utf-8")
+        ok, missing = oa.check_ws(tmp_path)
+        assert ok and missing == []
+
+
+# --------------------------------------------- declared-bit oracle arming
+
+class TestDeclaredBitArming:
+    def test_reproduction_method_arms_every_question(self):
+        qids = req.declared_reproduction_qids(_spec())
+        assert qids == {"q1", "q2"}
+
+    def test_replay_evidence_method_arms_every_question(self):
+        qids = req.declared_reproduction_qids(
+            _spec(verification_method="replay-evidence"))
+        assert qids == {"q1", "q2"}
+
+    def test_static_and_manual_arms_nothing(self):
+        for method in ("static", "manual"):
+            assert req.declared_reproduction_qids(
+                _spec(verification_method=method)) == set()
+
+    def test_absent_method_keeps_per_question_bits_only(self):
+        """A spec without the method answer behaves exactly as before: only
+        explicitly flagged questions carry the bit."""
+        spec = {"primary_questions": [{"id": "q1", "reproduction": True},
+                                      {"id": "q2"}]}
+        assert req.declared_reproduction_qids(spec) == {"q1"}
+
+    def test_armed_verdict_refuses_unevidenced_claim(self, tmp_path):
+        (tmp_path / "task_spec.yaml").write_text(
+            yaml.safe_dump(_spec(verification_method="reproduction")),
+            encoding="utf-8")
+        claim = {"id": "C-1", "answers_question": "q1"}
+        ok, reason = req.equivalence_verdict(tmp_path, claim)
+        assert not ok
+        assert reason.strip()
+
+    def test_armed_verdict_passes_with_valid_artifact(self, tmp_path):
+        (tmp_path / "task_spec.yaml").write_text(
+            yaml.safe_dump(_spec(verification_method="replay-evidence")),
+            encoding="utf-8")
+        evidence = tmp_path / "evidence"
+        evidence.mkdir()
+        artifact = {
+            "schema": req.SCHEMA_ID,
+            "claim_id": "C-1",
+            "captured_inputs": ["cap-01", "cap-02", "cap-03", "cap-04"],
+            "variables": {"nonce": [0, 1], "param": ["x", "y"]},
+            "pairs": [
+                {"input_id": "cap-01", "inputs": {"nonce": 0, "param": "x"},
+                 "ref_output": "out-0", "repro_output": "out-0",
+                 "byte_equal": True},
+                {"input_id": "cap-02", "inputs": {"nonce": 0, "param": "y"},
+                 "ref_output": "out-1", "repro_output": "out-1",
+                 "byte_equal": True},
+                {"input_id": "cap-03", "inputs": {"nonce": 1, "param": "x"},
+                 "ref_output": "out-2", "repro_output": "out-2",
+                 "byte_equal": True},
+                {"input_id": "cap-04", "inputs": {"nonce": 1, "param": "y"},
+                 "ref_output": "out-3", "repro_output": "out-3",
+                 "byte_equal": True},
+            ],
+        }
+        (evidence / "replay-C-1.json").write_text(
+            json.dumps(artifact, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8")
+        claim = {"id": "C-1", "answers_question": "q1"}
+        ok, reason = req.equivalence_verdict(tmp_path, claim)
+        assert ok, reason
+
+    def test_unarmed_method_leaves_plain_claims_untouched(self, tmp_path):
+        (tmp_path / "task_spec.yaml").write_text(
+            yaml.safe_dump(_spec(verification_method="manual")),
+            encoding="utf-8")
+        claim = {"id": "C-1", "answers_question": "q1"}
+        ok, reason = req.equivalence_verdict(tmp_path, claim)
+        assert ok and reason == ""
+
+
+# ------------------------------------------------------ analysis-entry gate
+
+def _entry_ws(tmp_path: Path) -> Path:
+    """A workspace whose template stamp is current, so the stale gate passes
+    and the anchor gate is what decides."""
+    ws = tmp_path / "ws"
+    ws.mkdir(parents=True)
+    stamp = template_version.stamp_line(
+        template_version.read_skill_version())
+    (ws / "CLAUDE.md").write_text(f"{stamp}\n", encoding="utf-8")
+    return ws
+
+
+class TestAnalysisEntryGate:
+    def test_rc_constant_is_seven(self):
+        import kunglao
+        assert kunglao.RC_ORACLE_ANCHORS_MISSING == 7
+
+    def test_entry_refuses_while_answers_missing(self, tmp_path, capsys):
+        ws = _entry_ws(tmp_path)
+        import kunglao
+        rc = kunglao.cmd_analysis(argparse.Namespace(workspace=str(ws)))
+        out = capsys.readouterr()
+        assert rc == 7
+        for field in oa.FIELDS:
+            assert field in out.err
+
+    def test_entry_proceeds_past_anchor_gate_when_answered(
+            self, tmp_path, capsys):
+        ws = _entry_ws(tmp_path)
+        (ws / "task_spec.yaml").write_text(
+            yaml.safe_dump(_spec()), encoding="utf-8")
+        import kunglao
+        rc = kunglao.cmd_analysis(argparse.Namespace(workspace=str(ws)))
+        capsys.readouterr()
+        # The anchor gate passed; the heartbeat verify gate now decides.
+        assert rc == kunglao.RC_HEARTBEAT_VERIFY_FAIL
+
+
+# ------------------------------------------- completion-oracle consumption
+
+class TestOraclePrefill:
+    def test_skeleton_prefills_task_text_from_goal(self, tmp_path):
+        assert kunglao_init.write_task_oracle_skeleton(
+            tmp_path, task_text="recover the config decryption routine")
+        doc = yaml.safe_load((tmp_path / "task-oracle.yaml").read_text(
+            encoding="utf-8"))
+        assert doc["task_text"] == "recover the config decryption routine"
+
+    def test_skeleton_keeps_marker_without_goal(self, tmp_path):
+        kunglao_init.write_task_oracle_skeleton(tmp_path)
+        doc = yaml.safe_load((tmp_path / "task-oracle.yaml").read_text(
+            encoding="utf-8"))
+        assert doc["task_text"] == kunglao_init.ORACLE_BACKFILL_MARKER
+
+    def test_existing_oracle_is_never_clobbered(self, tmp_path):
+        target = tmp_path / "task-oracle.yaml"
+        target.write_text("task_text: keep me\n", encoding="utf-8")
+        assert not kunglao_init.write_task_oracle_skeleton(
+            tmp_path, task_text="a fresh goal")
+        assert "keep me" in target.read_text(encoding="utf-8")
+
+
+# ------------------------------------------ boundary validations (owner scope)
+
+def _spec_without(*fields: str) -> dict:
+    doc = _spec()
+    for field in fields:
+        doc.pop(field)
+    return doc
+
+
+class TestBoundaryValidations:
+    @pytest.fixture
+    def entry_ws(self, tmp_path) -> Path:
+        return _entry_ws(tmp_path)
+
+    def _write_spec(self, ws: Path, doc: dict | None) -> None:
+        if doc is None:
+            (ws / "task_spec.yaml").unlink(missing_ok=True)
+            return
+        (ws / "task_spec.yaml").write_text(
+            yaml.safe_dump(doc), encoding="utf-8")
+
+    def test_entry_rejects_each_missing_anchor(self, entry_ws, capsys):
+        import kunglao
+        for field in oa.FIELDS:
+            self._write_spec(entry_ws, _spec_without(field))
+            rc = kunglao.cmd_analysis(argparse.Namespace(
+                workspace=str(entry_ws)))
+            err = capsys.readouterr().err
+            assert rc == 7, f"{field}: expected refusal, got rc={rc}"
+            assert field in err, f"{field} not named in refusal: {err}"
+            capsys.readouterr()
+
+    def test_resume_rejects_missing_anchors(self, entry_ws, capsys):
+        import kunglao
+        self._write_spec(entry_ws, _spec_without("success_criterion"))
+        rc = kunglao.cmd_resume(argparse.Namespace(
+            workspace=str(entry_ws), json=False))
+        err = capsys.readouterr().err
+        assert rc == 7
+        assert "success_criterion" in err
+
+    def test_resume_proceeds_when_complete(self, entry_ws, capsys):
+        import kunglao
+        self._write_spec(entry_ws, _spec())
+        rc = kunglao.cmd_resume(argparse.Namespace(
+            workspace=str(entry_ws), json=False))
+        capsys.readouterr()
+        assert rc != 7
+
+    def test_entry_names_the_repair_path(self, entry_ws, capsys):
+        """A task_spec with fields missing is repairable in place: the
+        refusal names the re-entry command that fills only the gaps."""
+        import kunglao
+        self._write_spec(entry_ws, _spec_without("goal_verbatim"))
+        rc = kunglao.cmd_analysis(argparse.Namespace(
+            workspace=str(entry_ws)))
+        err = capsys.readouterr().err
+        assert rc == 7
+        assert "--resolve" in err and "--force" not in err
+
+    def test_corrupt_spec_asks_for_full_reinit(self, entry_ws, capsys):
+        """An unreadable contract is not repairable in place: the refusal
+        directs to the full re-init path instead."""
+        import kunglao
+        (entry_ws / "task_spec.yaml").write_text(
+            "primary_questions: [ unclosed\n", encoding="utf-8")
+        rc = kunglao.cmd_analysis(argparse.Namespace(
+            workspace=str(entry_ws)))
+        err = capsys.readouterr().err
+        assert rc == 7
+        assert "--force" in err, err
+
+def _run_init(ws: Path, extra: list[str]) -> subprocess.CompletedProcess:
+    """Hermetic init run: toolchain skipped, the host-exec ask answered
+    explicitly (non-interactive), profile writes pinned to a temp root."""
+    import os
+    argv = [sys.executable, str(SCRIPTS / "kunglao-init.py"), str(ws),
+            "--skip-toolchain", *extra,
+            "--host-exec-protection", "enabled",
+            "--profile-root", str(ws.parent / "profile-root")]
+    env = dict(os.environ)
+    env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "0"
+    env["PYTHONIOENCODING"] = "utf-8"
+    return subprocess.run(argv, capture_output=True, text=True,
+                          env=env, timeout=300, cwd=str(ROOT))
+
+
+# ------------------------------------------------ upgrade backfill (legacy)
+
+class TestUpgradeBackfill:
+    """A legacy workspace (initialized before the anchors existed) must not
+    deadlock: upgrade backfills the missing answers through the same
+    structured interview channel — analysis entry and resume then pass."""
+
+    def _current_ws(self, tmp_path: Path, spec: dict | None) -> Path:
+        import kunglao_upgrade as up
+        ws = tmp_path / "ws"
+        ws.mkdir(parents=True)
+        (ws / "CLAUDE.md").write_text(
+            template_version.stamp_line(
+                template_version.read_skill_version()) + "\n",
+            encoding="utf-8")
+        if spec is not None:
+            (ws / "task_spec.yaml").write_text(
+                yaml.safe_dump(spec), encoding="utf-8")
+        assert up._vkey(template_version.read_workspace_version(ws)) >= \
+            up._vkey(template_version.read_skill_version())
+        return ws
+
+    def test_upgrade_pends_and_elicits_for_legacy_spec(self, tmp_path,
+                                                       capsys):
+        import kunglao_upgrade as up
+        ws = self._current_ws(tmp_path, _spec_without(*oa.FIELDS))
+        items: list = []
+        rc = up.upgrade(ws, dry_run=False, items_out=items)
+        out = capsys.readouterr().out
+        assert rc == up.RC_ANCHORS_PENDING == 8
+        doc = json.loads(out.strip().splitlines()[-1])
+        ids = {d["decision_id"] for d in doc["decisions"]}
+        assert ids == set(oa.FIELDS)
+        assert any(i["name"] == "oracle_anchor_backfill" for i in items)
+
+    def test_upgrade_backfills_from_answers_then_gates_pass(self, tmp_path,
+                                                            capsys):
+        import kunglao_upgrade as up
+        ws = self._current_ws(tmp_path, _spec_without(*oa.FIELDS))
+        answers = {"goal_verbatim": "recover the license check",
+                   "success_criterion": "key matches the captured blob",
+                   "verification_method": "reproduction"}
+        rc = up.upgrade(ws, dry_run=False,
+                        items_out=[], resolve=answers)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "backfilled via interview" in out
+        ok, gaps, _state = oa.inspect(ws)
+        assert ok and gaps == []
+
+    def test_upgrade_reports_complete_without_reask(self, tmp_path, capsys):
+        import kunglao_upgrade as up
+        ws = self._current_ws(tmp_path, _spec())
+        rc = up.upgrade(ws, dry_run=False, items_out=[])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "anchors: complete" in out
+        assert '"decisions"' not in out
+
+    def test_upgrade_backfills_only_missing_fields(self, tmp_path, capsys):
+        import kunglao_upgrade as up
+        ws = self._current_ws(
+            tmp_path, _spec_without("success_criterion",
+                                    "verification_method"))
+        answers = {"goal_verbatim": "IGNORED existing goal",
+                   "verification_method": "static"}
+        rc = up.upgrade(ws, dry_run=False, items_out=[], resolve=answers)
+        capsys.readouterr()
+        assert rc == up.RC_ANCHORS_PENDING  # success_criterion still missing
+        import yaml as _yaml
+        doc = _yaml.safe_load((ws / "task_spec.yaml").read_text(
+            encoding="utf-8"))
+        assert doc["goal_verbatim"] == \
+            "recover the config decryption routine"  # never clobbered
+        assert doc["verification_method"] == "static"
+
+    def test_dry_run_reports_without_writing(self, tmp_path, capsys):
+        import kunglao_upgrade as up
+        ws = self._current_ws(tmp_path, _spec_without(*oa.FIELDS))
+        before = (ws / "task_spec.yaml").read_bytes()
+        rc = up.upgrade(ws, dry_run=True, items_out=[])
+        out = capsys.readouterr().out
+        assert rc == 0  # a dry run plans, never pends
+        assert "anchor" in out
+        assert (ws / "task_spec.yaml").read_bytes() == before
+
+    def test_json_status_names_anchor_pending(self):
+        import kunglao_upgrade as up
+        assert up.RC_ANCHORS_PENDING == 8
+
+# -------------------------------------------------- repair re-entry (init)
+
+class TestRepairReEntry:
+    def test_validate_values_rejects_bad_method(self):
+        with pytest.raises(ValueError):
+            oa.validate_values({"verification_method": "vibes"})
+        oa.validate_values({"verification_method": "static"})  # no raise
+
+    def test_repair_fills_only_missing_and_preserves_state(self, tmp_path):
+        """The re-entry fills ONLY the missing answers: an existing answer
+        survives a conflicting repair value, and the analysis state (the
+        claim register) is byte-identical across the repair run."""
+        ws = tmp_path / "ws"
+        seed_bins(ws)
+        (ws / "runs").mkdir()
+        (ws / "task_spec.yaml").write_text(
+            yaml.safe_dump(_spec_without("success_criterion",
+                                         "verification_method")),
+            encoding="utf-8")
+        r1 = _run_init(ws, ["--type", "windows"])
+        assert r1.returncode == 0, r1.stderr
+        register_before = (ws / "claim-register.yaml").read_bytes()
+        answers = tmp_path / "answers.json"
+        answers.write_text(json.dumps({
+            "goal_verbatim": "a CONFLICTING goal that must be ignored",
+            "success_criterion": "plaintext matches the app render",
+            "verification_method": "static",
+        }), encoding="utf-8")
+        r2 = _run_init(ws, ["--resolve", str(answers)])
+        assert r2.returncode == 0, r2.stderr
+        doc = yaml.safe_load((ws / "task_spec.yaml").read_text(
+            encoding="utf-8"))
+        assert doc["goal_verbatim"] == \
+            "recover the config decryption routine"  # never clobbered
+        assert doc["success_criterion"] == \
+            "plaintext matches the app render"
+        assert doc["verification_method"] == "static"
+        assert (ws / "claim-register.yaml").read_bytes() == \
+            register_before
+        assert "anchor repair complete" in r2.stdout
+
+    def test_repair_refuses_bad_method_value(self, tmp_path):
+        ws = tmp_path / "ws"
+        seed_bins(ws)
+        (ws / "runs").mkdir()
+        r1 = _run_init(ws, ["--type", "windows"])
+        assert r1.returncode == 0, r1.stderr
+        answers = tmp_path / "answers.json"
+        answers.write_text(json.dumps({
+            "verification_method": "vibes"}), encoding="utf-8")
+        r2 = _run_init(ws, ["--resolve", str(answers)])
+        assert r2.returncode != 0
+        assert "anchor repair refused" in r2.stderr
+
+    def test_repair_refused_on_corrupt_contract(self, tmp_path):
+        """An unreadable contract is not repairable in place: the re-entry
+        refuses without writing, the corrupt bytes survive untouched, and
+        the remediation names the full re-init path (in-place repair on a
+        corrupt file would silently replace the whole intake record with
+        just the three anchors)."""
+        ws = tmp_path / "ws"
+        seed_bins(ws)
+        (ws / "runs").mkdir()
+        r1 = _run_init(ws, ["--type", "windows"])
+        assert r1.returncode == 0, r1.stderr
+        corrupt = "primary_questions: [ unclosed\n"
+        (ws / "task_spec.yaml").write_text(corrupt, encoding="utf-8")
+        answers = tmp_path / "answers.json"
+        answers.write_text(json.dumps({
+            "goal_verbatim": "g",
+            "success_criterion": "s",
+            "verification_method": "manual",
+        }), encoding="utf-8")
+        r2 = _run_init(ws, ["--resolve", str(answers)])
+        assert r2.returncode != 0
+        assert "--force" in r2.stderr, r2.stderr
+        assert (ws / "task_spec.yaml").read_text(encoding="utf-8") == corrupt
+
+    def test_repair_reports_still_missing(self, tmp_path):
+        ws = tmp_path / "ws"
+        seed_bins(ws)
+        (ws / "runs").mkdir()
+        r1 = _run_init(ws, ["--type", "windows"])
+        assert r1.returncode == 0, r1.stderr
+        answers = tmp_path / "answers.json"
+        answers.write_text(json.dumps({
+            "verification_method": "manual"}), encoding="utf-8")
+        r2 = _run_init(ws, ["--resolve", str(answers)])
+        assert r2.returncode == 0, r2.stderr
+        assert "still missing" in r2.stderr
+
+
+class TestInitEndToEnd:
+    @pytest.fixture
+    def fresh_ws(self, tmp_path) -> Path:
+        ws = tmp_path / "ws"
+        seed_bins(ws)
+        (ws / "runs").mkdir()
+        return ws
+
+    def test_init_prints_reminder_while_answers_missing(self, fresh_ws):
+        r = _run_init(fresh_ws, ["--type", "windows"])
+        assert r.returncode == 0, r.stderr
+        assert "anchors incomplete" in r.stdout, r.stdout
+
+    def test_init_prefills_oracle_and_skips_reminder_when_answered(
+            self, fresh_ws):
+        (fresh_ws / "task_spec.yaml").write_text(
+            yaml.safe_dump(_spec()), encoding="utf-8")
+        r = _run_init(fresh_ws, ["--type", "windows"])
+        assert r.returncode == 0, r.stderr
+        assert "anchors incomplete" not in r.stdout
+        doc = yaml.safe_load((fresh_ws / "task-oracle.yaml").read_text(
+            encoding="utf-8"))
+        assert doc["task_text"] == "recover the config decryption routine"

--- a/tests/test_runtime_version_758.py
+++ b/tests/test_runtime_version_758.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import pytest
 
+from _factories import seed_oracle_anchors  # noqa: E402
+
 REPO = Path(__file__).resolve().parents[1]
 SCRIPTS = REPO / "scripts"
 
@@ -98,6 +100,7 @@ def _mini_ws(tmp_path: Path) -> Path:
         stamp + "\nclaims: []\n# [initialized] state_hash=abc\n", encoding="utf-8")
     (ws / "analysis_state.txt").write_text(
         "state_hash=abc\nproject_type=windows\n", encoding="utf-8")
+    seed_oracle_anchors(ws)
     return ws
 
 
@@ -167,6 +170,7 @@ def _carriers(tmp_path: Path) -> Path:
         old + "\n# facts\nF001 | PROVEN | C-1 | keep me\n", encoding="utf-8")
     (ws / "claim-register.yaml").write_text(
         old + "\nclaims: []\n# [initialized] 2026-08-01\n", encoding="utf-8")
+    seed_oracle_anchors(ws)
     return ws
 
 

--- a/tests/test_upgrade_safety_753.py
+++ b/tests/test_upgrade_safety_753.py
@@ -111,6 +111,12 @@ def synth_v012_ws(tmp: Path) -> Path:
     write_hook_state(ws, active_hooks=["active_intervention"],
                      phase="IDLE", user_override={},
                      extra={"state": "active"})
+    # the three required intake answers (present: the tests below pin
+    # migration semantics, not the anchor interview)
+    (ws / "task_spec.yaml").write_text(
+        "goal_verbatim: legacy goal\n"
+        "success_criterion: legacy criterion\n"
+        "verification_method: manual\n", encoding="utf-8")
     return ws
 
 


### PR DESCRIPTION
Closes #191

## Summary

The init intake interview now explicitly elicits the three oracle-grade elements that steer the whole loop — the user's **goal (verbatim)**, the **success criterion** (what counts as done), and the **verification method** (reproduction / replay-evidence / static / manual) — and lands them as first-class `task_spec.yaml` fields consumed by the completion oracle and the replay-equivalence admission/verdict teeth. Unanswered anchors refuse analysis entry and resume (rc=7); nothing is ever guessed.

### What already existed vs the delta

Existed: the needs-first agent interview (primary_questions / scope / constraints / depth / success_criteria into task_spec.yaml before the toolchain gate), the `--resolve answers.json` exit-8 pending channel, the task-oracle skeleton with its backfill marker + D6 refuse, and the per-question `reproduction: true` / per-claim `replay_evidence` declared bits. The three anchors themselves had zero hits anywhere in the tree.

Added:
- `scripts/oracle_anchors.py` — fail-closed validation (blank / non-string / out-of-enum method = missing), state-aware contract read (absent / corrupt / incomplete / complete), non-clobbering merge-apply, enum validation for repair values
- **Analysis-entry + resume gates** (`kunglao analysis` / `kunglao resume`, rc=7): two remediation states — repair in place via the init re-entry (only missing fields filled) vs full re-init (`--force`) for an unreadable contract
- **kunglao-init consumption**: task-oracle `task_text` pre-filled from the verbatim goal at scaffold time; stdout reminder while the interview is incomplete; anchor repair re-entry on the resume branch
- **Replay-oracle arming**: `declared_reproduction_qids` unions the method answer — `reproduction` / `replay-evidence` declare every primary question for the controlled-comparison teeth; `static` / `manual` and the absent field keep the legacy behavior exactly
- **Upgrade backfill (deadlock fix)**: both upgrade success paths detect missing anchors and elicit them through the same structured interview channel (pending JSON on stdout, rc=8, `--resolve` re-entry) — a legacy workspace can no longer be caught between the new gates and an upgrade that claims it is current. The completion report states anchor status explicitly (`anchors: complete` / `anchors: backfilled via interview`)
- **Corrupt-state guard (review HIGH fix)**: the init repair re-entry refuses on an unreadable contract (rc error, zero writes, names `--force`) — in-place merge would have silently replaced the whole intake record with just the three anchors
- **Surfaces**: task_spec template (+ README "How to state the task" interlink from the init prompt), `skills/init/SKILL.md`, `agents/kunglao-init-worker.md`, `skills/analysis/SKILL.md` (rc=7), `skills/upgrade/SKILL.md` (rc=8 + anchor status), main SKILL input contract, scripts inventory row

### Tests

43 new contract tests (RED-first): fail-closed validation, task_spec round-trip, declared-bit arming incl. verdict integration (unevidenced reproduction claim refused / valid artifact passes), entry + resume refusals per missing field, repair-path messaging, corrupt-contract refusal (init `--resolve` side and analysis-entry side), real-init subprocess end-to-end (reminder line, oracle pre-fill, repair fills only missing fields), upgrade backfill (pending elicit, backfill from answers, only-missing semantics, dry-run writes nothing, JSON status).

Fixtures for the upgrade/resume suites that pin non-anchor semantics were completed with an anchor-complete contract (no assertions weakened).

### Gates

- fast tier: 2963 passed / 5 skipped; integration tier green (a residual xdist-parallel failure cluster was reproduced only under a concurrently running suite and passes in isolation/sequential — recall 17/17, flaky cluster 106/106 sequential)
- comment-hygiene lint clean (660 files); ruff clean on all changed files (5 pre-existing baseline errors in untouched files)
- discovery Gate 9 ALL-PASS; ext-scan ok; deploy-manifest written + verified (410 entries); `release_receipt --check` rc=0
