### PR TITLE
fix: statusline v2 assembly — init-first deployment, tick data plane, self-heal, honest state (#212)

### DIFF
--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -27,7 +27,7 @@ files:
   - src: hooks/heartbeat_touch.py
     dest: .claude/hooks/heartbeat_touch.py
     kind: hook
-    sha256: a212e9607c15df4b80e5a61451d6bb2b57c783e8da508369638f9a5441119701
+    sha256: 9e3cd7eb1ea5f5446ec7f01fd2164c262281796418472c90c77d12f075e282ee
   - src: hooks/lib_kunglao.py
     dest: .claude/hooks/lib_kunglao.py
     kind: hook
@@ -383,7 +383,7 @@ files:
   - src: scripts/hook_activation.py
     dest: .claude/scripts/hook_activation.py
     kind: scaffold
-    sha256: f09099e2410d017a04f3bead55394ae57b99106981f9f7a95f78138e11fc8734
+    sha256: 457a60aad0338c17b624cd6b84313919959dbfdf9524d7b96620d5010e72dd03
   - src: scripts/hook_exit_codes.py
     dest: .claude/scripts/hook_exit_codes.py
     kind: scaffold
@@ -443,7 +443,7 @@ files:
   - src: scripts/kunglao-init.py
     dest: .claude/scripts/kunglao-init.py
     kind: scaffold
-    sha256: b4645646c839fef4f21c2f56542a55a5b89c18187d036a5b7bf01fd6d1858b7a
+    sha256: 00cec3a2f48b509d7900d4d721c04b27f1ff7aa449203cdf9ebb7915aa4107ef
   - src: scripts/kunglao-monitor.py
     dest: .claude/scripts/kunglao-monitor.py
     kind: scaffold
@@ -491,7 +491,7 @@ files:
   - src: scripts/kunglao_upgrade.py
     dest: .claude/scripts/kunglao_upgrade.py
     kind: scaffold
-    sha256: 0c14f9f551ffa5e77f3bdf51246664d65adc3602952284ce73520bb06561419e
+    sha256: 1beeeb663ec477c80ccf51e822e35448de0a1c27a79fddeee28e53bdf159fb49
   - src: scripts/kunglao_verify.py
     dest: .claude/scripts/kunglao_verify.py
     kind: scaffold
@@ -731,7 +731,7 @@ files:
   - src: scripts/statusline_snapshot.py
     dest: .claude/scripts/statusline_snapshot.py
     kind: scaffold
-    sha256: 4e62a12ce011feb379a7a6470439e19a12c11f49b8f59bd7d4aea0c2183f9762
+    sha256: 573f5167217e4904681c6a8dab64125437adfa011f3b479a9db9b54c77faa44b
   - src: scripts/structural_check.py
     dest: .claude/scripts/structural_check.py
     kind: scaffold
@@ -843,7 +843,7 @@ files:
   - src: scripts/statusline_render.mjs
     dest: .claude/scripts/statusline_render.mjs
     kind: scaffold
-    sha256: b45436cff3796ff3f7ee09031b59e0d83f944615db0f44729702b299fc983df0
+    sha256: 4cb5bbed5cb3cf9dac508a0edb48422d865e5ede55934cb700198029a37f6739
   - src: references/_INDEX.md
     dest: .claude/references/_INDEX.md
     kind: asset
@@ -1215,7 +1215,7 @@ files:
   - src: templates/CLAUDE.md.base.tmpl
     dest: .claude/templates/CLAUDE.md.base.tmpl
     kind: asset
-    sha256: c0f936197382cdef12538c9f2ee5cd94ca5f6a1c075bd1ad53324cce055111fc
+    sha256: fa4f8790216ec4f596c33054c2f58ddcc461528fbdd9897a3059dd835d1be881
   - src: templates/README.md
     dest: .claude/templates/README.md
     kind: asset

--- a/hooks/heartbeat_touch.py
+++ b/hooks/heartbeat_touch.py
@@ -29,7 +29,8 @@ from pathlib import Path
 # #618: durable-sidecar access via the #671 path-hygiene authority (same
 # pattern as completion_gate) — the hook lands its pulse in the #830
 # append-only substrate, not just the cache file.
-from _path_hygiene import ensure_scripts_path, scripts_on_path  # noqa: E402
+from _path_hygiene import (  # noqa: E402
+    ensure_scripts_path, load_module_by_path, scripts_on_path)
 
 # #863 Family F: the harness-wide time-stamp util lives in scripts/;
 # reach it through the #671 path-hygiene authority (no second def).
@@ -40,6 +41,62 @@ import harness_common
 # PreToolUse/Bash + Stop fire often; the sidecar is a liveness substrate,
 # not a tool-call trace (growth stays ~cadence-shaped, not tool-shaped).
 PULSE_DEDUP_SECONDS = 60
+
+
+def _write_statusline_snapshot(ws: Path) -> None:
+    """#212: the statusline data plane is the DEPLOYED workspace copy.
+
+    Resolution order (each tier fail-open, each strictly more capable):
+
+      1. ``<ws>/.claude/scripts/statusline_snapshot.py`` — THE data plane
+         (workspace-relative, self-contained against skill upgrades),
+         loaded by resolved path, never by sys.path order (#671/#770);
+      2. the ambient scripts/ import (non-deployed hook mode);
+      3. the canonical install's env via one bounded subprocess — the
+         #783 deployed-mode `uv run --project <ws>` command runs on a bare
+         interpreter when the workspace carries no pyproject.toml, so a
+         yaml-importing data plane would silently never write. The env
+         degradation lands here, in the cosmetic face, and never touches
+         the heartbeat / analysis path.
+
+    Callers wrap this — the statusline never blocks a tool call.
+    """
+    deployed = ws / ".claude" / "scripts" / "statusline_snapshot.py"
+    if deployed.is_file():
+        try:
+            mod = load_module_by_path("statusline_snapshot_ws", deployed)
+            mod.write_snapshot(ws)
+            return
+        except Exception:  # noqa: BLE001 — degrade, never block the tool
+            pass
+    try:
+        import statusline_snapshot  # scripts/ on path via #671 boot
+        statusline_snapshot.write_snapshot(ws)
+        return
+    except ImportError:
+        pass  # bare-interpreter env (no yaml) — tier 3 below
+    except Exception:  # noqa: BLE001 — statusline never blocks tools
+        return
+    try:
+        import shutil
+        import subprocess
+        with scripts_on_path():
+            import hook_activation
+        root = hook_activation.canonical_install_root()
+        uv = shutil.which("uv")
+        # the CODE stays the workspace data plane (deployed copy, else the
+        # skill-root script); the canonical install only supplies the ENV
+        # (yaml et al.) the bare `uv run --project <ws>` interpreter lacks.
+        script = deployed if deployed.is_file() \
+            else root / "scripts" / "statusline_snapshot.py"
+        if uv is None or not script.is_file():
+            return
+        subprocess.run(
+            [uv, "run", "--project", str(root), "python", str(script),
+             str(ws)],
+            capture_output=True, timeout=60, check=False)
+    except Exception:  # noqa: BLE001 — cosmetic face, never blocks tools
+        pass
 
 
 utc_now = harness_common.utc_now_z  # #863 Family F: single source
@@ -80,14 +137,15 @@ def main() -> int:
                     hbmod.append_tick_log(ws, actor="hook")
             except Exception:  # noqa: BLE001 — liveness substrate best-effort
                 pass
-            # #142: per-tool-use statusline snapshot refresh — the v2
+            # #142/#212: per-tool-use statusline snapshot refresh — the v2
             # freshness contract rides the existing touch path so the
             # working-period snapshot mtime advances ~= per tool call,
-            # without waiting for the 5-min tick. Fail-open: the statusline
-            # is cosmetic and must never block or fail a tool call.
+            # without waiting for the 5-min tick. #212: the tick invokes the
+            # DEPLOYED data plane (<ws>/.claude/scripts/) when init has
+            # materialized it. Fail-open: the statusline is cosmetic and
+            # must never block or fail a tool call.
             try:
-                import statusline_snapshot  # scripts/ on path via #671 boot
-                statusline_snapshot.write_snapshot(ws)
+                _write_statusline_snapshot(ws)
             except Exception:  # noqa: BLE001 — statusline never blocks tools
                 pass
             return 0

--- a/scripts/hook_activation.py
+++ b/scripts/hook_activation.py
@@ -795,6 +795,10 @@ ORCHESTRATOR_MCP_MATCHER = (
 # registry is hooks-only (event-keyed) and tests pin its set + shape.
 STATUSLINE_RENDER_FILE = "statusline_render.mjs"
 STATUSLINE_SETTINGS_KEY = "statusLine"
+# Renderer budget is sub-second; the entry timeout kills the legacy
+# long-tick class (owner reference pattern). Single source: this constant +
+# statusline_entry_shape, which both the writer and the checker consume.
+STATUSLINE_TIMEOUT_S = 10
 
 
 def statusline_render_command(workspace: Path | None) -> str:
@@ -816,8 +820,49 @@ def statusline_render_command(workspace: Path | None) -> str:
     return f"node {canonical.as_posix()}"
 
 
+def statusline_entry_shape(workspace: Path | None) -> dict:
+    """THE statusLine settings entry shape (single source). Consumers: the
+    writer (register_statusline) and the checker
+    (verify_statusline_registration) can never drift apart."""
+    return {"type": "command",
+            "command": statusline_render_command(workspace),
+            "timeout": STATUSLINE_TIMEOUT_S}
+
+
+def verify_statusline_registration(workspace: Path) -> dict:
+    """Read-only verification face (issue 212: upgrade's every-run
+    re-verify).
+
+    ok = the settings entry equals the canonical shape AND the referenced
+    renderer file exists on disk. Never writes. reason names the fault:
+    "missing" | "stale-shape" | "renderer-missing".
+    """
+    ws = Path(workspace).resolve()
+    target = ws / ".claude" / "settings.json"
+    expected = statusline_entry_shape(ws)
+    entry = None
+    try:
+        doc = json.loads(target.read_text(encoding="utf-8"))
+        entry = doc.get(STATUSLINE_SETTINGS_KEY) if isinstance(doc, dict) else None
+    except (OSError, ValueError):
+        entry = None
+    if entry == expected:
+        renderer = expected["command"].split(" ", 1)[1]
+        if Path(renderer).exists():
+            return {"ok": True, "present": True, "reason": None,
+                    "command": expected["command"], "expected": expected}
+        return {"ok": False, "present": True, "reason": "renderer-missing",
+                "command": expected["command"], "expected": expected}
+    reason = "missing" if entry is None else "stale-shape"
+    return {"ok": False, "present": bool(entry), "reason": reason,
+            "command": (entry or {}).get("command")
+            if isinstance(entry, dict) else None,
+            "expected": expected}
+
+
 def register_statusline(workspace: Path) -> dict:
-    """#142 PROJECT-scoped statusLine registration (keep-alive repair face).
+    """#142 PROJECT-scoped statusLine registration (keep-alive repair face,
+    extended by issue 212: the init FIRST-step writer).
 
     Writes ONLY <workspace>/.claude/settings.json — the #258 project target,
     different key (`statusLine`, not `hooks`). There is deliberately NO
@@ -839,7 +884,7 @@ def register_statusline(workspace: Path) -> dict:
             existing = {}
     if not isinstance(existing, dict):
         existing = {}
-    entry = {"type": "command", "command": statusline_render_command(ws)}
+    entry = statusline_entry_shape(ws)
     existing[STATUSLINE_SETTINGS_KEY] = entry
     target.write_text(
         json.dumps(existing, indent=2, ensure_ascii=False), encoding="utf-8")

--- a/scripts/kunglao-init.py
+++ b/scripts/kunglao-init.py
@@ -755,16 +755,29 @@ def seed_claims(sample: str, project_type: str, sample_sha: str) -> list[dict]:
     capability guesses are forbidden here (issue #412); the operator
     defines the analysis task (primary_questions) after init, and claim
     seeding from task_spec happens in the loop (DESIGN §7 0.9).
+
+    Issue 212 (field diagnosis): the seeds are CLOSED at the success-point write,
+    status PROVEN with init's own evidence attached — init verified each
+    identity fact by construction (it computed the values it wrote), so
+    leaving them OPEN made the statusline state machine lie "analyzing"
+    forever on an idle workspace. One atomic write at the init success
+    point: no post-write mutation, no state_hash drift, and the failed-init
+    cleanup path is unchanged (the register is removed as a this-run
+    artifact like before).
     """
+    evidence = "init-verified by construction (scaffold gate)"
     return [
-        {"id": "C-001", "status": "OPEN", "boundary_type": "positive_observation",
+        {"id": "C-001", "status": "PROVEN", "boundary_type": "positive_observation",
          "evidence_tier_attempted": 0, "promotion_attempts": 0, "depends_on": [],
+         "evidence": evidence,
          "title": f"Sample artifact identity — {sample} (filename; sha256 in C-003)"},
-        {"id": "C-002", "status": "OPEN", "boundary_type": "positive_observation",
+        {"id": "C-002", "status": "PROVEN", "boundary_type": "positive_observation",
          "evidence_tier_attempted": 0, "promotion_attempts": 0, "depends_on": [],
+         "evidence": evidence,
          "title": f"Project type — {project_type} (scaffold decision)"},
-        {"id": "C-003", "status": "OPEN", "boundary_type": "positive_observation",
+        {"id": "C-003", "status": "PROVEN", "boundary_type": "positive_observation",
          "evidence_tier_attempted": 0, "promotion_attempts": 0, "depends_on": [],
+         "evidence": evidence,
          "title": f"Sample sha256 — {sample_sha}"},
     ]
 
@@ -791,6 +804,7 @@ def claim_register_text(sample: str, sample_sha: str, state_hash: str,
         lines.append(f"  evidence_tier_attempted: {c['evidence_tier_attempted']}")
         lines.append(f"  promotion_attempts: {c['promotion_attempts']}")
         lines.append(f"  depends_on: {c['depends_on']}")
+        lines.append(f"  evidence: \"{c['evidence']}\"")
         lines.append(f"  title: \"{c['title']}\"")
     return "\n".join(lines) + "\n"
 
@@ -1988,6 +2002,20 @@ def scaffold(ws: Path) -> list[Path]:
         p.parent.mkdir(parents=True, exist_ok=True)
         atomic_write(p, stub)
         created.append(p)
+    # Mission-ledger baseline (issue 212 field diagnosis — the progress segment
+    # rendered nothing because runs/mission_ledger.yaml was never
+    # initialized). mission_ledger.init derives the 0/N PQ baseline from the
+    # needs-first task_spec (idempotent-refusing: an existing ledger is
+    # never rewritten); it is a starting baseline, never a cap — new claims
+    # grow N on the live ledger at runtime.
+    try:
+        from mission_ledger import init as _ml_init
+        _ml_init(ws)
+    except FileExistsError:
+        pass  # already initialized — the baseline is the workspace's data
+    except Exception as exc:  # noqa: BLE001 — baseline is WARN-tier
+        print(f"kunglao-init: WARN mission-ledger baseline skipped ({exc})",
+              file=sys.stderr)
     write_workspace_manifest(ws)  # #538 item 2: resume diff source
     return created
 
@@ -2075,6 +2103,38 @@ def hook_deploy_rc(report: dict) -> int:
     if report.get("deployed") and not report.get("selfcheck", {}).get("ok"):
         return RC_HOOK_WIRING
     return RC_OK
+
+
+def deploy_statusline(ws: Path) -> dict:
+    """Issue 212, FIRST step of init (owner priority update): the statusline is
+    the operator's only visible success/failure signal, so its wiring runs
+    BEFORE the toolchain probe / anchor interview / any scaffold write.
+
+    Writes ONLY the kunglao-owned `statusLine` key of
+    <ws>/.claude/settings.json via hook_activation.register_statusline (THE
+    registration entry; single source of the entry shape incl. the timeout).
+    Cosmetic face: a failed registration is a stderr WARN, never an init
+    failure. --no-hooks / plugin_mode callers skip this (the documented
+    opt-out). Later init phases (deploy_workspace_copy at deploy_hooks,
+    register_hooks at bootstrap) re-register at the fixed point: once the
+    workspace-local renderer copy exists, the command converges to it.
+    """
+    try:
+        res = hook_activation.register_statusline(ws)
+    except Exception as exc:  # noqa: BLE001 — cosmetic, never fails init
+        print(f"kunglao-init: WARN statusline registration failed ({exc})",
+              file=sys.stderr)
+        return {"ok": False, "error": str(exc)}
+    # stderr only: stdout is the machine channel — a pending exit-8 run
+    # must emit parseable JSON alone (the 455 contract), and this step runs BEFORE the
+    # intake, so any stdout line here would corrupt that contract.
+    if res.get("ok"):
+        print(f"kunglao-init: statusline registered -> {res.get('command')}",
+              file=sys.stderr)
+    else:
+        print(f"kunglao-init: WARN statusline registration self-check "
+              f"failed ({res.get('target')})", file=sys.stderr)
+    return res
 
 
 def deploy_hooks(ws: Path, hooks_json: Path | None) -> dict:
@@ -2772,6 +2832,13 @@ def run(ws: Path | None, force: bool = False, hooks_json: Path | None = None,
     # be written outside the resolved workspace root. Fail fast on a defect
     # rather than polluting a sibling directory.
     _assert_workspace_boundary(ws)
+
+    # STATUSLINE DEPLOYMENT IS THE FIRST STEP of init (issue 212 owner priority
+    # update). Before the toolchain probe, before the anchor interview, so
+    # the operator's success/failure signal exists before anything else.
+    # --no-hooks / plugin_mode is the documented opt-out.
+    if not no_hooks and not plugin_mode:
+        deploy_statusline(ws)
 
     # #367: hook install first — it must also run for resume-mode workspaces
     if install_git_hooks_flag:

--- a/scripts/kunglao_upgrade.py
+++ b/scripts/kunglao_upgrade.py
@@ -1478,6 +1478,41 @@ def _item_skill_staleness_check(ws: Path, dry: bool) -> str:
 # driver
 # --------------------------------------------------------------------------
 
+def _statusline_report(ws: Path, dry_run: bool) -> dict:
+    """Issue 212, FIRST line of every upgrade run (owner ruling): the statusline
+    registration is re-verified BEFORE any other output — it is the
+    operator's only visible success/failure signal. Read-only here: the
+    heal is deferred to the gated write points (never before the dirty
+    gate, never on a refused run, never on a dry run).
+    """
+    from hook_activation import verify_statusline_registration
+    rep = verify_statusline_registration(ws)
+    if rep["ok"]:
+        print(f"kunglao-upgrade: statusline: ok ({rep['command']})")
+        return rep
+    state = ("dry-run: would self-heal" if dry_run
+             else "self-heal at the gated write point")
+    print(f"kunglao-upgrade: statusline: {rep['reason']} "
+          f"({rep['command'] or 'unregistered'}) — {state}")
+    return rep
+
+
+def _statusline_heal(ws: Path, items_out: list | None = None) -> bool:
+    """Issue 212 self-heal: re-register the project statusLine key (overwrites
+    ONLY the kunglao-owned key; never the user-global file)."""
+    from hook_activation import register_statusline
+    try:
+        res = register_statusline(ws)
+    except Exception as exc:  # noqa: BLE001 — cosmetic face, never fails upgrade
+        _warn_line(f"kunglao-upgrade: WARN statusline self-heal failed ({exc})")
+        return False
+    print(f"kunglao-upgrade: statusline: self-healed -> {res.get('command')}")
+    if items_out is not None:
+        items_out.append({"name": "statusline_selfheal", "action": "applied",
+                          "detail": str(res.get("command") or "")})
+    return bool(res.get("ok"))
+
+
 def _anchor_backfill(ws: Path, dry_run: bool, resolve: dict | None,
                      items_out: list | None) -> tuple[int, dict | None]:
     """Detect missing required intake answers in task_spec.yaml and elicit
@@ -1574,6 +1609,11 @@ def upgrade(ws: Path, dry_run: bool = False,
            resolve: dict | None = None) -> int:
     ws = Path(ws)
     origin = template_version.read_workspace_version(ws)
+    # Issue 212: the statusline re-verify is the FIRST line of every upgrade run
+    # (owner ruling) — before the stamp refusal, before "already at
+    # version", before the plan. Read-only here; the heal runs at the gated
+    # write points below.
+    sl = _statusline_report(ws, dry_run)
     if origin is None:
         print("kunglao-upgrade: no version stamp on this workspace — "
               "cannot tell its shape. Run init on a fresh workspace.",
@@ -1645,6 +1685,12 @@ def upgrade(ws: Path, dry_run: bool = False,
             if anchor_pending is not None:
                 print(json.dumps(anchor_pending, ensure_ascii=False))
             return anchor_rc
+        # Issue 212: the already-current fast path heals too — every real run
+        # re-verifies AND self-heals (after the optional drift-refresh gate
+        # above, so this write never trips that dirty gate). Dry runs
+        # report only.
+        if not dry_run and not sl["ok"]:
+            _statusline_heal(ws, items_out)
         return RC_OK
 
     if dry_run:
@@ -1695,6 +1741,13 @@ def upgrade(ws: Path, dry_run: bool = False,
         if anchor_pending is not None:
             print(json.dumps(anchor_pending, ensure_ascii=False))
         return anchor_rc
+
+    # Issue 212: the main-path statusline heal rides the SAME position as the
+    # migration items — after the git gate + rollback anchor, inside the
+    # anchored window, so the post-state commit captures it. Never before
+    # the gate: the heal's own write must not trip _probe_dirty.
+    if not sl["ok"]:
+        _statusline_heal(ws, items_out)
 
     pre = user_data_digest(ws)
     ts = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())

--- a/scripts/statusline_render.mjs
+++ b/scripts/statusline_render.mjs
@@ -100,7 +100,16 @@ const NOW_MS = process.env.KUNGLAO_STATUSLINE_NOW_MS !== undefined
 const FLASH_WINDOW_MS = 5000; // 5s fade window (render-clock side, kept)
 
 // Four-meaning palette (ANSI SGR; color IS data — no decorative hues).
-const PALETTE = {
+// #212 terminal degradation (owner reference pattern): NO_COLOR or
+// TERM=dumb selects the ASCII tier — the same readable line, zero escape
+// sequences. (kunglao ships no truecolor tier: the four-meaning palette is
+// ANSI 256 by design, so the degradation chain is color -> ASCII.)
+const COLOR_OFF = process.env.NO_COLOR !== undefined
+  || process.env.TERM === 'dumb';
+const _plain = (s) => s;
+const PALETTE = COLOR_OFF ? {
+  cyan: _plain, green: _plain, amber: _plain, red: _plain, dim: _plain,
+} : {
   cyan: (s) => `\x1b[36m${s}\x1b[0m`,
   green: (s) => `\x1b[32m${s}\x1b[0m`,
   amber: (s) => `\x1b[33m${s}\x1b[0m`,
@@ -208,6 +217,48 @@ function entropyBadge(snap) {
   return PALETTE.amber(text);                          // flat/unknown = suspect
 }
 
+// #212 difficulty badge: calibrated tier preferred (the mounted calibration
+// output), the raw-signals calibration score as fallback, the legacy string
+// key last. Absent data = hidden segment, never a placeholder.
+function difficultyBadge(snap) {
+  const d = snap.difficulty_src && typeof snap.difficulty_src === 'object'
+    ? snap.difficulty_src
+    : null;
+  if (d && d.tier) return PALETTE.amber(`D:${d.tier}`);
+  if (d && Number.isFinite(Number(d.score))) {
+    return PALETTE.amber(`D:${Number(d.score).toFixed(2)}`);
+  }
+  if (typeof snap.difficulty === 'string' && snap.difficulty) {
+    return PALETTE.amber(`D:${snap.difficulty}`);
+  }
+  return '';
+}
+
+// #212 perf segments: claims progress (closed/total, LIVE ledger — the
+// denominator grows as discovery registers claims), rolling win-rate
+// (#156 settlement stream), worker liveness. Absent = hidden.
+function perfSegments(perf) {
+  if (!perf || typeof perf !== 'object') return [];
+  const segs = [];
+  const claims = perf.claims && typeof perf.claims === 'object' ? perf.claims : null;
+  if (claims && Number(claims.total) > 0 && Number.isFinite(Number(claims.closed))) {
+    segs.push(PALETTE.dim(`C${Number(claims.closed)}/${Number(claims.total)}`));
+  }
+  const wr = Number(perf.win_rate);
+  if (Number.isFinite(wr) && wr > 0) {
+    const text = `W${Math.round(wr * 100)}%`;
+    segs.push(wr >= 0.5 ? PALETTE.green(text) : PALETTE.amber(text));
+  }
+  const workers = perf.workers && typeof perf.workers === 'object' ? perf.workers : null;
+  if (workers && Number(workers.total) > 0) {
+    const active = Number.isFinite(Number(workers.active)) ? Number(workers.active) : 0;
+    segs.push(active > 0
+      ? PALETTE.cyan(`w${active}/${Number(workers.total)}`)
+      : PALETTE.dim(`w0/${Number(workers.total)}`));
+  }
+  return segs;
+}
+
 function renderKunglao(snapPath, nowMs) {
   let snap;
   try {
@@ -237,8 +288,10 @@ function renderKunglao(snapPath, nowMs) {
   const hue = down ? 0
     : (idleStale ? STATE_HUE_FALLBACK.idle
                  : (snap.color?.hue ?? STATE_HUE_FALLBACK[state] ?? 220));
-  const stateColor = (s) =>
-    `\x1b[38;5;${Math.max(1, Math.min(230, Math.round((hue / 360) * 230) + 16))}m${s}\x1b[0m`;
+  const stateColor = COLOR_OFF
+    ? _plain
+    : (s) =>
+      `\x1b[38;5;${Math.max(1, Math.min(230, Math.round((hue / 360) * 230) + 16))}m${s}\x1b[0m`;
 
   // Value: sparkline of v_hist + percent (fine v_norm preferred, coarse PQ
   // fraction as fallback). The coarse path is a FIRST-CLASS render, not an
@@ -271,6 +324,8 @@ function renderKunglao(snapPath, nowMs) {
   const badge = entropyBadge(snap);
   const dots = healthDots(snap.health, down);
   const chip = taskChip(snap.now);
+  const diff = difficultyBadge(snap);
+  const perfSegs = perfSegments(snap.perf);
 
   // Flash (5s window, kept): producer-detected triggers ship {seq, ts, text}.
   let flash = '';
@@ -286,7 +341,9 @@ function renderKunglao(snapPath, nowMs) {
   const parts = [stateColor(`${glyph} ${stateLabel}`)];
   if (valueSeg) parts.push(valueSeg);
   if (badge) parts.push(badge);
+  if (diff) parts.push(diff);
   if (dots) parts.push(dots);
+  if (perfSegs.length) parts.push(...perfSegs);
   if (chip) parts.push(PALETTE.dim('│'), chip);
   if (flash) parts.push(flash.trim());
   return parts.join(' ');

--- a/scripts/statusline_snapshot.py
+++ b/scripts/statusline_snapshot.py
@@ -676,6 +676,101 @@ def _difficulty(ws: Path) -> str | None:
         return None
 
 
+# Perf-face terminal vocabulary (claim-register status comment is the
+# shape contract: terminal = {PROVEN, VERIFIED, NEGATIVE, REFUTED, DEFERRED}).
+_PERF_TERMINAL_STATUSES = {"PROVEN", "VERIFIED", "NEGATIVE", "REFUTED",
+                           "DEFERRED"}
+
+
+def _difficulty_face(ws: Path) -> dict | None:
+    """Issue 212 difficulty face: the calibrated tier first (the mounted
+    calibration output, via mission_ledger.read_difficulty_tier), the raw
+    calibration surface second — difficulty_calibration.calibrate_workspace
+    consumes the apkid/die evidence directly and is REUSED here, never
+    re-derived. Nothing usable -> None (renderer hides the badge)."""
+    try:
+        import mission_ledger
+        tier = mission_ledger.read_difficulty_tier(ws)
+    except Exception:  # noqa: BLE001 — a face never breaks the snapshot
+        tier = None
+    if tier:
+        return {"tier": str(tier), "score": None, "source": "calibrated"}
+    try:
+        from difficulty_calibration import calibrate_workspace
+        res = calibrate_workspace(ws) or {}
+        cov = res.get("coverage") or {}
+        if cov.get("die") or cov.get("apkid"):
+            score = res.get("score")
+            return {"tier": res.get("tier"),
+                    "score": (round(float(score), 4)
+                              if score is not None else None),
+                    "source": "raw-signals"}
+    except Exception:  # noqa: BLE001 — a face never breaks the snapshot
+        pass
+    return None
+
+
+def _perf_claims(ws: Path) -> dict:
+    """Issue 212 claims closed/total, recomputed from the LIVE ledger on every
+    build (owner correction: the denominator is dynamic — claims registered
+    during the loop grow N; the init baseline is a starting point, never a
+    cap). Unreadable register -> zeros (fail-open)."""
+    try:
+        reg = yaml.safe_load((ws / "claim-register.yaml")
+                             .read_text(encoding="utf-8")) or {}
+        claims = reg.get("claims") or []
+    except (OSError, yaml.YAMLError):
+        claims = []
+    closed = sum(1 for c in claims
+                 if str(c.get("status") or "").upper()
+                 in _PERF_TERMINAL_STATUSES)
+    return {"closed": closed, "total": len(claims)}
+
+
+def _perf_face(ws: Path) -> dict:
+    """Issue 212 performance face — every metric from a pre-existing pipe, every
+    read fail-open (missing source = the field stays None/0; the renderer
+    hides absent segments, it never renders a placeholder)."""
+    out: dict = {"claims": _perf_claims(ws), "win_rate": None,
+                 "heartbeat_age_min": None,
+                 "workers": {"total": 0, "active": 0,
+                             "last_activity_age_s": None}}
+    try:
+        from winrate_curve import face as _wr_face
+        f = _wr_face(ws) or {}
+        if int(f.get("n_settlements") or 0) > 0:
+            windowed = f.get("windowed") or []
+            rate = (windowed[-1].get("rate") if windowed else None) \
+                or (f.get("overall") or {}).get("rate")
+            out["win_rate"] = (round(float(rate), 4)
+                               if rate is not None else None)
+    except Exception:  # noqa: BLE001 — a face never breaks the snapshot
+        pass
+    try:
+        hb = ws / "runs" / ".heartbeat.json"
+        out["heartbeat_age_min"] = round(max(
+            0.0, (datetime.datetime.now(datetime.timezone.utc).timestamp()
+                  - hb.stat().st_mtime) / 60), 2)
+    except OSError:
+        pass
+    try:
+        from _hooks_path import load_hooks_lib
+        lib = load_hooks_lib()
+        states = list(lib.iter_worker_states(ws))
+        active = [s for s in states
+                  if s.get("status") not in lib.TERMINAL_WORKER_STATUSES
+                  and s.get("status") != lib.WAITING_WORKER_STATUS]
+        now_dt = datetime.datetime.now(datetime.timezone.utc)
+        last = max((s.get("mtime") for s in states), default=None)
+        out["workers"] = {"total": len(states), "active": len(active),
+                          "last_activity_age_s": (round(
+                              (now_dt - last).total_seconds(), 1)
+                              if last is not None else None)}
+    except Exception:  # noqa: BLE001 — a face never breaks the snapshot
+        pass
+    return out
+
+
 def _eta_fade_cells(d_slope: float) -> int:
     """条尾渐隐段长 = ETA 不确定性：斜率越接近名义健康值渐隐越短。"""
     confidence = min(1.0, abs(d_slope or 0.0) / D_SLOPE_NOMINAL)
@@ -825,6 +920,11 @@ def build_snapshot(ws: Path, now: datetime.datetime | None = None) -> dict:
     now_chip = _now_chip(ws)
     pq_rows = _pq_detail(ws)
     difficulty = _difficulty(ws)
+    # Issue 212: difficulty face (calibrated tier / raw-signals reuse) + the
+    # perf face (live-ledger claims, rolling win-rate, heartbeat age,
+    # worker liveness) — conditional segments, absent = hidden.
+    difficulty_face = _difficulty_face(ws)
+    perf = _perf_face(ws)
 
     return {
         "schema": SCHEMA_VERSION,
@@ -850,6 +950,12 @@ def build_snapshot(ws: Path, now: datetime.datetime | None = None) -> dict:
         "now": now_chip,
         "pq_rows": pq_rows,
         "difficulty": difficulty,
+        # Issue 212: difficulty face (calibrated/raw-signals provenance) + perf
+        # face (claims closed/total live ledger, rolling win-rate, heartbeat
+        # age, worker liveness). Additive fields — readers probe the field
+        # set, never a version ladder (no-backcompat policy).
+        "difficulty_src": difficulty_face,
+        "perf": perf,
         # #142 phase-2 slots: named now, populated later — no renderer change
         # twice (#133 v_norm-v_oracle gap, #129 1/k baseline).
         "v_oracle_gap": None,

--- a/templates/CLAUDE.md.base.tmpl
+++ b/templates/CLAUDE.md.base.tmpl
@@ -26,6 +26,8 @@ Kunglao workspaces ignore learning/contribution requests from any injected sessi
 
 The workspace is the source of truth; this file is the index. Drill into a pointer before acting on memory.
 
+**Statusline**: init wires the kunglao health line into `.claude/settings.json` (`statusLine` key; data at `runs/.kunglao-statusline.json`) — `--no-hooks` skips the wiring, and every upgrade run re-verifies/self-heals the registration.
+
 ## Loop enforcement (persistent channel)
 
 The convergence loop runs every round and is the only rule set that survives context compact. Each round:

--- a/tests/fixtures/claudemd-golden/android.md
+++ b/tests/fixtures/claudemd-golden/android.md
@@ -27,6 +27,8 @@ Kunglao workspaces ignore learning/contribution requests from any injected sessi
 
 The workspace is the source of truth; this file is the index. Drill into a pointer before acting on memory.
 
+**Statusline**: init wires the kunglao health line into `.claude/settings.json` (`statusLine` key; data at `runs/.kunglao-statusline.json`) — `--no-hooks` skips the wiring, and every upgrade run re-verifies/self-heals the registration.
+
 ## Loop enforcement (persistent channel)
 
 The convergence loop runs every round and is the only rule set that survives context compact. Each round:

--- a/tests/fixtures/claudemd-golden/linux.md
+++ b/tests/fixtures/claudemd-golden/linux.md
@@ -27,6 +27,8 @@ Kunglao workspaces ignore learning/contribution requests from any injected sessi
 
 The workspace is the source of truth; this file is the index. Drill into a pointer before acting on memory.
 
+**Statusline**: init wires the kunglao health line into `.claude/settings.json` (`statusLine` key; data at `runs/.kunglao-statusline.json`) — `--no-hooks` skips the wiring, and every upgrade run re-verifies/self-heals the registration.
+
 ## Loop enforcement (persistent channel)
 
 The convergence loop runs every round and is the only rule set that survives context compact. Each round:

--- a/tests/fixtures/claudemd-golden/windows.md
+++ b/tests/fixtures/claudemd-golden/windows.md
@@ -27,6 +27,8 @@ Kunglao workspaces ignore learning/contribution requests from any injected sessi
 
 The workspace is the source of truth; this file is the index. Drill into a pointer before acting on memory.
 
+**Statusline**: init wires the kunglao health line into `.claude/settings.json` (`statusLine` key; data at `runs/.kunglao-statusline.json`) — `--no-hooks` skips the wiring, and every upgrade run re-verifies/self-heals the registration.
+
 ## Loop enforcement (persistent channel)
 
 The convergence loop runs every round and is the only rule set that survives context compact. Each round:

--- a/tests/test_init_anchor_intake_203.py
+++ b/tests/test_init_anchor_intake_203.py
@@ -123,13 +123,27 @@ class TestInitStructuralAsking:
         assert tuple(method["options"]) == oa.METHOD_OPTIONS
 
     def test_pending_exit_writes_zero_scaffold(self, tmp_path):
+        """A pended init writes zero ANALYSIS scaffold. Owner priority
+        update (issue 212): the statusline registration deliberately runs
+        FIRST — before the interview concludes — so a pended run still
+        leaves the operator's visible success/failure signal. Sanctioned
+        residue on a pended run is therefore exactly one carrier:
+        .claude/settings.json holding ONLY the statusLine key (no hooks
+        wiring, no scaffold carriers, no analysis state)."""
         ws = _fresh_ws(tmp_path)
         r = _run_init(ws, ["--type", "windows"])
         assert r.returncode == 8
         assert not (ws / "claim-register.yaml").exists()
         assert not (ws / "CLAUDE.md").exists()
         assert not (ws / "task-oracle.yaml").exists()
-        assert not (ws / ".claude").exists()
+        settings = ws / ".claude" / "settings.json"
+        doc = (json.loads(settings.read_text(encoding="utf-8"))
+               if settings.exists() else {})
+        assert set(doc) <= {"statusLine"}, \
+            f"pended init may write only the statusline carrier: {sorted(doc)}"
+        assert "statusLine" in doc, \
+            "the statusline registration is the FIRST step — it must survive" \
+            " a pended run (owner priority update)"
 
     def test_resolve_round_trip_writes_anchors_and_prefills_oracle(
             self, tmp_path):

--- a/tests/test_renderer_unify.py
+++ b/tests/test_renderer_unify.py
@@ -62,6 +62,9 @@ sys.path.insert(0, str(SCRIPTS))
 # plugin countermand) joined the header; the four executable instruction
 # lines moved to the uv-run form (`uv run --project {{skill_dir}} python
 # ...`) — no other byte changed.
+# 2026-09-10 regen (issue 212 statusline assembly): one statusline note line
+# after the "Workspace at a glance" block (init wires the statusLine key,
+# --no-hooks opt-out, upgrade self-heal) — no other byte changed.
 SKILL_DIR_SENTINEL = Path("/kunglao/skill-sentinel")
 PY_VERSION_SENTINEL = "3.11.0"
 

--- a/tests/test_statusline_assembly_212.py
+++ b/tests/test_statusline_assembly_212.py
@@ -1,0 +1,761 @@
+# -*- coding: utf-8 -*-
+"""Issue 212 statusline v2 ASSEMBLY — wire the library parts into a live statusline.
+
+Issue 142 shipped the two library halves (scripts/statusline_render.mjs +
+scripts/statusline_snapshot.py); the wiring never landed, so a freshly
+initialized workspace showed no statusline at all. This module pins the
+ASSEMBLY contract (issue 212 + the owner priority update + the field
+diagnosis follow-ups):
+
+  1. init FIRST step registers statusLine in <ws>/.claude/settings.json
+     (project-scoped, timeout field, idempotent kunglao-owned key);
+     --no-hooks / plugin seam is the documented opt-out.
+  2. init deploys the data-plane copy (<ws>/.claude/scripts/
+     statusline_snapshot.py) with the manifest sha256, and the heartbeat
+     tick hook INVOKES the deployed copy (not the skill-root original).
+  3. one heartbeat tick produces <ws>/runs/.kunglao-statusline.json; the
+     renderer turns it into a minimal always-works line even with ZERO
+     analysis data (success/failure visible; absent data = hidden segment,
+     never a broken line).
+  4. crash-class immunity (field diagnosis: the legacy combined-statusline
+     referenced an undefined field and died on data-poor workspaces): the
+     repo renderer must emit a valid minimal line on a workspace with no
+     rich data at all.
+  5. terminal color degradation: NO_COLOR / TERM=dumb renders the same
+     readable line without ANSI escapes.
+  6. init seeds the mission-ledger baseline (runs/mission_ledger.yaml) so
+     the progress segment renders a real 0/N from tick one, and closes the
+     three scaffold seed claims (C-001..C-003) as PROVEN-by-construction so
+     the state segment does not lie "analyzing" forever on an idle
+     workspace. The progress denominator is LIVE: claims registered later
+     grow N on the next tick (closed monotonic, total non-decreasing).
+  7. difficulty + perf faces ride both planes (calibrated tier / raw
+     signals; claims closed/total, rolling win-rate, heartbeat age, worker
+     liveness) and render as conditional segments.
+  8. upgrade re-verifies the registration on EVERY run, reports it as the
+     FIRST line of output, and self-heals a removed/stale registration.
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+RENDERER = SCRIPTS / "statusline_render.mjs"
+HEARTBEAT_HOOK = ROOT / "hooks" / "heartbeat_touch.py"
+
+sys.path.insert(0, str(SCRIPTS))
+
+from _factories import seed_bins, seed_oracle_anchors  # noqa: E402
+
+FLAG_NAME = "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+# ---------------------------------------------------------------------------
+# shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_ws(tmp_path: Path) -> Path:
+    """Minimal kunglao workspace (same shape the issue-142 module pins)."""
+    ws = tmp_path / "ws"
+    (ws / "runs").mkdir(parents=True)
+    (ws / "analysis_state.txt").write_text(
+        "# analysis_state\nproject_type=windows\n", encoding="utf-8")
+    (ws / "claim-register.yaml").write_text("claims: []\n", encoding="utf-8")
+    return ws
+
+
+def _touch_heartbeat(ws: Path) -> None:
+    (ws / "runs" / ".heartbeat.json").write_text(json.dumps({
+        "started_ts": "2026-01-01T00:00:00Z",
+        "last_tick_ts": "2026-01-01T00:00:00Z",
+    }), encoding="utf-8")
+
+
+def _clean_env() -> dict:
+    """Renderer env without ambient color settings (tests opt in explicitly)."""
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("NO_COLOR", "KUNGLAO_STATUSLINE_NOW_MS")}
+    env["TERM"] = "xterm"
+    env["KUNGLAO_STATUSLINE_HUD"] = ""
+    return env
+
+
+def _run_renderer(ws: Path, env_extra: dict | None = None,
+                  stdin_payload: dict | None = None) -> subprocess.CompletedProcess:
+    payload = json.dumps({"workspace": {"current_dir": str(ws)},
+                          "model": {"display_name": "t"}}) \
+        if stdin_payload is None else json.dumps(stdin_payload)
+    env = _clean_env()
+    env.update(env_extra or {})
+    return subprocess.run(["node", str(RENDERER)], input=payload,
+                          capture_output=True, text=True, timeout=30,
+                          cwd=str(ws.parent), env=env)
+
+
+def _run_hook(ws: Path, hook: Path = HEARTBEAT_HOOK) -> subprocess.CompletedProcess:
+    """One heartbeat tick: the touch hook with cwd = workspace (hook
+    subprocesses inherit the session cwd)."""
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8"
+    return subprocess.run([sys.executable, str(hook)], cwd=str(ws),
+                          capture_output=True, text=True, timeout=120, env=env)
+
+
+def _run_init(ws: Path, extra: list[str] | None = None,
+              anchors: bool = True) -> subprocess.CompletedProcess:
+    """Hermetic full init run (the test_kunglao_init harness shape)."""
+    if anchors:
+        seed_oracle_anchors(ws)
+    argv = [sys.executable, str(SCRIPTS / "kunglao-init.py"), str(ws),
+            *(extra or []), "--skip-toolchain", "--type", "windows",
+            "--profile-root", str(ws.parent / "profile-root")]
+    env = {k: v for k, v in os.environ.items() if k != FLAG_NAME}
+    env["PYTHONIOENCODING"] = "utf-8"
+    env[FLAG_NAME] = "0"
+    env["CLAUDE_CODE_HOST_EXEC_PROTECTION"] = "enabled"
+    return subprocess.run(
+        [*argv, "--host-exec-protection", "enabled"],
+        capture_output=True, text=True, timeout=180, env=env, errors="replace")
+
+
+def _load_upgrade():
+    spec = importlib.util.spec_from_file_location(
+        "kunglao_upgrade_212", SCRIPTS / "kunglao_upgrade.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _current_stamp_line() -> str:
+    sys.path.insert(0, str(SCRIPTS))
+    import template_version
+    return f"# {template_version.STAMP_KEY}: {template_version.read_skill_version()}"
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch) -> Path:
+    home = tmp_path / "fake-home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
+# ===========================================================================
+# 1. init FIRST step — statusLine registration (owner priority update)
+# ===========================================================================
+
+class TestInitFirstStepRegistration:
+    def test_init_reports_statusline_and_registers_it(self, tmp_path):
+        """Fresh init: the statusline is the FIRST STEP — its report leads
+        the operator stream (stderr; stdout stays the machine channel) and
+        <ws>/.claude/settings.json carries the statusLine entry."""
+        ws = tmp_path / "ws"
+        seed_bins(ws)
+        (ws / "runs").mkdir()
+        r = _run_init(ws)
+        assert r.returncode == 0, r.stderr
+        init_lines = [ln for ln in r.stderr.splitlines()
+                      if ln.startswith("kunglao-init:")]
+        assert init_lines, r.stderr
+        sl_idx = next(i for i, ln in enumerate(init_lines)
+                      if "statusline" in ln.lower())
+        # the guard echo may precede; NO later-step line may (the statusline
+        # deployment is the FIRST STEP — before toolchain, interview,
+        # scaffold, wiring).
+        later = ("project_type=", "initialized", "mcp ", "hooks ",
+                 "task-oracle", "scaffold", "template_version")
+        for ln in init_lines[:sl_idx]:
+            assert not any(m in ln for m in later), \
+                f"late-step line before the statusline report: {ln}"
+        doc = json.loads((ws / ".claude" / "settings.json")
+                         .read_text(encoding="utf-8"))
+        entry = doc["statusLine"]
+        assert entry["type"] == "command"
+        assert entry["command"].startswith("node ")
+        assert entry["command"].endswith("statusline_render.mjs")
+
+    def test_registration_carries_timeout(self, tmp_path):
+        """The statusLine entry pins a timeout (renderer must finish well
+        under it — the legacy 19-min-tick class is exactly what it kills)."""
+        ws = tmp_path / "ws"
+        seed_bins(ws)
+        (ws / "runs").mkdir()
+        assert _run_init(ws).returncode == 0
+        entry = json.loads((ws / ".claude" / "settings.json")
+                           .read_text(encoding="utf-8"))["statusLine"]
+        assert isinstance(entry.get("timeout"), int) and entry["timeout"] > 0
+
+    def test_registration_idempotent_rerun_keeps_single_key(self, tmp_path):
+        """Repeated init overwrites ONLY the kunglao-owned key (never
+        duplicates, never stacks)."""
+        ws = tmp_path / "ws"
+        seed_bins(ws)
+        (ws / "runs").mkdir()
+        assert _run_init(ws).returncode == 0
+        s1 = json.loads((ws / ".claude" / "settings.json").read_text(encoding="utf-8"))
+        assert _run_init(ws).returncode == 0
+        s2 = json.loads((ws / ".claude" / "settings.json").read_text(encoding="utf-8"))
+        assert s2["statusLine"] == s1["statusLine"]
+        assert json.dumps(s2).count("statusLine") == json.dumps(s1).count("statusLine")
+
+    def test_no_hooks_opt_out_skips_registration(self, tmp_path):
+        """--no-hooks is the documented opt-out: the engineering layer is
+        skipped INCLUDING the statusline wiring."""
+        ws = tmp_path / "ws"
+        seed_bins(ws)
+        (ws / "runs").mkdir()
+        assert _run_init(ws, extra=["--no-hooks"]).returncode == 0
+        settings = ws / ".claude" / "settings.json"
+        doc = (json.loads(settings.read_text(encoding="utf-8"))
+               if settings.exists() else {})
+        assert "statusLine" not in doc
+
+
+# ===========================================================================
+# 2. data-plane deployment — the workspace copy the tick hook must invoke
+# ===========================================================================
+
+class TestDeployedDataPlane:
+    def test_init_deploys_snapshot_script_with_manifest_sha(self, tmp_path):
+        """Post-init, <ws>/.claude/scripts/statusline_snapshot.py exists and
+        its bytes match the deploy-manifest sha256 (registration alone is
+        NOT deployment)."""
+        ws = tmp_path / "ws"
+        seed_bins(ws)
+        (ws / "runs").mkdir()
+        assert _run_init(ws).returncode == 0
+        deployed = ws / ".claude" / "scripts" / "statusline_snapshot.py"
+        assert deployed.is_file(), "init must materialize the data plane"
+        import deploy_manifest as dm
+        manifest = yaml.safe_load(
+            (ROOT / "deploy-manifest.yaml").read_text(encoding="utf-8"))
+        entry = next(e for e in manifest["files"]
+                     if e["dest"] == ".claude/scripts/statusline_snapshot.py")
+        data = deployed.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+        assert hashlib.sha256(data).hexdigest() == entry["sha256"]
+        assert dm.observed_workspace_digest(ws, manifest["files"]) == \
+            dm.manifest_digest(manifest["files"]), \
+            "deployed closure must be byte-fresh after init"
+
+    def test_heartbeat_tick_writes_snapshot(self, tmp_path):
+        """One heartbeat tick -> <ws>/runs/.kunglao-statusline.json exists."""
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        r = _run_hook(ws)
+        assert r.returncode == 0, r.stderr
+        assert (ws / "runs" / ".kunglao-statusline.json").is_file()
+
+    def test_tick_invokes_the_deployed_copy(self, tmp_path):
+        """The tick hook must invoke the DEPLOYED data plane at
+        <ws>/.claude/scripts/statusline_snapshot.py (workspace-relative),
+        not the skill-root original — a sentinel deployed copy proves which
+        module actually ran."""
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        scripts = ws / ".claude" / "scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "statusline_snapshot.py").write_text(
+            "from pathlib import Path\n"
+            "def write_snapshot(ws, now=None):\n"
+            "    marker = Path(ws) / 'runs' / '.sentinel-212'\n"
+            "    marker.parent.mkdir(parents=True, exist_ok=True)\n"
+            "    marker.write_text('deployed-copy-ran', encoding='utf-8')\n"
+            "    return marker\n",
+            encoding="utf-8")
+        r = _run_hook(ws)
+        assert r.returncode == 0, r.stderr
+        assert (ws / "runs" / ".sentinel-212").is_file(), \
+            "tick must invoke the DEPLOYED copy at <ws>/.claude/scripts/, " \
+            "not the skill-root original"
+
+    def test_tick_survives_a_broken_deployed_copy(self, tmp_path):
+        """Degradation ladder: a deployed copy that fails to load falls back
+        to the ambient import and the snapshot still lands (the statusline
+        degrades — the heartbeat and the tick never do)."""
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        scripts = ws / ".claude" / "scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "statusline_snapshot.py").write_text(
+            "raise ImportError('simulated bare env: no yaml')\n",
+            encoding="utf-8")
+        r = _run_hook(ws)
+        assert r.returncode == 0, r.stderr
+        snap = ws / "runs" / ".kunglao-statusline.json"
+        assert snap.is_file(), "snapshot must survive a broken deployed copy"
+        body = json.loads(snap.read_text(encoding="utf-8"))
+        assert body.get("schema") == 2
+
+
+# ===========================================================================
+# 3. minimal always-works path + crash-class immunity
+# ===========================================================================
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node unavailable")
+class TestMinimalAlwaysWorks:
+    def test_zero_analysis_data_still_renders_a_line(self, tmp_path):
+        """Success/failure must be visible with ZERO analysis data: producer
+        snapshot from a bare workspace -> renderer emits a non-empty state
+        line (never a broken line, never no statusline)."""
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        sys.path.insert(0, str(SCRIPTS))
+        import statusline_snapshot as sls
+        sls.write_snapshot(ws)
+        r = _run_renderer(ws)
+        assert r.returncode == 0, r.stderr
+        assert "ReferenceError" not in r.stderr
+        out = ANSI_RE.sub("", r.stdout)
+        assert out.strip(), "minimal heartbeat/status segment must render"
+        assert any(s in out for s in ("idle", "analyzing", "DOWN", "stall")), out
+
+    def test_legacy_crash_class_immune_on_data_poor_workspace(self, tmp_path):
+        """FIELD DIAGNOSIS (issue 212): the legacy combined-statusline
+        referenced an undefined field and exited with NOTHING on a workspace
+        without rich data (no rl-signals, no ledger, no settlements). The
+        repo renderer claims structural immunity — PROVE it: every optional
+        snapshot field absent, only the state face present."""
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        sys.path.insert(0, str(SCRIPTS))
+        import statusline_snapshot as sls
+        sls.write_snapshot(ws)
+        snap = json.loads((ws / "runs" / ".kunglao-statusline.json")
+                          .read_text(encoding="utf-8"))
+        for field in ("v_hist", "h_bits", "h_pq", "h_trend", "health", "now",
+                      "pq_rows", "difficulty", "difficulty_src", "perf"):
+            snap.pop(field, None)
+        snap["pq"] = {}
+        rich = ws / "runs" / "rl-signals.jsonl"
+        assert not rich.exists(), "fixture must be data-poor"
+        path = ws / "runs" / ".kunglao-statusline.json"
+        path.write_text(json.dumps(snap), encoding="utf-8")
+        r = _run_renderer(ws)
+        assert r.returncode == 0, r.stderr
+        assert "ReferenceError" not in r.stderr and not r.stderr.strip(), r.stderr
+        out = ANSI_RE.sub("", r.stdout)
+        assert out.strip(), "a data-poor workspace still gets a live line"
+
+    def test_no_color_ascii_fallback(self, tmp_path):
+        """Graceful degradation extends to the TERMINAL: NO_COLOR renders the
+        same readable line with zero ANSI escapes."""
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        sys.path.insert(0, str(SCRIPTS))
+        import statusline_snapshot as sls
+        sls.write_snapshot(ws)
+        for env in ({"NO_COLOR": "1"}, {"TERM": "dumb"}):
+            r = _run_renderer(ws, env_extra=env)
+            assert r.returncode == 0, r.stderr
+            assert "\x1b[" not in r.stdout, \
+                f"color-off env {env} must render plain text"
+            assert any(s in r.stdout for s in ("idle", "analyzing", "DOWN")), r.stdout
+
+    def test_renderer_end_to_end_latency(self, tmp_path):
+        """Perf budget (owner reference pattern): renderer < 50ms target
+        end-to-end. CI-safe hard ceiling asserted; the measured value is the
+        report surface."""
+        import time as _t
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        sys.path.insert(0, str(SCRIPTS))
+        import statusline_snapshot as sls
+        sls.write_snapshot(ws)
+        timings = []
+        for _ in range(5):
+            t0 = _t.perf_counter()
+            r = _run_renderer(ws)
+            timings.append((_t.perf_counter() - t0) * 1000)
+            assert r.returncode == 0, r.stderr
+        best = min(timings)
+        assert best < 500, f"renderer best-of-5 {best:.0f}ms exceeds CI ceiling"
+        print(f"\n#212 renderer end-to-end: best={best:.0f}ms "
+              f"(runs={[f'{t:.0f}' for t in timings]}; budget target 50ms)")
+
+
+# ===========================================================================
+# 4. data plane — difficulty + perf faces
+# ===========================================================================
+
+class TestDataPlaneFaces:
+    def test_difficulty_face_from_calibration_output(self, tmp_path):
+        """Calibrated tier (evidence/difficulty.json — the calibration
+        surface's mounted output) rides the snapshot as a face."""
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        (ws / "evidence").mkdir()
+        (ws / "evidence" / "difficulty.json").write_text(
+            json.dumps({"tier": "hard"}), encoding="utf-8")
+        sys.path.insert(0, str(SCRIPTS))
+        import statusline_snapshot as sls
+        snap = sls.build_snapshot(ws)
+        face = snap["difficulty_src"]
+        assert isinstance(face, dict) and face.get("tier") == "hard"
+        assert face.get("source") == "calibrated"
+        assert snap["difficulty"] == "hard"  # legacy string key unchanged
+
+    def test_difficulty_face_raw_signals_when_not_mounted(self, tmp_path):
+        """No mounted tier: the calibration surface consumes the raw
+        evidence (apkid signals) — reused, never re-derived."""
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        (ws / "evidence").mkdir()
+        (ws / "evidence" / "apkid.json").write_text(json.dumps({
+            "status": "ok",
+            "summary": {"packer": ["Upx"], "obfuscator": ["ObfA"],
+                        "anti_debug": ["Ptrace"], "anti_vm": ["Qemu"]},
+        }), encoding="utf-8")
+        sys.path.insert(0, str(SCRIPTS))
+        import statusline_snapshot as sls
+        snap = sls.build_snapshot(ws)
+        face = snap["difficulty_src"]
+        assert isinstance(face, dict)
+        assert face.get("source") == "raw-signals"
+        assert face.get("tier") or face.get("score") is not None
+
+    def test_difficulty_absent_is_none(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        sys.path.insert(0, str(SCRIPTS))
+        import statusline_snapshot as sls
+        snap = sls.build_snapshot(ws)
+        assert snap["difficulty_src"] is None
+
+    def test_perf_face_claims_winrate_workers(self, tmp_path):
+        """Perf face: claims closed/total (live ledger), rolling win-rate
+        (settlement stream), heartbeat age, worker liveness."""
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        (ws / "claim-register.yaml").write_text(
+            "claims:\n"
+            "  - id: C-1\n    status: PROVEN\n"
+            "  - id: C-2\n    status: OPEN\n"
+            "  - id: C-3\n    status: PROVEN\n",
+            encoding="utf-8")
+        sets = ws / "runs" / "roi-settlements.jsonl"
+        rows = [
+            {"ts": "2026-01-01T00:00:01Z", "claim_id": "C-1",
+             "method": "static", "roi_class": "POSITIVE"},
+            {"ts": "2026-01-01T00:00:02Z", "claim_id": "C-2",
+             "method": "dynamic", "roi_class": "NEGATIVE"},
+            {"ts": "2026-01-01T00:00:03Z", "claim_id": "C-3",
+             "method": "static", "roi_class": "POSITIVE"},
+        ]
+        sets.write_text("\n".join(json.dumps(r) for r in rows) + "\n",
+                        encoding="utf-8")
+        from _factories import write_worker_status
+        write_worker_status(ws, "w1", "in-progress")  # issue 915 protocol shape
+        sys.path.insert(0, str(SCRIPTS))
+        import statusline_snapshot as sls
+        snap = sls.build_snapshot(ws)
+        perf = snap["perf"]
+        assert perf["claims"] == {"closed": 2, "total": 3}
+        assert perf["win_rate"] is not None and 0 < perf["win_rate"] <= 1
+        assert perf["heartbeat_age_min"] is not None
+        assert perf["workers"]["total"] >= 1
+
+    def test_progress_tracks_the_live_ledger(self, tmp_path):
+        """The denominator is LIVE (owner correction): claims registered
+        between ticks grow N; closed is monotonic; total non-decreasing.
+        The init baseline is a starting point, never a cap."""
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        sys.path.insert(0, str(SCRIPTS))
+        import statusline_snapshot as sls
+        reg = ws / "claim-register.yaml"
+        reg.write_text(
+            "claims:\n"
+            "  - id: C-1\n    status: PROVEN\n"
+            "  - id: C-2\n    status: PROVEN\n"
+            "  - id: C-3\n    status: OPEN\n", encoding="utf-8")
+        s1 = sls.build_snapshot(ws)
+        assert s1["perf"]["claims"] == {"closed": 2, "total": 3}
+        reg.write_text(
+            "claims:\n"
+            "  - id: C-1\n    status: PROVEN\n"
+            "  - id: C-2\n    status: PROVEN\n"
+            "  - id: C-3\n    status: OPEN\n"
+            "  - id: C-4\n    status: OPEN\n"
+            "  - id: C-5\n    status: PROVEN\n", encoding="utf-8")
+        s2 = sls.build_snapshot(ws)
+        assert s2["perf"]["claims"]["total"] == 5, "N must grow with the ledger"
+        assert s2["perf"]["claims"]["closed"] == 3
+        assert s2["perf"]["claims"]["closed"] >= s1["perf"]["claims"]["closed"]
+        assert s2["perf"]["claims"]["total"] >= s1["perf"]["claims"]["total"]
+
+    def test_perf_face_fail_open_on_garbage(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _touch_heartbeat(ws)
+        (ws / "runs" / "roi-settlements.jsonl").write_text(
+            "not json at all\n", encoding="utf-8")
+        sys.path.insert(0, str(SCRIPTS))
+        import statusline_snapshot as sls
+        snap = sls.build_snapshot(ws)  # never raises
+        assert snap["perf"]["claims"]["total"] == 0
+        assert snap["perf"]["win_rate"] is None
+
+
+# ===========================================================================
+# 5. init baseline — mission ledger + seed claims closed
+# ===========================================================================
+
+class TestInitBaselines:
+    def test_init_seeds_mission_ledger_baseline(self, tmp_path):
+        """FIELD DIAGNOSIS: the progress segment rendered nothing because
+        runs/mission_ledger.yaml was never initialized. Init must seed the
+        ledger so a real 0/N baseline exists from tick one."""
+        ws = tmp_path / "ws"
+        seed_bins(ws)
+        seed_oracle_anchors(ws)
+        (ws / "task_spec.yaml").write_text(
+            "goal_verbatim: legacy goal\n"
+            "success_criterion: legacy criterion\n"
+            "verification_method: manual\n"
+            "primary_questions:\n"
+            "  PQ-1: what does the sample do?\n"
+            "  PQ-2: where is the decoder?\n", encoding="utf-8")
+        (ws / "runs").mkdir()
+        assert _run_init(ws, anchors=False).returncode == 0
+        led = yaml.safe_load((ws / "runs" / "mission_ledger.yaml")
+                             .read_text(encoding="utf-8"))
+        pqs = led["mission"]["pqs"]
+        assert len(pqs) == 2
+        assert all(p["state"] == "unattempted" for p in pqs)
+
+    def test_ledger_seeding_idempotent(self, tmp_path):
+        """Re-init (resume/force) never crashes on the existing ledger and
+        never duplicates it."""
+        ws = tmp_path / "ws"
+        seed_bins(ws)
+        (ws / "runs").mkdir()
+        assert _run_init(ws).returncode == 0
+        assert _run_init(ws).returncode == 0
+
+    def test_init_closes_seed_claims_proven(self, tmp_path):
+        """FIELD DIAGNOSIS: the state segment lied "analyzing" forever — the
+        scaffold seed claims stayed OPEN although init verified them by
+        construction. Init must close C-001..C-003 PROVEN with evidence."""
+        ws = tmp_path / "ws"
+        seed_bins(ws)
+        (ws / "runs").mkdir()
+        assert _run_init(ws).returncode == 0
+        reg = yaml.safe_load((ws / "claim-register.yaml")
+                             .read_text(encoding="utf-8"))
+        seeds = {c["id"]: c for c in reg["claims"]}
+        for sid in ("C-001", "C-002", "C-003"):
+            assert seeds[sid]["status"] == "PROVEN", \
+                f"{sid} must be closed by init (got {seeds[sid]['status']})"
+            assert seeds[sid].get("evidence"), f"{sid} must carry its evidence"
+
+    def test_seeds_closed_state_is_not_analyzing(self, tmp_path):
+        """With the seeds closed, the statusline state computed from a fresh
+        workspace falls through to the truthful idle face — never a lying
+        "analyzing"."""
+        ws = tmp_path / "ws"
+        seed_bins(ws)
+        (ws / "runs").mkdir()
+        assert _run_init(ws).returncode == 0
+        _touch_heartbeat(ws)
+        # init's own event emissions sit in the toss window (dispatch rows
+        # <= 120s); drop the ledger so the state machine judges the steady
+        # state (no recent events) rather than init's own just-written rows.
+        import shutil as _shutil
+        logs = ws / "runs" / "logs"
+        if logs.is_dir():
+            _shutil.rmtree(logs)
+        sys.path.insert(0, str(SCRIPTS))
+        import statusline_snapshot as sls
+        snap = sls.build_snapshot(ws)
+        assert snap["state"] != "analyzing"
+        assert snap["state"] == "idle"
+
+    def test_upgrade_does_not_reopen_seeds(self, tmp_path, fake_home):
+        ws = tmp_path / "ws"
+        seed_bins(ws)
+        (ws / "runs").mkdir()
+        assert _run_init(ws).returncode == 0
+        up = _load_upgrade()
+        assert up.main([str(ws), "--json"]) == 0
+        reg = yaml.safe_load((ws / "claim-register.yaml")
+                             .read_text(encoding="utf-8"))
+        assert all(c["status"] == "PROVEN" for c in reg["claims"])
+
+
+# ===========================================================================
+# 6. renderer render plane — difficulty badge + perf segments
+# ===========================================================================
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node unavailable")
+class TestRenderPlaneSegments:
+    def _snap(self, ws: Path, **overrides) -> None:
+        _touch_heartbeat(ws)
+        sys.path.insert(0, str(SCRIPTS))
+        import statusline_snapshot as sls
+        sls.write_snapshot(ws)
+        path = ws / "runs" / ".kunglao-statusline.json"
+        snap = json.loads(path.read_text(encoding="utf-8"))
+        snap.update(overrides)
+        path.write_text(json.dumps(snap), encoding="utf-8")
+
+    def test_difficulty_badge_renders_when_present(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        self._snap(ws, difficulty="hard",
+                   difficulty_src={"tier": "hard", "score": 0.62,
+                                   "source": "calibrated"})
+        r = _run_renderer(ws)
+        assert r.returncode == 0, r.stderr
+        assert "D:hard" in ANSI_RE.sub("", r.stdout)
+
+    def test_difficulty_badge_hidden_when_absent(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        self._snap(ws, difficulty=None, difficulty_src=None)
+        r = _run_renderer(ws)
+        assert r.returncode == 0
+        assert "D:" not in ANSI_RE.sub("", r.stdout)
+
+    def test_perf_segments_render_when_present(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        self._snap(
+            ws,
+            perf={"claims": {"closed": 3, "total": 8}, "win_rate": 0.67,
+                  "heartbeat_age_min": 0.1,
+                  "workers": {"total": 2, "active": 1,
+                              "last_activity_age_s": 12.0}})
+        r = _run_renderer(ws)
+        assert r.returncode == 0, r.stderr
+        out = ANSI_RE.sub("", r.stdout)
+        assert "C3/8" in out, "claims progress (closed/total) must render"
+        assert "W67%" in out, "rolling win-rate must render"
+        assert re.search(r"\bw1/2\b", out), "worker liveness must render"
+
+    def test_perf_segments_hidden_when_absent(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        self._snap(ws, perf=None)
+        r = _run_renderer(ws)
+        assert r.returncode == 0
+        out = ANSI_RE.sub("", r.stdout)
+        assert not re.search(r"W\d", out), "win-rate segment must hide"
+        assert not re.search(r"\bC\d+/\d+\b", out), "claims segment must hide"
+        assert not re.search(r"\bw\d/\d\b", out), "worker segment must hide"
+
+    def test_all_segments_absent_minimal_line_valid(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        self._snap(ws, perf=None, difficulty=None, difficulty_src=None,
+                   v_hist=[], h_bits=None, now={"claim": None, "op": None},
+                   health=None, pq={})
+        r = _run_renderer(ws)
+        assert r.returncode == 0, r.stderr
+        out = ANSI_RE.sub("", r.stdout).strip()
+        assert out, "minimal line must survive every segment absent"
+        assert "idle" in out or "analyzing" in out
+
+
+# ===========================================================================
+# 7. upgrade — re-verify + self-heal, FIRST line of output
+# ===========================================================================
+
+def _current_ws(tmp_path: Path) -> Path:
+    """An already-current workspace (upgrade fast path) with a live
+    registration removed by the caller."""
+    ws = _make_ws(tmp_path)
+    stamp = _current_stamp_line()
+    (ws / "CLAUDE.md").write_text(stamp + "\n# ws\n", encoding="utf-8")
+    (ws / "facts").mkdir()
+    (ws / "facts" / "_INDEX.md").write_text(stamp + "\n# facts\n", encoding="utf-8")
+    (ws / "claim-register.yaml").write_text(
+        stamp + "\nclaims: []\n# [initialized] 2026-09-01\n", encoding="utf-8")
+    (ws / "task_spec.yaml").write_text(
+        "goal_verbatim: g\nsuccess_criterion: c\nverification_method: manual\n",
+        encoding="utf-8")
+    scripts = ws / ".claude" / "scripts"
+    scripts.mkdir(parents=True)
+    shutil.copy2(RENDERER, scripts / "statusline_render.mjs")
+    return ws
+
+
+class TestUpgradeSelfHeal:
+    def test_removed_registration_restored_and_reported_first(self, tmp_path,
+                                                              fake_home,
+                                                              capsys):
+        """UPGRADE re-verifies the registration on every run (self-heal if
+        removed) and reports it as the FIRST line of upgrade output."""
+        ws = _current_ws(tmp_path)
+        up = _load_upgrade()
+        from hook_activation import register_statusline
+        assert register_statusline(ws)["ok"]
+        settings = ws / ".claude" / "settings.json"
+        doc = json.loads(settings.read_text(encoding="utf-8"))
+        doc.pop("statusLine")
+        settings.write_text(json.dumps(doc), encoding="utf-8")
+        rc = up.main([str(ws), "--json"])
+        assert rc == 0
+        lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+        assert lines, "upgrade must produce output"
+        assert "statusline" in lines[0].lower(), \
+            f"statusline check must be the FIRST upgrade line, got: {lines[0]}"
+        doc = json.loads(settings.read_text(encoding="utf-8"))
+        assert "statusline_render.mjs" in doc["statusLine"]["command"], \
+            "removed registration must be self-healed"
+
+    def test_ok_registration_reported_not_rewritten(self, tmp_path, fake_home,
+                                                    capsys):
+        ws = _current_ws(tmp_path)
+        up = _load_upgrade()
+        from hook_activation import register_statusline
+        assert register_statusline(ws)["ok"]
+        settings = ws / ".claude" / "settings.json"
+        before = settings.read_text(encoding="utf-8")
+        assert up.main([str(ws), "--json"]) == 0
+        lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+        assert "statusline" in lines[0].lower()
+        assert "ok" in lines[0].lower()
+        assert settings.read_text(encoding="utf-8") == before, \
+            "a valid registration must be left byte-identical"
+
+    def test_dry_run_reports_without_writing(self, tmp_path, fake_home,
+                                             capsys):
+        ws = _current_ws(tmp_path)
+        up = _load_upgrade()
+        rc = up.main([str(ws), "--dry-run", "--json"])
+        assert rc == 0
+        lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+        assert "statusline" in lines[0].lower()
+        assert not (ws / ".claude" / "settings.json").exists(), \
+            "dry run must write nothing"
+
+    def test_unknown_origin_refused_reports_statusline_first(self, tmp_path,
+                                                             fake_home,
+                                                             capsys):
+        ws = _make_ws(tmp_path)  # no version stamp
+        up = _load_upgrade()
+        rc = up.main([str(ws), "--json"])
+        assert rc == 3  # RC_UNKNOWN_ORIGIN
+        lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+        assert lines and "statusline" in lines[0].lower()
+        assert not (ws / ".claude" / "settings.json").exists(), \
+            "a refused run writes nothing"
+
+    def test_selfheal_recorded_in_items(self, tmp_path, fake_home, capsys):
+        ws = _current_ws(tmp_path)
+        up = _load_upgrade()
+        assert up.main([str(ws), "--json"]) == 0
+        out = capsys.readouterr().out
+        envelope = json.loads([ln for ln in out.splitlines() if ln.strip()][-1])
+        names = [i.get("name") for i in envelope.get("items") or []]
+        assert any("statusline" in str(n) for n in names), \
+            f"self-heal must be recorded as an item: {names}"


### PR DESCRIPTION
## Summary

Assembles statusline v2 (#142) end to end: the two library halves shipped in #142 (scripts/statusline_render.mjs + scripts/statusline_snapshot.py) were dead code on disk — no hook wrote the snapshot, no statusLine registration existed, init wired nothing. Per the owner priority update, **statusline deployment is now the FIRST step of init AND upgrade** — it is the operator's only visible success/failure signal, so nothing else may run before it.

- **Init FIRST step**: kunglao-init registers the project-scoped statusLine entry (right after the path-shape gate, before toolchain/interview/scaffold). Entry shape single-sourced in hook_activation: `{"type":"command","command":"node <ws>/.claude/scripts/statusline_render.mjs","timeout":10}` — the timeout kills the legacy long-tick class. --no-hooks / plugin seam is the documented opt-out. The report line goes to stderr only: stdout stays the machine channel (a pending exit-8 run must emit parseable JSON alone).
- **Tick data plane = the DEPLOYED copy**: heartbeat_touch loads <ws>/.claude/scripts/statusline_snapshot.py by resolved path (never sys.path order, the #671/#770 shadow class), failing back to the ambient import and finally to one bounded subprocess under the canonical install env. Manifest registration was already present; materialization is now acceptance-tested (post-init sha256 == manifest sha).
- **Upgrade self-heal**: every upgrade run re-verifies the registration and reports it as the FIRST line of output; a missing/stale registration is healed at the gated write points only (after the dirty gate / rollback anchor on the migration path, after the drift-refresh gate on the already-current fast path; never on dry-run or refused runs). Recorded as item `statusline_selfheal`.
- **Honest state**: init seeds runs/mission_ledger.yaml (0/N baseline, idempotent) and closes the scaffold seed claims C-001..C-003 as PROVEN-by-construction with evidence attached at the success-point write — a fresh workspace now renders the truthful idle face instead of a lying "analyzing" forever.
- **Field-diagnosis follow-ups**: crash-class immunity against undefined-field snapshots is proven by test on a data-poor workspace; the claude-hud-update clobber vector is countered by the project-scoped pin (the user-global settings file is never written); progress denominator is live (claims registered between ticks grow N; closed monotonic, total non-decreasing).
- **Conditional segments (absent data = hidden, never a broken line)**: renderer gains the difficulty badge (`D:max` — calibrated tier via mission_ledger.read_difficulty_tier, else the raw-signals surface via difficulty_calibration.calibrate_workspace, reused never re-derived), claims progress (`C3/4`), rolling win-rate (`W50%`, #156 stream), worker liveness (`w1/1`), plus a NO_COLOR/TERM=dumb ASCII tier. Snapshot schema stays 2 (additive fields; readers probe the field set, no version ladder).
- **deploy-manifest.yaml** regenerated last (--verify OK, 393 entries); **CLAUDE.md.base.tmpl** carries the one-line statusline note (wired by init, opt-out, upgrade self-heal).

## Reference acknowledgments (owner-requested)

- The legacy `~/.claude/statusline/combined-statusline.mjs` is acknowledged as the v1 reference, superseded by the repo renderer. It is not harvested and not modified; its undefined-field crash class and its direct rl-signals.jsonl read (the #142 contract violation) remain the regression shapes this PR's tests pin against.
- The claude-hud-update clobber vector (a HUD/plugin update reverting a hand-edited global statusline entry to bare claude-hud) is neutralized by keeping the kunglao registration PROJECT-scoped and idempotent (overwrites only the kunglao-owned key), plus upgrade self-heal and the hooks_selfcheck keep-alive face.
- Adopted from the kcchien/claude-code-statusline reference: the entry timeout field, the terminal color-degradation ladder (ASCII tier; kunglao ships no truecolor tier by design — the four-meaning palette is ANSI 256), threshold-driven faces (win-rate green >= 50%, amber below; idle = the stale-but-alive dim face), and smart hiding of absent segments.

## Known gap (bounded, out of scope here)

#783 deployed-mode hook commands run `uv run --project <ws>`, but init never scaffolds a workspace pyproject.toml — bare workspaces therefore resolve a dependency-less interpreter, so yaml-importing data planes silently never wrote. This PR contains the degradation inside the cosmetic face (tiered fallback; the heartbeat and analysis paths are untouched). A workspace uv-project scaffold remains the #783 follow-up.

## Live demo (throwaway workspace, this branch's build)

- init: `kunglao-init: statusline registered -> node <ws>/.claude/scripts/statusline_render.mjs` (stderr line 5, before toolchain/interview); settings entry as above; deployed snapshot sha256 == manifest sha; ledger `[('PQ-1','unattempted'),('PQ-2','unattempted')]`; seeds `[('C-001','PROVEN'),('C-002','PROVEN'),('C-003','PROVEN')]`.
- One tick via the exact registered hook command -> `runs/.kunglao-statusline.json` exists.
- Rendered line (plain; raw carries 256-color SGR):

  `○ idle ░░░░░░░░░░ 0% ●●● C3/3`

  With claims/worker/settlements/difficulty evidence: `◈ analyzing ░░░░░░░░░░ 0% D:max ●●● C3/4 W50% w1/1 ⚡已 0t` (denominator grew 3 -> 4 live). NO_COLOR renders the identical line escape-free.
- Self-heal: delete the key -> `kunglao-upgrade: statusline: missing (unregistered) — self-heal at the gated write point` ... `kunglao-upgrade: statusline: self-healed -> node <ws>/.claude/scripts/statusline_render.mjs`.
- Perf: 80-110ms end-to-end including node startup (render logic is a single O(1) snapshot read; the test asserts a 500ms CI ceiling and prints measured).

## Test plan

- [x] New tests/test_statusline_assembly_212.py (33 tests, RED-first — 22 RED before implementation): first-step registration (+timeout, idempotency, opt-out), deployed-copy invocation (sentinel), manifest-sha closure, tick->snapshot, minimal always-works line, crash-class immunity, NO_COLOR tier, perf, difficulty/perf faces (calibrated + raw-signals + fail-open), live-ledger progress growth, seeds PROVEN (state not "analyzing"), upgrade re-verify/self-heal/dry-run/refusal/item-record.
- [x] Contract amendment: test_init_anchor_intake_203.test_pending_exit_writes_zero_scaffold — a pended init now leaves exactly the statusLine carrier (owner priority update supersedes the zero-.claude expectation; zero ANALYSIS scaffold still pinned).
- [x] CLAUDE.md goldens regenerated through the pinned sentinel path (one note line; byte-diff = that line only).
- [x] Local: fast leg 2946 passed; docs leg 139 passed; integration 3505 passed (2 failures are pre-existing on clean dev: live adb device `wslvyltsoft8yxba` on the runner machine affects test_android_server_fail_without_listener + test_env_drift_475 L1 noop — device/network class, not code).
- [x] ruff clean on changed files; comment-hygiene clean (no new tracker shapes); deploy-manifest --verify OK; quality gates 9 + ext-scan ALL-PASS.

Closes #212
