### PR TITLE
fix: stop env_check venv probe from requiring dropped cryptography

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -311,7 +311,7 @@ files:
   - src: scripts/env_check.py
     dest: .claude/scripts/env_check.py
     kind: scaffold
-    sha256: df54cf47007d7502cd34e1dd22c00cd46a8240192db2d519b86d0f53c342a5f2
+    sha256: 076336348f94826ca7f04baf4afa3f59f997551e70f979d123386d5303d1997e
   - src: scripts/env_manifest.py
     dest: .claude/scripts/env_manifest.py
     kind: scaffold
@@ -1215,7 +1215,7 @@ files:
   - src: templates/CLAUDE.md.base.tmpl
     dest: .claude/templates/CLAUDE.md.base.tmpl
     kind: asset
-    sha256: c0f936197382cdef12538c9f2ee5cd94ca5f6a1c075bd1ad53324cce055111fc
+    sha256: 9bb9ab4842f30d791ca28c5e74739d1065a3c64209fcc9d92710b43b29850a29
   - src: templates/README.md
     dest: .claude/templates/README.md
     kind: asset

--- a/openspec/changes/issue-207-venv-probe-stale-cryptography/proposal.md
+++ b/openspec/changes/issue-207-venv-probe-stale-cryptography/proposal.md
@@ -1,0 +1,35 @@
+# issue-207-venv-probe-stale-cryptography — lock-faithful venv probe
+
+## Why
+
+`scripts/env_check.py::check_venv_sample` still probes
+`import cryptography, yaml`. `venv_sample` is a blocking Phase 0 row, so a
+clean `uv sync --locked` install FAILs analysis entry even though
+`cryptography` was dropped from `pyproject.toml` and is not imported
+anywhere. Operator-facing copies of the leftover (`CLAUDE.md.base.tmpl`,
+`skills/kunglao-agent/SKILL.md`) tell agents to install and verify a
+package the lock no longer ships.
+
+## What Changes
+
+1. Probe the skill-root venv with `import yaml` (PyYAML is the declared,
+   actually-imported runtime dep). A lock-faithful interpreter with yaml
+   present and cryptography absent PASSes.
+2. Align the workspace handbook venv line and the skill Phase 0 venv
+   probe with the same declared set. Regen the three claudemd-golden
+   fixtures through the existing sentinel path.
+3. Refresh deploy-manifest digests for the touched deployed sources.
+
+## Impact
+
+- Producer: `check_venv_sample` → `runs/.env-check.json` `venv_sample` row.
+- Consumer: `hooks/env_check_gate.py` / Phase 0 refuse analysis entry on
+  a blocking FAIL.
+- No probe of guarded extras (`z3-solver`, `jinja2`). No behavior change
+  for a missing venv interpreter or a missing yaml install.
+
+## Acceptance
+
+- Lock-faithful venv (yaml present, cryptography absent) → `venv_sample` PASS.
+- Source pin: `env_check.py` no longer contains `import cryptography`.
+- Goldens byte-identical to the sentinel render after the handbook line change.

--- a/openspec/changes/issue-207-venv-probe-stale-cryptography/tasks.md
+++ b/openspec/changes/issue-207-venv-probe-stale-cryptography/tasks.md
@@ -1,0 +1,6 @@
+- [x] RED: lock-faithful venv (yaml present, cryptography absent) FAILs `check_venv_sample`
+- [x] GREEN: probe `import yaml` only; docstring / checklist text match
+- [x] Align `templates/CLAUDE.md.base.tmpl` and `skills/kunglao-agent/SKILL.md`
+- [x] Regen `tests/fixtures/claudemd-golden/{windows,linux,android}.md`
+- [x] Refresh deploy-manifest digests for touched sources
+- [x] Targeted pytest + ruff on the touched files

--- a/scripts/env_check.py
+++ b/scripts/env_check.py
@@ -27,7 +27,7 @@ Checks:
                          hooks dropped, the #258/#372 silent-drop class).
                          Deployment targets resolve from the wire_up_settings
                          registry (hook_deployment_targets) — never a mirror.
-  5. venv + sample     — SKILL-root venv python exists w/ cryptography+yaml
+  5. venv + sample     — SKILL-root venv python exists w/ yaml
                          (#409: uv run --project <skill_root> is authoritative,
                          not ws/.venv); sample sha256
   6. python_version   — running interpreter matches the 3.11 pin (.python-version,
@@ -504,8 +504,11 @@ def check_hooks(ws: Path) -> tuple[str, str]:
 
 
 def check_venv_sample(ws: Path, sample_sha256: str | None) -> tuple[bool, str]:
-    """SKILL-root venv python with cryptography+yaml; sample sha256 vs
-    task_spec if present.
+    """SKILL-root venv python with yaml; sample sha256 vs task_spec if present.
+
+    Probes the declared runtime set (PyYAML), not leftover packages dropped
+    from pyproject. A lock-faithful uv sync must PASS this row: venv_sample
+    is blocking, so probing an undeclared package fails a healthy install.
 
     #409: the authoritative interpreter is the SKILL-root venv (uv run
     --project <skill_root>) resolved by sys.platform (Scripts/python.exe |
@@ -515,10 +518,10 @@ def check_venv_sample(ws: Path, sample_sha256: str | None) -> tuple[bool, str]:
     venv_py = platform_paths.venv_python(SKILL_DIR / ".venv")
     if venv_py.exists():
         try:
-            r = subprocess.run([str(venv_py), "-c", "import cryptography, yaml"],
+            r = subprocess.run([str(venv_py), "-c", "import yaml"],
                                capture_output=True, text=True, timeout=30, encoding="utf-8", errors="replace")
             if r.returncode != 0:
-                problems.append(f"venv missing deps (cryptography/yaml): {r.stderr.strip()[:80]}")
+                problems.append(f"venv missing deps (yaml): {r.stderr.strip()[:80]}")
         except Exception as exc:
             problems.append(f"venv probe failed: {exc}")
     else:

--- a/skills/kunglao-agent/SKILL.md
+++ b/skills/kunglao-agent/SKILL.md
@@ -95,7 +95,7 @@ Run the steps in order; any FAIL blocks the next step.
    Dynamic channel (full matrix in `references/contracts/cold-start-contract.md`): `KUNGLAO_CHANNEL=vmr|ssh|docker|adb|local` — five equivalent control planes; dynamic tasks probe HARD (vmr liveness / ssh/docker/adb capability), static-only tasks WARN without probing; `local` is static-only — a dynamic task on `local` is REJECTED.
    Enter analysis only with `OVERALL=PASS`; fix each FAIL (steps 1-4 below are the repair manual) and re-run until PASS.
 
-1. **Probe the Python venv**: check activation (`$env:VIRTUAL_ENV` / `sys.prefix != sys.base_prefix` / `.venv` exists). Activated → record `venv=<path>` in `analysis_state.txt`. Not activated and `.venv/` missing → create it (`python -m venv .venv`), install dependencies (cryptography, pyyaml) into that venv only, verify with `python -c "import cryptography, yaml"`.
+1. **Probe the Python venv**: check activation (`$env:VIRTUAL_ENV` / `sys.prefix != sys.base_prefix` / `.venv` exists). Activated → record `venv=<path>` in `analysis_state.txt`. Not activated and `.venv/` missing → create it (`python -m venv .venv`), install the locked dependency set (`uv sync --locked`) into that venv only, verify with `python -c "import yaml"`.
 
 2. **Probe the toolchain**: confirm the directory layout — `scripts/`, `hooks/`, `templates/` (`state/` state templates, `scripts/` script templates, `frida/` Frida templates), `tools/` (tool homes: `crypto/` `static/` `ghidra/` `frida/` `t2/` `auxiliary/` `pipelines/`) — exist (`ls <SKILL_DIR>/scripts/`); Python + dependency libraries available; `convergence_check.py` executes.
 

--- a/templates/CLAUDE.md.base.tmpl
+++ b/templates/CLAUDE.md.base.tmpl
@@ -208,7 +208,7 @@ Any reusable analysis logic must land as a parameterized CLI script under `{{ski
 
 ## Python venv
 
-Path: `{{venv_path}}`. Key deps: `cryptography`, `pyyaml`. Activate before running scripts.
+Path: `{{venv_path}}`. Key deps: `pyyaml`. Activate before running scripts.
 
 ## Keeping this handbook alive
 

--- a/tests/fixtures/claudemd-golden/android.md
+++ b/tests/fixtures/claudemd-golden/android.md
@@ -259,7 +259,7 @@ Any reusable analysis logic must land as a parameterized CLI script under `/kung
 
 ## Python venv
 
-Path: `.venv/`. Key deps: `cryptography`, `pyyaml`. Activate before running scripts. Python 3.11.0.
+Path: `.venv/`. Key deps: `pyyaml`. Activate before running scripts. Python 3.11.0.
 
 ## Keeping this handbook alive
 

--- a/tests/fixtures/claudemd-golden/linux.md
+++ b/tests/fixtures/claudemd-golden/linux.md
@@ -248,7 +248,7 @@ Any reusable analysis logic must land as a parameterized CLI script under `/kung
 
 ## Python venv
 
-Path: `.venv/`. Key deps: `cryptography`, `pyyaml`. Activate before running scripts. Python 3.11.0.
+Path: `.venv/`. Key deps: `pyyaml`. Activate before running scripts. Python 3.11.0.
 
 ## Keeping this handbook alive
 

--- a/tests/fixtures/claudemd-golden/windows.md
+++ b/tests/fixtures/claudemd-golden/windows.md
@@ -249,7 +249,7 @@ Any reusable analysis logic must land as a parameterized CLI script under `/kung
 
 ## Python venv
 
-Path: `.venv/`. Key deps: `cryptography`, `pyyaml`. Activate before running scripts. Python 3.11.0.
+Path: `.venv/`. Key deps: `pyyaml`. Activate before running scripts. Python 3.11.0.
 
 ## Keeping this handbook alive
 

--- a/tests/test_env_check.py
+++ b/tests/test_env_check.py
@@ -4,8 +4,9 @@
 Three scenarios (mirroring the incident-driven acceptance criteria):
   1. AGENT_TEAMS flag set (process scope) -> check ① FAIL, overall FAIL, exit 1
      (the 2026-08-12 polluted-session shape)
-  2. VM unreachable (socket refused/timed out) -> vm check FAIL, exit 1
-     (dynamic analysis blocked; static may proceed — recoverable FAIL)
+  2. VM unreachable (socket refused/timed out) -> vm check FAIL
+     (dynamic analysis blocked; static may proceed — DEGRADED T3 row,
+     overall stays PASS)
   3. all five checks PASS -> exit 0 + runs/.env-check.json snapshot says PASS
 
 The check functions take explicit paths / module state so tests can monkeypatch
@@ -176,7 +177,13 @@ def test_flag_set_fails_exit_1(monkeypatch, tmp_path):
 
 
 def test_vm_unreachable_fails(monkeypatch, tmp_path):
-    """Scenario 2: VM sockets refused/timed out -> vm check FAIL, exit 1 (recoverable)."""
+    """Scenario 2: VM sockets refused/timed out -> vm check FAIL.
+
+    vm_reachability is DEGRADED (T3-restricted), so overall stays PASS.
+    Pre-fix this assertion was exit-1 only because the venv probe also
+    FAILed on the leftover cryptography import — a lock-faithful venv
+    must not keep that accidental blocking row.
+    """
     ws = _kunglao_ws(tmp_path)
     monkeypatch.delenv(FLAG_NAME, raising=False)
 
@@ -188,9 +195,11 @@ def test_vm_unreachable_fails(monkeypatch, tmp_path):
     monkeypatch.setattr(env_check, "VM_HOST", "127.0.0.1")
     monkeypatch.setattr(env_check.socket, "create_connection", _boom)
     rc = run(ws)
-    assert rc == 1
     snap = json.loads((ws / "runs" / ".env-check.json").read_text(encoding="utf-8"))
     assert snap["checks"]["vm_reachability"]["status"] == "FAIL"
+    assert rc == 0
+    assert snap["overall"] == "PASS"
+    assert "vm_reachability" in snap.get("degraded", [])
 
 
 def test_all_pass_exit_0(monkeypatch, tmp_path):
@@ -468,6 +477,51 @@ def test_venv_check_ignores_workspace_venv_when_skill_root_present(monkeypatch, 
     snap = json.loads((ws / "runs" / ".env-check.json").read_text(encoding="utf-8"))
     assert snap["checks"]["venv_sample"]["status"] == "PASS", \
         f"workspace .venv must be ignored when skill-root venv is authoritative: {snap['checks']['venv_sample']}"
+
+
+def test_venv_probe_accepts_lock_faithful_interpreter_without_cryptography(
+        monkeypatch, tmp_path):
+    """A uv-sync --locked venv ships yaml and does not ship cryptography.
+
+    cryptography was dropped from pyproject (release-contract: not imported
+    anywhere). Probing it FAIL-closes a healthy install because venv_sample
+    is a blocking Phase 0 row. The probe must import the declared runtime
+    set (yaml), not the leftover package.
+    """
+    import env_check
+    ws = _kunglao_ws(tmp_path)
+    monkeypatch.setattr(env_check, "SKILL_DIR", tmp_path / "skill-root")
+    venv_py = platform_paths.venv_python(env_check.SKILL_DIR / ".venv")
+    venv_py.parent.mkdir(parents=True)
+    venv_py.write_text("", encoding="utf-8")
+
+    def fake_run(argv, *a, **k):
+        code = argv[2] if len(argv) >= 3 and argv[1] == "-c" else ""
+        if "cryptography" in code:
+            return subprocess.CompletedProcess(
+                argv, 1, "",
+                "ModuleNotFoundError: No module named 'cryptography'\n")
+        if "yaml" in code:
+            return subprocess.CompletedProcess(argv, 0, "", "")
+        return subprocess.CompletedProcess(argv, 1, "", "unexpected probe")
+
+    monkeypatch.setattr(env_check.subprocess, "run", fake_run)
+    ok, detail = env_check.check_venv_sample(ws, None)
+    assert ok is True, detail
+    assert "cryptography" not in detail.lower()
+
+
+def test_venv_probe_source_does_not_import_cryptography():
+    """env_check and operator-facing copies must not probe a package the lock does not ship."""
+    root = Path(__file__).resolve().parents[1]
+    src = (root / "scripts" / "env_check.py").read_text(encoding="utf-8")
+    assert "import cryptography" not in src
+    assert "cryptography+yaml" not in src
+    assert "cryptography/yaml" not in src
+    skill = (root / "skills" / "kunglao-agent" / "SKILL.md").read_text(encoding="utf-8")
+    tmpl = (root / "templates" / "CLAUDE.md.base.tmpl").read_text(encoding="utf-8")
+    assert "cryptography" not in skill
+    assert "cryptography" not in tmpl
 
 
 def test_venv_python_resolves_by_platform():

--- a/tests/test_renderer_unify.py
+++ b/tests/test_renderer_unify.py
@@ -62,6 +62,8 @@ sys.path.insert(0, str(SCRIPTS))
 # plugin countermand) joined the header; the four executable instruction
 # lines moved to the uv-run form (`uv run --project {{skill_dir}} python
 # ...`) — no other byte changed.
+# 2026-09-10 regen (venv probe leftover): Key deps dropped cryptography
+# (not in the lock); pyyaml remains. Frame body otherwise unchanged.
 SKILL_DIR_SENTINEL = Path("/kunglao/skill-sentinel")
 PY_VERSION_SENTINEL = "3.11.0"
 


### PR DESCRIPTION
## Summary

`scripts/env_check.py::check_venv_sample` still probed `import cryptography, yaml` after cryptography was dropped from `pyproject.toml`. `venv_sample` is a blocking Phase 0 row, so a lock-faithful `uv sync --locked` venv failed analysis entry even though yaml is present and cryptography is not a declared dependency.

This PR probes `import yaml` only and drops the leftover from the workspace handbook, skill Phase 0 probe, and claudemd goldens.

## Issue linkage (REQUIRED)
Closes #207

Milestone: none

## Anti-orphan gate (REQUIRED)

1. **Who reads this at runtime?** `hooks/env_check_gate.py` and Phase 0 (`skills/kunglao-agent/SKILL.md`) consume the `venv_sample` row that `scripts/env_check.py::check_venv_sample` writes into `runs/.env-check.json`.
2. **What state transition writes this?** `env_check.run()` writes `runs/.env-check.json` during Phase 0 / `env_check_gate`; a blocking FAIL refuses analysis entry.

## Test plan

- [x] `uv run python -m pytest tests/test_env_check.py tests/test_renderer_unify.py tests/test_claudemd_g2g3_758.py tests/test_claudemd_single_source.py tests/test_contract_docs.py tests/test_skill_invocation.py tests/test_release_receipt.py tests/test_deploy_manifest_783.py -q`
- [x] `uv run ruff check scripts/env_check.py tests/test_env_check.py tests/test_renderer_unify.py`
- [x] `uv run python scripts/deploy_manifest.py --verify`
- [x] `uv run python scripts/comment_hygiene_lint.py`
- [x] `uv run python scripts/release_receipt.py --check`

## Labels
bug, capability:autonomy, theme:toolchain