### PR TITLE
fix: one batched recall child per dispatch — closes the #194 recall-injection CI flake

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -39,7 +39,7 @@ files:
   - src: hooks/recall_inject.py
     dest: .claude/hooks/recall_inject.py
     kind: hook
-    sha256: abe4212d35b8b16119d4045965ace827528e664f849ddf70cf7da840b604bd69
+    sha256: febe8906d5920b1eb20ed760d8a3e420364c38087aeac96b4f1629c74ace1c60
   - src: hooks/session_start.py
     dest: .claude/hooks/session_start.py
     kind: hook
@@ -675,7 +675,7 @@ files:
   - src: scripts/references_recall.py
     dest: .claude/scripts/references_recall.py
     kind: scaffold
-    sha256: 82132e68ee8ebf1ea0505cc07022539b6bded79b92a2fd552029035dfad81c06
+    sha256: 5fe601a7c4ad1488744907b9ebe47f9b740f2d53fd3394289acf2db572c70be6
   - src: scripts/refutation_propagate.py
     dest: .claude/scripts/refutation_propagate.py
     kind: scaffold

--- a/hooks/recall_inject.py
+++ b/hooks/recall_inject.py
@@ -18,9 +18,14 @@ Design (mirrors dispatch_gate / env_check_gate, inject-only):
     (dynamic-debugging scene / verify-static-vs-dynamic.md); tier 2 + default ->
     "static analysis" (disasm/static-analysis scene — "disasm" itself matches nothing
     in the index).
-  - Each query runs `python scripts/references_recall.py <query>` as a
-    subprocess (timeout 5s). FAIL_OPEN at every layer: any failure -> no
-    injection, exit 0 pass-through — recall must NEVER block dispatch.
+  - All queries of a dispatch run in ONE `references_recall.py --queries
+    <q1> <q2> ...` subprocess (timeout RECALL_BATCH_TIMEOUT). The layered
+    index is parsed once per dispatch, not once per query — the per-query
+    child made every query individually flake-prone under CI xdist
+    contention (#194: a child past its timeout is swallowed by fail-open
+    and the affected query silently contributes nothing). FAIL_OPEN at
+    every layer: any failure -> no injection, exit 0 pass-through — recall
+    must NEVER block dispatch.
   - On a match it emits the hookSpecificOutput.additionalContext JSON shape
     (same as dispatch_gate.py:137-142 / env_check_gate main()) with a
     "Before dispatching, read: <files>" guidance. rc is ALWAYS 0: this hook
@@ -52,7 +57,15 @@ from _path_hygiene import (  # #671 sys.path hygiene authority
 
 SKILL_DIR = Path(__file__).resolve().parent.parent  # kunglao-agent/
 RECALL_SCRIPT = SKILL_DIR / "scripts" / "references_recall.py"
-RECALL_TIMEOUT = 5.0          # recall must never hold dispatch hostage
+# #194: every recall subprocess is ONE batched child per dispatch — it
+# parses the layered index ONCE (the parse, not the scoring, is the cost;
+# ~2.5 s on a fast unloaded machine) and answers all queries. The former
+# per-query children (5 s each, 4-5 per dispatch) each re-paid that parse
+# and individually tipped past their timeout under CI xdist contention,
+# which fail-open swallowed into silently missing queries — the #194
+# recall-injection flake. One window with real headroom, bounded by the
+# old serial envelope (len(queries) x 5 s).
+RECALL_BATCH_TIMEOUT = 20.0
 FILES_PER_QUERY = 4           # top hits only — guidance stays compact;
 # four keeps the verification-method file reachable for VM-class claims
 # NOTE (#357): ranking below is token-overlap scoring, which is
@@ -191,22 +204,44 @@ def _parse_files(stdout: str) -> tuple[str, ...]:
     return tuple(files)
 
 
-def _run_recall(query: str, cwd: Path | None = None) -> tuple[int, str]:
-    """One recall query as a subprocess. Returns (rc, stdout). Any failure
-    (missing script, timeout, unreadable index) -> (rc != 0, '').
-    #814: passes --ws so workspace demotion multipliers close the loop."""
-    cmd = [sys.executable, str(RECALL_SCRIPT), query]
+_BATCH_QUERY_SEP = "# ==== query: "
+
+
+def _run_recall_batch(queries: list[str],
+                      cwd: Path | None = None) -> tuple[int, str]:
+    """#194: ALL of a dispatch's recall queries in ONE child subprocess
+    (`references_recall.py --queries ...`) — the layered index is parsed
+    once instead of once per query. Returns (rc, stdout); any failure
+    (missing script, timeout, usage error) -> (rc != 0, '')."""
+    if not queries:
+        return 0, ""
+    cmd = [sys.executable, str(RECALL_SCRIPT), "--queries", *queries]
     if cwd is not None:
         cmd += ["--ws", str(cwd)]
     try:
         r = subprocess.run(
             cmd,
             capture_output=True, text=True, encoding="utf-8", errors="replace",
-            cwd=str(cwd) if cwd else None, timeout=RECALL_TIMEOUT,
+            cwd=str(cwd) if cwd else None, timeout=RECALL_BATCH_TIMEOUT,
         )
         return r.returncode, r.stdout or ""
     except Exception:  # noqa: BLE001 — recall must NEVER block dispatch
         return 1, ""
+
+
+def _split_batch_stdout(stdout: str, queries: list[str]) -> dict[str, str]:
+    """Per-query stdout sections from a --queries batch run. Each section
+    starts at its exact `# ==== query: <q>` separator line; a query with
+    no section parses as empty (equivalent to no match)."""
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in stdout.splitlines():
+        if line.startswith(_BATCH_QUERY_SEP):
+            current = line[len(_BATCH_QUERY_SEP):].strip()
+            sections.setdefault(current, [])
+        elif current is not None:
+            sections[current].append(line)
+    return {q: "\n".join(sections.get(q, [])) for q in queries}
 
 
 def _utility_rerank(files: tuple[str, ...], ws: Path) -> tuple[str, ...]:
@@ -246,10 +281,18 @@ def recall_files(query: str, cwd: Path | None = None,
     face) and a tool-value table exists, the result is reranked by pooled tool
     utility. Callers without a workspace (failure_analysis_gate._failure_modes_recall)
     are structurally unaffected. Fail-open: no table / corrupt table / any
-    error -> the original query-match order."""
-    runner = recall_runner if recall_runner is not None else _run_recall
+    error -> the original query-match order.
+
+    #194: the runner-less subprocess path rides the batch face too (one
+    index parse, RECALL_BATCH_TIMEOUT window) — the standalone 5 s per-query
+    child is gone; its tight window was the other half of the #194 flake
+    (failure_analysis_gate's single recall query timed out under the same
+    CI contention). An injected recall_runner keeps its exact per-query
+    contract."""
+    if recall_runner is None:
+        return recall_files_batch([query], cwd=cwd)[0]
     try:
-        rc, stdout = runner(query)
+        rc, stdout = recall_runner(query)
     except Exception:  # noqa: BLE001 — FAIL_OPEN at every layer
         return ()
     if rc != 0 or not stdout:
@@ -258,6 +301,42 @@ def recall_files(query: str, cwd: Path | None = None,
     if cwd is not None:
         files = _utility_rerank(files, Path(cwd))
     return tuple(files)
+
+
+def recall_files_batch(queries: list[str], cwd: Path | None = None,
+                       recall_runner=None) -> list[tuple[str, ...]]:
+    """#194: per-query file tuples for one dispatch, answered by ONE
+    references_recall.py child (`--queries` batch face — the layered index
+    is parsed once, not once per query). The per-query subprocess was the
+    #194 flake: every child re-parsed the full index and individually
+    flirted with its timeout under CI xdist contention, and fail-open then
+    silently dropped whole queries (pinned doc-set assertions flapped with
+    a different failing membership every run).
+
+    Contract:
+      - recall_runner injected (pure tests, sibling callers): delegated to
+        the per-query recall_files path — one runner call per query, same
+        shapes as before.
+      - no runner: one batched child; rc != 0 or empty stdout fails open
+        for the whole dispatch (all tuples empty) — same failure semantics
+        the per-query path had, now at dispatch granularity.
+      - rerank: when cwd is supplied, each non-empty query result is
+        utility-reranked exactly like recall_files does.
+    """
+    if recall_runner is not None:
+        return [recall_files(q, cwd=cwd, recall_runner=recall_runner)
+                for q in queries]
+    rc, stdout = _run_recall_batch(queries, cwd)
+    if rc != 0 or not stdout:
+        return [() for _ in queries]
+    sections = _split_batch_stdout(stdout, queries)
+    out: list[tuple[str, ...]] = []
+    for q in queries:
+        files = _parse_files(sections.get(q, ""))
+        if cwd is not None and files:
+            files = _utility_rerank(files, Path(cwd))
+        out.append(files)
+    return out
 
 
 def _guidance(queries: list[str], files: list[str]) -> str:
@@ -333,8 +412,10 @@ def evaluate(payload: dict, recall_runner=None) -> tuple[int, str, str | None]:
 
     files: list[str] = []
     seen: set[str] = set()
-    for query in queries:
-        for f in recall_files(query, cwd=ws, recall_runner=recall_runner)[:FILES_PER_QUERY]:
+    per_query = recall_files_batch(queries, cwd=ws,
+                                   recall_runner=recall_runner)
+    for batch_files in per_query:
+        for f in batch_files[:FILES_PER_QUERY]:
             if f not in seen:
                 seen.add(f)
                 files.append(f)

--- a/scripts/references_recall.py
+++ b/scripts/references_recall.py
@@ -61,6 +61,7 @@ _HEADER_CELLS = {"文件", "场景", "file", "files", "domain", "scenario", "pur
 
 USAGE = (
     "Usage: references_recall.py <query>\n"
+    "       references_recall.py --queries <query> [<query> ...] [--ws <ws>]\n"
     "       references_recall.py --list-categories\n"
     "       references_recall.py --scene-map\n"
     "       references_recall.py --joint <workspace> [--joint-limit N]\n"
@@ -967,6 +968,40 @@ def main(argv: list[str]) -> int:
             return 1
         print_result(result, entries)
         return 0
+
+    # #194: batch face — ONE index parse answers N queries. The per-query
+    # CLI (above) re-parses the whole layered index for every invocation
+    # (~2.5 s each before scoring a token); hooks/recall_inject used to pay
+    # that per query per dispatch, putting every child individually inside
+    # reach of its subprocess timeout under CI xdist contention (the #194
+    # recall-injection flake). Output is per-query sections, each introduced
+    # by an exact `# ==== query: <q>` separator line followed by that
+    # query's normal print_result/print_no_match block, so the caller can
+    # split deterministically. rc: 0 = any query matched, 1 = none, 2 =
+    # usage error.
+    if argv[1] == "--queries":
+        rest = argv[2:]
+        ws_arg = None
+        if "--ws" in rest:
+            i = rest.index("--ws")
+            if i + 1 < len(rest):
+                ws_arg = Path(rest[i + 1])
+                rest = rest[:i] + rest[i + 2:]
+        queries = [q for q in rest if q]
+        if not queries:
+            print(USAGE, file=sys.stderr)
+            return 2
+        demotions = demotion_map(ws_arg) if ws_arg else None
+        any_match = False
+        for q in queries:
+            print(f"# ==== query: {q}")
+            result = recall(entries, scenes, q, demotions=demotions)
+            if result.kind == "none":
+                print_no_match(q, entries)
+            else:
+                any_match = True
+                print_result(result, entries)
+        return 0 if any_match else 1
 
     # #814: optional --ws <path> → demotion 乘子闭环进打分
     ws_arg = None

--- a/scripts/references_recall.py
+++ b/scripts/references_recall.py
@@ -969,12 +969,12 @@ def main(argv: list[str]) -> int:
         print_result(result, entries)
         return 0
 
-    # #194: batch face — ONE index parse answers N queries. The per-query
+    # Batch face — ONE index parse answers N queries. The per-query
     # CLI (above) re-parses the whole layered index for every invocation
     # (~2.5 s each before scoring a token); hooks/recall_inject used to pay
     # that per query per dispatch, putting every child individually inside
-    # reach of its subprocess timeout under CI xdist contention (the #194
-    # recall-injection flake). Output is per-query sections, each introduced
+    # reach of its subprocess timeout under CI xdist contention (the
+    # recall-injection CI flake). Output is per-query sections, each introduced
     # by an exact `# ==== query: <q>` separator line followed by that
     # query's normal print_result/print_no_match block, so the caller can
     # split deterministically. rc: 0 = any query matched, 1 = none, 2 =

--- a/tests/test_recall_inject.py
+++ b/tests/test_recall_inject.py
@@ -175,9 +175,9 @@ def test_recall_partial_match_keeps_matched_files(tmp_path):
     assert ctx and "dynamic-re-tool-priority.md" in ctx
 
 
-# ---- #194: one recall child per dispatch, not one per query ----
+# ---- one recall child per dispatch, not one per query ----
 #
-# Issue #194: evaluate() spawned one references_recall.py subprocess PER
+# Issue 194: evaluate() spawned one references_recall.py subprocess PER
 # QUERY. Every child re-parses the whole layered index (~2.5 s on an
 # unloaded fast machine; slower on the CI runner), so each of the 4-5
 # queries per dispatch individually flirted with the 5 s RECALL_TIMEOUT
@@ -191,7 +191,7 @@ def test_recall_partial_match_keeps_matched_files(tmp_path):
 
 
 def test_batch_timeout_is_a_single_bounded_hostage_window():
-    """#194: the batched call has its own budget — ONE bounded window per
+    """The batched call has its own budget — ONE bounded window per
     dispatch, never per-query. The budget must give the single index parse
     real CI headroom (>= 15 s); no per-query 5 s window may remain, since
     that tight window was the guillotine the flake tripped."""
@@ -205,7 +205,7 @@ def test_batch_timeout_is_a_single_bounded_hostage_window():
 
 
 def test_all_queries_answered_by_one_subprocess(tmp_path, monkeypatch):
-    """#194 core pin: a dispatch with N recall queries spawns exactly ONE
+    """Core pin: a dispatch with N recall queries spawns exactly ONE
     references_recall.py child (the index is parsed once), via the
     `--queries` batch face. (Pre-fix this spawned one child per query.)"""
     import subprocess as sp
@@ -233,7 +233,7 @@ def test_all_queries_answered_by_one_subprocess(tmp_path, monkeypatch):
 
 
 def test_batched_stdout_splits_per_query(tmp_path, monkeypatch):
-    """#194: the batched child answers each query in its own `# ====
+    """The batched child answers each query in its own `# ====
     query:` section; evaluate() must split and merge them exactly like the
     per-query path did (dedup, FILES_PER_QUERY per query, order kept)."""
     import recall_inject
@@ -269,7 +269,7 @@ def test_batched_stdout_splits_per_query(tmp_path, monkeypatch):
 
 
 def test_batch_child_failure_fails_open_all_queries(tmp_path, monkeypatch):
-    """#194: the single batched child dying (timeout/crash) fails open for
+    """The single batched child dying (timeout/crash) fails open for
     the whole dispatch — (0, '', None), never a raise. Same fail-open
     contract the per-query path had, now at dispatch granularity."""
     import subprocess as sp

--- a/tests/test_recall_inject.py
+++ b/tests/test_recall_inject.py
@@ -175,6 +175,117 @@ def test_recall_partial_match_keeps_matched_files(tmp_path):
     assert ctx and "dynamic-re-tool-priority.md" in ctx
 
 
+# ---- #194: one recall child per dispatch, not one per query ----
+#
+# Issue #194: evaluate() spawned one references_recall.py subprocess PER
+# QUERY. Every child re-parses the whole layered index (~2.5 s on an
+# unloaded fast machine; slower on the CI runner), so each of the 4-5
+# queries per dispatch individually flirted with the 5 s RECALL_TIMEOUT
+# guillotine. Under CI xdist contention individual children tipped past
+# 5 s, TimeoutExpired was swallowed by fail-open, the affected query
+# silently contributed nothing, and the pinned doc-set assertions flapped
+# with a different failing membership every run (same sha PASS and FAIL
+# minutes apart). Mechanism fix: ONE batched child parses the index once
+# and answers all queries; the injected recall_runner contract (fake
+# runners called once per query) is preserved for pure tests.
+
+
+def test_batch_timeout_is_a_single_bounded_hostage_window():
+    """#194: the batched call has its own budget — ONE bounded window per
+    dispatch, never per-query. The budget must give the single index parse
+    real CI headroom (>= 15 s); no per-query 5 s window may remain, since
+    that tight window was the guillotine the flake tripped."""
+    import recall_inject
+
+    assert recall_inject.RECALL_BATCH_TIMEOUT >= 15, (
+        "batched recall needs one window with real headroom, not 4-5 tight "
+        "per-query windows")
+    assert not hasattr(recall_inject, "RECALL_TIMEOUT"), (
+        "the per-query 5 s guillotine must stay retired")
+
+
+def test_all_queries_answered_by_one_subprocess(tmp_path, monkeypatch):
+    """#194 core pin: a dispatch with N recall queries spawns exactly ONE
+    references_recall.py child (the index is parsed once), via the
+    `--queries` batch face. (Pre-fix this spawned one child per query.)"""
+    import subprocess as sp
+
+    import recall_inject
+
+    ws = _kunglao_ws(tmp_path)
+    spawns = []
+
+    real_run = sp.run
+
+    def counting_run(cmd, **kw):
+        spawns.append(list(cmd))
+        return real_run(cmd, **kw)
+
+    monkeypatch.setattr(recall_inject.subprocess, "run", counting_run)
+    rc, stderr, ctx = evaluate(_payload(ws, VM_CLAIM))
+    assert rc == 0 and stderr == "" and ctx
+    assert len(spawns) == 1, (
+        f"one dispatch = one recall child; got {len(spawns)}: {spawns}")
+    assert "--queries" in spawns[0], (
+        f"child must use the --queries batch face: {spawns[0]}")
+    assert "vm" in spawns[0] and "dynamic" in spawns[0], (
+        "every query must travel in the single child")
+
+
+def test_batched_stdout_splits_per_query(tmp_path, monkeypatch):
+    """#194: the batched child answers each query in its own `# ====
+    query:` section; evaluate() must split and merge them exactly like the
+    per-query path did (dedup, FILES_PER_QUERY per query, order kept)."""
+    import recall_inject
+
+    ws = _kunglao_ws(tmp_path)
+
+    canned = (
+        "# ==== query: vm\n"
+        "# references recall: vm — 1 file(s)\n"
+        "orchestration/dynamic-re-tool-priority.md | a | b | c\n"
+        "# ==== query: dynamic\n"
+        "# references recall: dynamic — 2 file(s)\n"
+        "re-library/tools/dynamic/tools-dynamic.md | a | b | c\n"
+        "orchestration/verify-static-vs-dynamic.md | a | b | c\n"
+    )
+
+    class Done:
+        returncode = 0
+        stdout = canned
+        stderr = ""
+
+    def fake_run(cmd, **kw):
+        assert "--queries" in cmd, f"batch face expected: {cmd}"
+        return Done()
+
+    monkeypatch.setattr(recall_inject.subprocess, "run", fake_run)
+    rc, stderr, ctx = evaluate(_payload(ws, VM_CLAIM))
+    assert rc == 0 and stderr == ""
+    assert ctx, "batched stdout must still inject"
+    for expected in ("dynamic-re-tool-priority.md", "tools-dynamic.md",
+                     "verify-static-vs-dynamic.md"):
+        assert expected in ctx, f"{expected} missing from batched injection"
+
+
+def test_batch_child_failure_fails_open_all_queries(tmp_path, monkeypatch):
+    """#194: the single batched child dying (timeout/crash) fails open for
+    the whole dispatch — (0, '', None), never a raise. Same fail-open
+    contract the per-query path had, now at dispatch granularity."""
+    import subprocess as sp
+
+    import recall_inject
+
+    ws = _kunglao_ws(tmp_path)
+
+    def timeout_run(cmd, **kw):
+        raise sp.TimeoutExpired(cmd, 20.0)
+
+    monkeypatch.setattr(recall_inject.subprocess, "run", timeout_run)
+    rc, stderr, ctx = evaluate(_payload(ws, VM_CLAIM))
+    assert rc == 0 and stderr == "" and ctx is None
+
+
 # ---- silent on non-dispatch / non-kunglao payloads ----
 
 


### PR DESCRIPTION
## Summary

Closes #194. The integration leg (`Integration + slow tier (xdist parallel)`) flaked on the recall-injection family: same dev sha passing and failing minutes apart, with the failing-test membership shifting between runs (CI evidence: run 34296846291 FAIL / 34296846377 PASS on f0461aa; PR #193 rerun 34327562813 FAIL).

## Root cause

`hooks/recall_inject.evaluate` spawned ONE `references_recall.py` subprocess **per query**. Every child re-parses the whole layered index — `build_index` is ~2.5 s of the ~2.7 s child wall time on a fast unloaded machine (scoring is ~0.01 s), and CI runners are slower — so each of the 4-5 per-dispatch queries sat individually inside reach of its 5 s `RECALL_TIMEOUT`. Under CI xdist contention individual children tipped past the window; `subprocess.TimeoutExpired` is swallowed by the fail-open contract, and the affected query silently contributed nothing. The pinned doc-set assertions then flapped exactly as observed:

- `ctx is None` faces (all queries of that test timed out) — `test_default_t1_claim_still_gets_recall`, `test_redteam_dispatch_gets_failure_modes_injection`, `test_failure_gate_blocked_output_recalls_failure_modes`
- partial faces (one query timed out, its files missing while others survived) — `test_go_claim_recalls_languages_go` ("go" child died; the surviving "vm"/"dynamic" children filled ctx), `test_vm_claim_injects_recall_guidance` ("dynamic" child died), `test_web_risk_claim_injects_new_doc` ("risk control"/"crawler" children died, "static analysis" survived -> malware docs without `web-risk-control.md`)

Which queries timed out varies with scheduler luck -> shifting failing membership per run on the same sha. `failure_analysis_gate`'s single recall query rode the same tight 5 s window.

## Fix (mechanism level — isolation, no assertion weakening)

- `scripts/references_recall.py`: additive `--queries <q1> <q2> ...` batch face — ONE index parse answers N queries, each section under an exact `# ==== query: <q>` separator. Single-query CLI unchanged.
- `hooks/recall_inject.py`: `evaluate` answers a dispatch via `recall_files_batch` — one batched child with one bounded `RECALL_BATCH_TIMEOUT = 20` (at or below the old serial worst case `len(queries) x 5 s`, ~2-3x headroom over the contended CI parse). The 5 s per-query child is retired; `recall_files`' runner-less path rides the batch face too. Injected `recall_runner` keeps its exact per-query contract (pure tests unchanged and untouched). Fail-open preserved at dispatch granularity: batch child failure -> no injection, rc 0, never raises.

## TDD evidence

- RED (pre-fix, exact triggering arrangement): `nice -n 19 uv run python -m pytest tests/test_recall_inject.py tests/test_web_knowledge_761.py -n 2 --dist loadgroup -q` under 16 nice-0 CPU hogs -> **3 failed** with the same family members CI failed (`test_failure_gate_blocked_output_recalls_failure_modes`, `test_redteam_dispatch_gets_failure_modes_injection`, `test_web_risk_claim_injects_new_doc`); under 12 hogs -> **2 failed** (redteam + web-risk).
- New mechanism pins (written first, RED before the fix): `test_batch_timeout_is_a_single_bounded_hostage_window` (AttributeError pre-fix), `test_all_queries_answered_by_one_subprocess` (3 spawns pre-fix), `test_batched_stdout_splits_per_query`, `test_batch_child_failure_fails_open_all_queries`.
- GREEN: same family at the same 12-hog arrangement **3/3 passed**; recall-adjacent families (`test_recall_inject`, `test_web_knowledge_761`, `test_references_recall`, `test_recall_quality_814`, `test_references_index`) **115 passed**; failure-analysis families **29 passed**; full fast tier **2963 passed, 5 skipped**. ruff clean on all three touched files.

## Test plan

- [x] Recall-injection family green under the triggering arrangement, 3 consecutive runs
- [x] Full fast tier green locally (`-m "fast and not docs" -n 2`)
- [x] ruff clean
- [ ] CI integration leg green, 3 consecutive runs (watching)
