### PR TITLE
fix: recall answers in-process against a memoized index — closes the parse wall behind the CI flake

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -39,7 +39,7 @@ files:
   - src: hooks/recall_inject.py
     dest: .claude/hooks/recall_inject.py
     kind: hook
-    sha256: febe8906d5920b1eb20ed760d8a3e420364c38087aeac96b4f1629c74ace1c60
+    sha256: 9784d196a919460a3fde1bd4c451fb5b5bc8f2ac23b11b001ebd32aff69b8130
   - src: hooks/session_start.py
     dest: .claude/hooks/session_start.py
     kind: hook

--- a/hooks/recall_inject.py
+++ b/hooks/recall_inject.py
@@ -18,12 +18,18 @@ Design (mirrors dispatch_gate / env_check_gate, inject-only):
     (dynamic-debugging scene / verify-static-vs-dynamic.md); tier 2 + default ->
     "static analysis" (disasm/static-analysis scene — "disasm" itself matches nothing
     in the index).
-  - All queries of a dispatch run in ONE `references_recall.py --queries
-    <q1> <q2> ...` subprocess (timeout RECALL_BATCH_TIMEOUT). The layered
-    index is parsed once per dispatch, not once per query — the per-query
-    child made every query individually flake-prone under CI xdist
-    contention (#194: a child past its timeout is swallowed by fail-open
-    and the affected query silently contributes nothing). FAIL_OPEN at
+  - All queries of a dispatch are answered IN-PROCESS: the layered index
+    is parsed once per process and memoized (first recall in a process
+    pays ~2.5 s, every later query is milliseconds), and the per-query
+    file tuples come straight from the recall engine — no subprocess on
+    the fast path. History: per-query children re-parsed the index every
+    time and individually blew their wall-clock windows under CI xdist
+    contention (the recall-injection flake); even one batched child per
+    dispatch kept a window around a parse, and CI-class 2-4 core runners
+    pushed that parse to 10-30 s. A window around a parse is load-fragile
+    by construction; memoized in-process recall has no window to blow.
+    The batched child (`references_recall.py --queries`) survives as the
+    fail-open fallback when the in-process path cannot run. FAIL_OPEN at
     every layer: any failure -> no injection, exit 0 pass-through — recall
     must NEVER block dispatch.
   - On a match it emits the hookSpecificOutput.additionalContext JSON shape
@@ -57,15 +63,15 @@ from _path_hygiene import (  # #671 sys.path hygiene authority
 
 SKILL_DIR = Path(__file__).resolve().parent.parent  # kunglao-agent/
 RECALL_SCRIPT = SKILL_DIR / "scripts" / "references_recall.py"
-# #194: every recall subprocess is ONE batched child per dispatch — it
-# parses the layered index ONCE (the parse, not the scoring, is the cost;
-# ~2.5 s on a fast unloaded machine) and answers all queries. The former
-# per-query children (5 s each, 4-5 per dispatch) each re-paid that parse
-# and individually tipped past their timeout under CI xdist contention,
-# which fail-open swallowed into silently missing queries — the #194
-# recall-injection flake. One window with real headroom, bounded by the
-# old serial envelope (len(queries) x 5 s).
+# Fallback window for the batched child (see _run_recall_batch): the
+# fast path is in-process memoized recall with NO window; the child only
+# runs when the in-process path cannot. One window with real headroom,
+# bounded by the old serial envelope (len(queries) x 5 s).
 RECALL_BATCH_TIMEOUT = 20.0
+# Recall engine, loaded once per process; parsed index memoized per
+# (resolved path, mtime_ns, size) so a changed index file re-parses.
+_RECALL_MODULE = None
+_INDEX_CACHE: dict = {}
 FILES_PER_QUERY = 4           # top hits only — guidance stays compact;
 # four keeps the verification-method file reachable for VM-class claims
 # NOTE (#357): ranking below is token-overlap scoring, which is
@@ -244,6 +250,56 @@ def _split_batch_stdout(stdout: str, queries: list[str]) -> dict[str, str]:
     return {q: "\n".join(sections.get(q, [])) for q in queries}
 
 
+def _recall_module():
+    """The references_recall engine, loaded by explicit path once per
+    process (the loader understands the hooks/scripts module split; the
+    module object is memoized so repeated dispatches skip the import)."""
+    global _RECALL_MODULE
+    if _RECALL_MODULE is None:
+        _RECALL_MODULE = load_module_by_path(
+            "kunglao_references_recall", RECALL_SCRIPT)
+    return _RECALL_MODULE
+
+
+def _memoized_index(mod):
+    """Parsed layered index, memoized per (resolved path, mtime_ns, size).
+    The parse is the cost (~2.5 s CPU unloaded, 10-30 s on loaded CI-class
+    runners) — it must happen once per process, never once per dispatch
+    and never once per query. A stat change on the index file invalidates
+    the memo (tests and live index regeneration both rely on that)."""
+    path = mod.default_index_path()
+    st = path.stat()
+    key = (str(path.resolve()), st.st_mtime_ns, st.st_size)
+    idx = _INDEX_CACHE.get(key)
+    if idx is None:
+        idx = mod.build_index(path)
+        _INDEX_CACHE.clear()  # keep only the current generation
+        _INDEX_CACHE[key] = idx
+    return idx
+
+
+def _inprocess_batch(queries: list[str],
+                     cwd: Path | None = None) -> list[tuple[str, ...]]:
+    """All of a dispatch's queries answered IN-PROCESS against the
+    memoized index. Raises on any problem (missing module, unreadable
+    index, stat failure) — the caller owns the fail-open ladder."""
+    if not queries:
+        return []
+    mod = _recall_module()
+    idx = _memoized_index(mod)
+    entries, scenes = list(idx.entries), list(idx.scenes)
+    ws = Path(cwd) if cwd is not None else None
+    demotions = mod.demotion_map(ws) if ws is not None else None
+    out: list[tuple[str, ...]] = []
+    for q in queries:
+        result = mod.recall(entries, scenes, q, demotions=demotions)
+        files = tuple(result.files)
+        if ws is not None and files:
+            files = _utility_rerank(files, ws)
+        out.append(files)
+    return out
+
+
 def _utility_rerank(files: tuple[str, ...], ws: Path) -> tuple[str, ...]:
     """#881 wiring 2: post-recall utility rerank — recall was pure query-match
     with no value signal; reference docs whose filename names a tool with a
@@ -283,12 +339,10 @@ def recall_files(query: str, cwd: Path | None = None,
     are structurally unaffected. Fail-open: no table / corrupt table / any
     error -> the original query-match order.
 
-    #194: the runner-less subprocess path rides the batch face too (one
-    index parse, RECALL_BATCH_TIMEOUT window) — the standalone 5 s per-query
-    child is gone; its tight window was the other half of the #194 flake
-    (failure_analysis_gate's single recall query timed out under the same
-    CI contention). An injected recall_runner keeps its exact per-query
-    contract."""
+    #194: the runner-less path rides the in-process memoized face (one
+    parse per process, no window); the batched child is only the
+    fail-open fallback. An injected recall_runner keeps its exact
+    per-query contract."""
     if recall_runner is None:
         return recall_files_batch([query], cwd=cwd)[0]
     try:
@@ -305,27 +359,29 @@ def recall_files(query: str, cwd: Path | None = None,
 
 def recall_files_batch(queries: list[str], cwd: Path | None = None,
                        recall_runner=None) -> list[tuple[str, ...]]:
-    """#194: per-query file tuples for one dispatch, answered by ONE
-    references_recall.py child (`--queries` batch face — the layered index
-    is parsed once, not once per query). The per-query subprocess was the
-    #194 flake: every child re-parsed the full index and individually
-    flirted with its timeout under CI xdist contention, and fail-open then
-    silently dropped whole queries (pinned doc-set assertions flapped with
-    a different failing membership every run).
-
-    Contract:
+    """Per-query file tuples for one dispatch. Fast path: IN-PROCESS
+    against the memoized layered index — the parse happens once per
+    process, every later dispatch is milliseconds, and no subprocess is
+    spawned (a wall-clock window around a parse is load-fragile by
+    construction; the batched child's window was exactly that, and it is
+    what kept the flake alive on CI-class runners). Fail-open ladder:
       - recall_runner injected (pure tests, sibling callers): delegated to
         the per-query recall_files path — one runner call per query, same
         shapes as before.
-      - no runner: one batched child; rc != 0 or empty stdout fails open
-        for the whole dispatch (all tuples empty) — same failure semantics
-        the per-query path had, now at dispatch granularity.
+      - no runner: in-process first; if that raises for any reason, fall
+        back to the batched child (`--queries`, RECALL_BATCH_TIMEOUT);
+        rc != 0 or empty stdout there -> all tuples empty (no injection),
+        rc stays 0, never a raise.
       - rerank: when cwd is supplied, each non-empty query result is
         utility-reranked exactly like recall_files does.
     """
     if recall_runner is not None:
         return [recall_files(q, cwd=cwd, recall_runner=recall_runner)
                 for q in queries]
+    try:
+        return _inprocess_batch(queries, cwd)
+    except Exception:  # noqa: BLE001 — fail-open ladder: child fallback next
+        pass
     rc, stdout = _run_recall_batch(queries, cwd)
     if rc != 0 or not stdout:
         return [() for _ in queries]

--- a/tests/test_recall_inject.py
+++ b/tests/test_recall_inject.py
@@ -175,67 +175,177 @@ def test_recall_partial_match_keeps_matched_files(tmp_path):
     assert ctx and "dynamic-re-tool-priority.md" in ctx
 
 
-# ---- one recall child per dispatch, not one per query ----
+# ---- recall parses the index ONCE per process, in-process ----
 #
-# Issue 194: evaluate() spawned one references_recall.py subprocess PER
-# QUERY. Every child re-parses the whole layered index (~2.5 s on an
-# unloaded fast machine; slower on the CI runner), so each of the 4-5
-# queries per dispatch individually flirted with the 5 s RECALL_TIMEOUT
-# guillotine. Under CI xdist contention individual children tipped past
-# 5 s, TimeoutExpired was swallowed by fail-open, the affected query
-# silently contributed nothing, and the pinned doc-set assertions flapped
-# with a different failing membership every run (same sha PASS and FAIL
-# minutes apart). Mechanism fix: ONE batched child parses the index once
-# and answers all queries; the injected recall_runner contract (fake
-# runners called once per query) is preserved for pure tests.
+# Issue 194, iteration 2. The first fix batched all queries of a dispatch
+# into one child, but the child still re-parsed the whole layered index
+# (~2.5 s CPU unloaded; measured 7-9 s under a local 4-worker storm and
+# 10-30 s on CI-class 2-4 core runners), so any wall-clock window around
+# the child stayed load-fragile. The mechanism fix is to parse the index
+# IN-PROCESS and memoize it: the first recall in a process pays the parse
+# once, every later query is milliseconds, and no recall child is spawned
+# on the fast path at all (the batched child survives only as the
+# fail-open fallback when the in-process path cannot run). The injected
+# recall_runner contract (fake runners called once per query) is
+# preserved for pure tests.
+
+_RECALL_SCRIPT_MARK = "references_recall"
+
+
+def _count_recall_children(recall_inject, monkeypatch):
+    """Monkeypatch subprocess.run to record only references_recall.py
+    child spawns (other incidental spawns, e.g. the git rev-parse the
+    trace logger makes, must not pollute the count)."""
+    import subprocess as sp
+
+    spawns = []
+    real_run = sp.run
+
+    def counting_run(cmd, **kw):
+        if any(_RECALL_SCRIPT_MARK in str(part) for part in cmd):
+            spawns.append(list(cmd))
+        return real_run(cmd, **kw)
+
+    monkeypatch.setattr(recall_inject.subprocess, "run", counting_run)
+    return spawns
+
+
+def _count_index_parses(recall_inject, monkeypatch):
+    """Monkeypatch build_index on the loaded recall module and clear the
+    memoization cache so a test observes fresh parses. Returns the parse
+    count list."""
+    mod = recall_inject._recall_module()
+    recall_inject._INDEX_CACHE.clear()
+    parses = []
+    real_build = mod.build_index
+
+    def counting_build(path):
+        parses.append(str(path))
+        return real_build(path)
+
+    monkeypatch.setattr(mod, "build_index", counting_build)
+    return parses
 
 
 def test_batch_timeout_is_a_single_bounded_hostage_window():
-    """The batched call has its own budget — ONE bounded window per
-    dispatch, never per-query. The budget must give the single index parse
-    real CI headroom (>= 15 s); no per-query 5 s window may remain, since
+    """The fallback batched child keeps ONE bounded window per dispatch
+    (>= 15 s of real headroom); no per-query 5 s window may remain, since
     that tight window was the guillotine the flake tripped."""
     import recall_inject
 
     assert recall_inject.RECALL_BATCH_TIMEOUT >= 15, (
-        "batched recall needs one window with real headroom, not 4-5 tight "
-        "per-query windows")
+        "the fallback child needs one window with real headroom, not 4-5 "
+        "tight per-query windows")
     assert not hasattr(recall_inject, "RECALL_TIMEOUT"), (
         "the per-query 5 s guillotine must stay retired")
 
 
-def test_all_queries_answered_by_one_subprocess(tmp_path, monkeypatch):
-    """Core pin: a dispatch with N recall queries spawns exactly ONE
-    references_recall.py child (the index is parsed once), via the
-    `--queries` batch face. (Pre-fix this spawned one child per query.)"""
+def test_recall_fast_path_spawns_no_child_and_parses_once(tmp_path, monkeypatch):
+    """Core pin: a dispatch's recall is answered IN-PROCESS — zero
+    references_recall children spawned, the layered index parsed exactly
+    once, and the pinned doc set still injected."""
+    import recall_inject
+
+    ws = _kunglao_ws(tmp_path)
+    spawns = _count_recall_children(recall_inject, monkeypatch)
+    parses = _count_index_parses(recall_inject, monkeypatch)
+
+    rc, stderr, ctx = evaluate(_payload(ws, VM_CLAIM))
+    assert rc == 0 and stderr == "" and ctx
+    assert spawns == [], (
+        f"fast path must spawn no recall children; got {spawns}")
+    assert len(parses) == 1, (
+        f"index must be parsed exactly once per dispatch; got {parses}")
+    for expected in ("dynamic-re-tool-priority.md", "tools-dynamic.md",
+                     "verify-static-vs-dynamic.md"):
+        assert expected in ctx, f"{expected} missing from in-process recall"
+
+
+def test_index_parse_memoized_across_dispatches(tmp_path, monkeypatch):
+    """Second dispatch in the SAME process must not re-parse the index —
+    the memoization is the whole point: one parse per process, not one
+    per dispatch (and historically, not one per query)."""
+    import recall_inject
+
+    spawns = _count_recall_children(recall_inject, monkeypatch)
+    parses = _count_index_parses(recall_inject, monkeypatch)
+
+    rc1, _, ctx1 = evaluate(_payload(_kunglao_ws(tmp_path / "a"), VM_CLAIM))
+    rc2, _, ctx2 = evaluate(_payload(_kunglao_ws(tmp_path / "b"), VM_CLAIM))
+    assert rc1 == 0 and rc2 == 0 and ctx1 and ctx2
+    assert len(parses) == 1, (
+        f"one parse per process expected; got {len(parses)}: {parses}")
+    assert spawns == [], "memoized dispatches must spawn no children"
+
+
+def test_index_cache_invalidates_when_index_file_changes(tmp_path, monkeypatch):
+    """The memo key carries the index file's stat; when the file changes
+    (mtime/size), the next recall re-parses instead of serving stale
+    entries. Unchanged file -> served from cache with zero re-parse.
+    Runs against a TMP copy of the index — bumping the shared repo file's
+    mtime would race other xdist workers' memo keys mid-run."""
+    import os
+    import shutil
+
+    import recall_inject
+
+    mod = recall_inject._recall_module()
+    tmp_index = tmp_path / "references" / "_INDEX.md"
+    tmp_index.parent.mkdir(parents=True)
+    shutil.copyfile(mod.default_index_path(), tmp_index)
+    monkeypatch.setattr(mod, "default_index_path", lambda: tmp_index)
+
+    recall_inject._INDEX_CACHE.clear()
+    parses = []
+    real_build = mod.build_index
+
+    def counting_build(path):
+        parses.append(str(path))
+        return real_build(path)
+
+    monkeypatch.setattr(mod, "build_index", counting_build)
+
+    recall_inject._memoized_index(mod)
+    recall_inject._memoized_index(mod)
+    assert len(parses) == 1, "unchanged index must be served from cache"
+
+    os.utime(tmp_index, None)  # content unchanged, mtime bumped
+    recall_inject._memoized_index(mod)
+    assert len(parses) == 2, "changed index stat must invalidate the cache"
+
+
+def test_inprocess_results_match_subprocess_cli(tmp_path, monkeypatch):
+    """Parity guard: the in-process answer for a query set must equal what
+    the references_recall CLI subprocess answers for the same set (the
+    pinned ranking contract may not drift between the two faces)."""
     import subprocess as sp
 
     import recall_inject
 
     ws = _kunglao_ws(tmp_path)
-    spawns = []
+    queries = ["vm", "dynamic"]
 
-    real_run = sp.run
+    spawns = _count_recall_children(recall_inject, monkeypatch)
+    inproc = recall_inject.recall_files_batch(list(queries), cwd=ws)
+    assert spawns == [], "parity baseline must come from the in-process face"
 
-    def counting_run(cmd, **kw):
-        spawns.append(list(cmd))
-        return real_run(cmd, **kw)
-
-    monkeypatch.setattr(recall_inject.subprocess, "run", counting_run)
-    rc, stderr, ctx = evaluate(_payload(ws, VM_CLAIM))
-    assert rc == 0 and stderr == "" and ctx
-    assert len(spawns) == 1, (
-        f"one dispatch = one recall child; got {len(spawns)}: {spawns}")
-    assert "--queries" in spawns[0], (
-        f"child must use the --queries batch face: {spawns[0]}")
-    assert "vm" in spawns[0] and "dynamic" in spawns[0], (
-        "every query must travel in the single child")
+    cmd = [sp.sys.executable if hasattr(sp, "sys") else "python3",
+           str(recall_inject.RECALL_SCRIPT), "--queries", *queries,
+           "--ws", str(ws)]
+    r = sp.run(cmd, capture_output=True, text=True, encoding="utf-8",
+               errors="replace", cwd=str(ws), timeout=120)
+    assert r.returncode == 0, r.stderr
+    sections = recall_inject._split_batch_stdout(r.stdout, queries)
+    from_cli = tuple(recall_inject._parse_files(sections[q])
+                     for q in queries)
+    assert inproc == list(from_cli), (
+        f"in-process {inproc} != CLI {list(from_cli)}")
 
 
 def test_batched_stdout_splits_per_query(tmp_path, monkeypatch):
-    """The batched child answers each query in its own `# ====
-    query:` section; evaluate() must split and merge them exactly like the
-    per-query path did (dedup, FILES_PER_QUERY per query, order kept)."""
+    """Fallback face: when the in-process path cannot run, the batched
+    child answers each query in its own `# ==== query:` section and
+    evaluate() splits and merges them (dedup, FILES_PER_QUERY, order)."""
     import recall_inject
 
     ws = _kunglao_ws(tmp_path)
@@ -259,6 +369,10 @@ def test_batched_stdout_splits_per_query(tmp_path, monkeypatch):
         assert "--queries" in cmd, f"batch face expected: {cmd}"
         return Done()
 
+    def broken_inprocess(queries, cwd):
+        raise RuntimeError("in-process recall unavailable")
+
+    monkeypatch.setattr(recall_inject, "_inprocess_batch", broken_inprocess)
     monkeypatch.setattr(recall_inject.subprocess, "run", fake_run)
     rc, stderr, ctx = evaluate(_payload(ws, VM_CLAIM))
     assert rc == 0 and stderr == ""
@@ -269,9 +383,9 @@ def test_batched_stdout_splits_per_query(tmp_path, monkeypatch):
 
 
 def test_batch_child_failure_fails_open_all_queries(tmp_path, monkeypatch):
-    """The single batched child dying (timeout/crash) fails open for
-    the whole dispatch — (0, '', None), never a raise. Same fail-open
-    contract the per-query path had, now at dispatch granularity."""
+    """When BOTH faces fail (in-process unavailable AND the fallback child
+    times out), recall fails open for the whole dispatch — (0, '', None),
+    never a raise."""
     import subprocess as sp
 
     import recall_inject
@@ -281,6 +395,10 @@ def test_batch_child_failure_fails_open_all_queries(tmp_path, monkeypatch):
     def timeout_run(cmd, **kw):
         raise sp.TimeoutExpired(cmd, 20.0)
 
+    def broken_inprocess(queries, cwd):
+        raise RuntimeError("in-process recall unavailable")
+
+    monkeypatch.setattr(recall_inject, "_inprocess_batch", broken_inprocess)
     monkeypatch.setattr(recall_inject.subprocess, "run", timeout_run)
     rc, stderr, ctx = evaluate(_payload(ws, VM_CLAIM))
     assert rc == 0 and stderr == "" and ctx is None


### PR DESCRIPTION
## Summary

Follow-up to PR #195 (merged 96dfa18). CI data showed the batched child still losing on 2-4 core public runners: the layered-index parse costs ~2.5 s CPU unloaded, measures 7-9 s under a local 4-worker xdist storm, and 10-30 s on CI-class hardware. Any wall-clock window around a parse is load-fragile by construction — and the remaining integration failures were exactly that (acceptance nested-suite 120 s timeout, `test_xml_injection_55` end-to-end empty stdout, `references_recall` CLI 60 s windows blowing under the spawn storm).

## Fix — in-process memoized recall (coordinator candidate a)

`hooks/recall_inject.py` now answers a dispatch's queries **in-process** against the memoized layered index:

- Parse once per process; memo keyed by (resolved path, `mtime_ns`, `size`) — a stat change on the index file invalidates.
- **Zero recall children on the fast path** — the spawn storm is gone, which also relieves every other subprocess face in the tier (CLI tests, nested acceptance suites).
- The batched child (`references_recall.py --queries`, 20 s window) survives only as the **fail-open fallback**: in-process raise -> child -> empties, rc 0, never raises.
- Injected `recall_runner` contract preserved (pure tests unchanged).

Also fixed the over-broad CI pin: it counted the trace logger's `git rev-parse HEAD` spawn (`scripts/kunglao_log.py:117`) as a recall child — the batch child itself was never empty on CI. The pin now counts only `references_recall.py` children.

## Measurement (the wall)

| arrangement | fresh-child parse wall |
|---|---|
| unloaded | 2.44 s |
| xdist -n 4 + 16 nice-0 hogs (local, 16-core) | 7.3-9.2 s |
| CI-class 2-4 vCPU public runner (coordinator data) | 10-30 s+ |

## Validation

- New/reworked pins (6): RED before (AttributeError on the absent fast path) -> GREEN after. Pins: zero recall children + parse once per dispatch; memoized across dispatches; stat invalidation (tmp index copy — the first draft bumped the shared repo index and raced other xdist workers, caught and fixed); in-process/CLI parity; fallback fail-open.
- Wide recall net (`test_recall_inject` + `test_web_knowledge_761` + `test_golden_replay` + `test_references_recall` + `test_recall_quality_814` + `test_references_index` + `test_xml_injection_55`) at the CI-like storm (xdist -n 4, 16 nice-0 hogs): **151 passed, 3/3 consecutive**.
- Full fast tier: 2963 passed / 5 skipped. ruff + comment-hygiene clean. Deploy-contract families 29 passed after the manifest regen (re-pin no-op, ext-scan clean, `deploy_manifest --write` LAST).

## Test plan

- [x] Pins RED first, GREEN after
- [x] Wide family 3x green at CI-like storm arrangement
- [x] Full fast tier green locally
- [x] ruff, comment-hygiene, deploy-contract green
- [ ] CI integration leg on this PR
