### PR TITLE
fix: apk_mem_gate verdict gates formal analysis — env-fact wiring, JVM probe, evidence classes (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,21 @@ release (see the mapping table at the end).
   `kunglao_log.emit` lands `runs/.rank-emit-fail.json` and clears on the
   next success, so the silent fail-open contract keeps the ranking result
   byte-identical while the failure stops being invisible (#218)
+- **APK memory gate verdict gates formal analysis (#215)**: init probes
+  `tools/static/apk_mem_gate.py` for the aligned android target and records
+  the verdict (jadx-ok / targeted-jadx / smali-only / refuse / unavailable)
+  into the env facts, with an explicit `unavailable` instead of a silent
+  skip, and the environment section renders it; `java -version` joins the
+  android check set as a CAPABILITY-tier probe (HARD when jadx is present,
+  WARN otherwise) and jadx's provider requirements become
+  `[dex, mem_budget_ok, jadx_bin, jvm]` — "no JVM" was a dexdc property the
+  field run misread as an environment fact, so the dexdc index entries now
+  say so and point at the probe; a →PROVEN transition of an
+  algorithm-recovery claim (scope keywords: key schedule / crypto constant /
+  state machine / algorithm verify) whose facts are all triage-grade now
+  fails admission with `evidence-class` named, while `evidence_class`
+  (triage / decompile / dynamic, absent = triage) joins the fact
+  frontmatter as a validated extension field
 
 ## [0.1.3] - 2026-08-25
 

--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -319,7 +319,7 @@ files:
   - src: scripts/env_manifest.py
     dest: .claude/scripts/env_manifest.py
     kind: scaffold
-    sha256: 3e69d392ffb71f18225e6024bdbac9d1ed6224c8ea3b0fe0d94bf671598adae8
+    sha256: 20c3212c8538715189b86531dac6dfb7bd9e6e74ed9c9db11c88653e2e5d3d31
   - src: scripts/env_repair_l1.py
     dest: .claude/scripts/env_repair_l1.py
     kind: scaffold
@@ -447,7 +447,7 @@ files:
   - src: scripts/kunglao-init.py
     dest: .claude/scripts/kunglao-init.py
     kind: scaffold
-    sha256: b76033fd64e0f67135cda1564fe5f50d7c1901fdb04132939db30d9fa34bd51a
+    sha256: a7070f3d8545502db8ff92ebf65d4f3cfb6bd092f6182b42516a1caf4e0afcc3
   - src: scripts/kunglao-monitor.py
     dest: .claude/scripts/kunglao-monitor.py
     kind: scaffold
@@ -511,7 +511,7 @@ files:
   - src: scripts/lint_facts.py
     dest: .claude/scripts/lint_facts.py
     kind: scaffold
-    sha256: 6354780ccc4aae54e80fad2a6c91d79cf9e5ffb0e5500378ee6d1672689682de
+    sha256: 98e6df2854b963a895d4b404ec315eef94be699533ca4023c8307bab4a614c65
   - src: scripts/liveness_policy.py
     dest: .claude/scripts/liveness_policy.py
     kind: scaffold
@@ -667,7 +667,7 @@ files:
   - src: scripts/register_proven_gate.py
     dest: .claude/scripts/register_proven_gate.py
     kind: scaffold
-    sha256: 51a8e65d0af96eea2adb27f4bbadaa38cd397ebb26a59f8b1fe6ed902df10dc8
+    sha256: cd4067a9583fc07267cc43358a8593331e58f2a0c9d73d34bd6f45b0a7ae24ec
   - src: scripts/release_check_selfcheck.py
     dest: .claude/scripts/release_check_selfcheck.py
     kind: scaffold
@@ -691,7 +691,7 @@ files:
   - src: scripts/report_render.py
     dest: .claude/scripts/report_render.py
     kind: scaffold
-    sha256: 0c2b975106f7bd961f82fa0eb5a11963c430b61184aa4904f5e6da003f54e7d6
+    sha256: 231d942d57c3550e38197527e0adb70bf0b558997a3644c5022bfa3c66b52765
   - src: scripts/retirement_gate.py
     dest: .claude/scripts/retirement_gate.py
     kind: scaffold
@@ -723,7 +723,7 @@ files:
   - src: scripts/route_capability.py
     dest: .claude/scripts/route_capability.py
     kind: scaffold
-    sha256: bcf2b0614a6d28e9b8bbeda9db77a0db7f05302cc0bf5485c8ba338501a1b18c
+    sha256: 22357585434825fc5ec89486c7a9d7d5a57b0160b568db359fd1842e72379a4e
   - src: scripts/shell_defaults.py
     dest: .claude/scripts/shell_defaults.py
     kind: scaffold
@@ -783,11 +783,11 @@ files:
   - src: scripts/toolchain.py
     dest: .claude/scripts/toolchain.py
     kind: scaffold
-    sha256: 899d7fc4d8d8943a98af5ba8a67737347000f9a87c7709f614be085d4a0db051
+    sha256: beb97b2c3cd892f85b5abd3608a5ad121bc23f8b4c73427d8f934796f11cc387
   - src: scripts/toolchain_install.py
     dest: .claude/scripts/toolchain_install.py
     kind: scaffold
-    sha256: 85883f178158155c37fc05d604d4558cb1da0c91d3b44d105805a1dd832b1e72
+    sha256: ed1a0bda7b7c9021f08bfd3217a23e4679330b0f57a45f056ebde6975713a004
   - src: scripts/toolchain_negotiation.py
     dest: .claude/scripts/toolchain_negotiation.py
     kind: scaffold
@@ -1231,7 +1231,7 @@ files:
   - src: templates/fact-frontmatter.md
     dest: .claude/templates/fact-frontmatter.md
     kind: asset
-    sha256: 3f4dda583752241db56b443cfe0a0dd650db1ab5b5ff3526d11386144f02b336
+    sha256: 8324cbc9ab7a33db0b74baf56a2a1f5aca9bd4535acb5c60a1288a626c1302ca
   - src: templates/frida/README.md
     dest: .claude/templates/frida/README.md
     kind: asset
@@ -1319,7 +1319,7 @@ files:
   - src: tools/_INDEX.yaml
     dest: .claude/tools/_INDEX.yaml
     kind: asset
-    sha256: 02ff549d25f885bbd3e59a77b68f4032dd6b3292c37624573af3f8ac5d7fc8a7
+    sha256: a318a40e3a55e1c56493c90723dd932696c39d8ac694b7781d92e0439c34e9af
   - src: tools/_index-auxiliary.md
     dest: .claude/tools/_index-auxiliary.md
     kind: asset
@@ -1343,7 +1343,7 @@ files:
   - src: tools/_index-static.md
     dest: .claude/tools/_index-static.md
     kind: asset
-    sha256: c56a36884cdc823e0bb0a9d388c1f882216bcead57f796bb7d3a4d97b11c83cb
+    sha256: 4668180ca6cfe7439c5fdf7de4e7acb38e14f0d7ccc8ce69792b7cc673ad4376
   - src: tools/_index-web.md
     dest: .claude/tools/_index-web.md
     kind: asset
@@ -1571,7 +1571,7 @@ files:
   - src: tools/validate_index.py
     dest: .claude/tools/validate_index.py
     kind: asset
-    sha256: 131585e75a1174d5f98e3018091bb82e824f95a690d82e5130a32f8303260e8a
+    sha256: f54a97e80b5ceae7bde5f16a8b270b24e449775bc0762416f281035f50e8298b
   - src: tools/web/README.md
     dest: .claude/tools/web/README.md
     kind: asset

--- a/scripts/env_manifest.py
+++ b/scripts/env_manifest.py
@@ -140,6 +140,34 @@ DEFAULT_MANIFEST_BASIS = ("no env-facts, no task_spec — conservative "
 
 
 @dataclass(frozen=True)
+class MemGateFact:
+    """Android memory-gate verdict recorded at init (issue 215).
+
+    A workspace PROBE fact, not a policy: the provider router reads the
+    authoritative copy from evidence/apk_mem_gate.json; this is the
+    documentation/env-facts mirror so an agent reading the environment
+    section sees the decompile-provider budget state without re-running
+    the gate. Verdict vocabulary: the tool's own four (jadx-ok /
+    targeted-jadx / smali-only / refuse) plus `unavailable` — the
+    recording-side value for "the probe could not run" (the tool never
+    emits it; a missing verdict must be visible, not silently absent).
+    """
+    verdict: str
+    est_heap_gb: float | None = None
+    budget_gb: float | None = None
+    reason: str = ""
+
+
+# Closed recording vocabulary (issue 215). The producer is
+# tools/static/apk_mem_gate.py; `unavailable` is added by the recorder.
+MEM_GATE_VERDICTS = ("jadx-ok", "targeted-jadx", "smali-only", "refuse",
+                     "unavailable")
+# The verdicts that satisfy the jadx provider precondition (mirror of
+# route_capability.MEM_GATE_JADX_OK — the router holds the routing copy).
+MEM_GATE_JADX_OK = ("jadx-ok", "targeted-jadx")
+
+
+@dataclass(frozen=True)
 class EnvManifest:
     """Resolved environment fact set (all five #450 fact families + the
     layout conventions + the derived requirement)."""
@@ -149,6 +177,7 @@ class EnvManifest:
     guest_channel: GuestChannel = DEFAULT_GUEST_CHANNEL
     layout: LayoutConventions = DEFAULT_LAYOUT
     source: str = "default"  # manifest-file | task-spec | default
+    mem_gate: MemGateFact | None = None
 
 
 DEFAULT_MANIFEST = EnvManifest()
@@ -283,6 +312,39 @@ def _parse_guest_channel(raw) -> GuestChannel:
                         notes=raw.get("notes") or None)
 
 
+def _parse_mem_gate(raw) -> MemGateFact | None:
+    """Parse the recorded android memory-gate fact; None when unrecorded.
+
+    Fail-closed on defect (same family as _parse_layout): a present-but-
+    garbage entry must not silently read as "no verdict recorded" — an
+    unknown verdict in particular is a defect, never a downgraded pass.
+    """
+    if raw is None:
+        return None
+    _require_mapping(raw, "mem_gate")
+    verdict = raw.get("verdict")
+    if not isinstance(verdict, str) or not verdict.strip():
+        raise ValueError("mem_gate.verdict must be a non-empty string")
+    if verdict not in MEM_GATE_VERDICTS:
+        raise ValueError(
+            f"mem_gate.verdict {verdict!r} outside the recording vocabulary "
+            f"{MEM_GATE_VERDICTS}")
+    nums: dict[str, float | None] = {}
+    for key in ("est_heap_gb", "budget_gb"):
+        value = raw.get(key)
+        if value is None:
+            nums[key] = None
+            continue
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"mem_gate.{key} must be a number")
+        nums[key] = float(value)
+    reason = raw.get("reason") or ""
+    if not isinstance(reason, str):
+        raise ValueError("mem_gate.reason must be a string")
+    return MemGateFact(verdict=verdict, est_heap_gb=nums["est_heap_gb"],
+                       budget_gb=nums["budget_gb"], reason=reason)
+
+
 def _parse_layout(raw) -> LayoutConventions:
     """Per-field merge over DEFAULT_LAYOUT; present-but-empty/garbage
     fields are a DEFECT (they would silently change discovery), not a
@@ -351,6 +413,7 @@ def resolve(ws: Path) -> EnvManifest:
             vm=_parse_vm(raw.get("vm")),
             guest_channel=_parse_guest_channel(raw.get("guest_channel")),
             layout=_parse_layout(raw.get("layout")),
+            mem_gate=_parse_mem_gate(raw.get("mem_gate")),
             source="task-spec" if derived.source == "task-spec"
             else "manifest-file")
     return EnvManifest(
@@ -359,6 +422,7 @@ def resolve(ws: Path) -> EnvManifest:
         vm=_parse_vm(raw.get("vm")),
         guest_channel=_parse_guest_channel(raw.get("guest_channel")),
         layout=_parse_layout(raw.get("layout")),
+        mem_gate=_parse_mem_gate(raw.get("mem_gate")),
         source="manifest-file")
 
 
@@ -520,7 +584,33 @@ def render_section(m: EnvManifest) -> str:
     lines.append(_channel_line(m))
     if m.vm.frida_start:
         lines.append(f"- frida start: {m.vm.frida_start}")
+    lines.append(_mem_gate_line(m))
     return "\n".join(lines) + "\n"
+
+
+def _mem_gate_line(m: EnvManifest) -> str:
+    """Android memory-gate verdict line (issue 215). Absent fact -> honest
+    unknown + the exact command that records it (never an invented budget)."""
+    if m.mem_gate is None:
+        return ("- APK memory gate: unknown — run `python "
+                "tools/static/apk_mem_gate.py <workspace> <target>` (init "
+                "records the verdict for an aligned android target)")
+    parts = []
+    if m.mem_gate.est_heap_gb is not None:
+        parts.append(f"est {m.mem_gate.est_heap_gb} GB")
+    if m.mem_gate.budget_gb is not None:
+        parts.append(f"budget {m.mem_gate.budget_gb} GB")
+    if m.mem_gate.verdict in MEM_GATE_JADX_OK:
+        parts.append("jadx-ok: the jadx provider precondition is satisfied")
+    elif m.mem_gate.verdict == "refuse":
+        parts.append("no decompile path at this budget; do not dispatch jadx")
+    else:
+        parts.append("jadx blocked: use baksmali / dexdc, never string triage "
+                     "for algorithm claims")
+    if m.mem_gate.reason:
+        parts.append(m.mem_gate.reason)
+    detail = f" ({', '.join(parts)})" if parts else ""
+    return f"- APK memory gate: {m.mem_gate.verdict}{detail}"
 
 
 # ---------- probe: minimal discovery entry (fail-open) ----------
@@ -686,6 +776,61 @@ def record_installed(ws: Path, name: str, manager: str, reprobe: str,
     installed = dict(merged.get("installed") or {})
     installed[name] = entry           # per-tool update-wins (docstring)
     merged["installed"] = installed
+    path.write_text(yaml.safe_dump(merged, sort_keys=False,
+                                   allow_unicode=True), encoding="utf-8")
+    return True
+
+
+def record_mem_gate(ws: Path, verdict: str, *,
+                    est_heap_gb: float | None = None,
+                    budget_gb: float | None = None,
+                    reason: str = "", at: str | None = None) -> bool:
+    """Merge the android memory-gate verdict into <ws>/env-facts.yaml
+    (issue 215) — same write-through shape as record_installed.
+
+    mem_gate = {verdict, est_heap_gb, budget_gb, reason, at}: the init
+    probe's record of what the gate said, so the environment section and
+    the analysis loop read one fact instead of re-deriving a budget.
+    UPDATE-WINS on this one key (a re-probe replaces the stale verdict —
+    the memory state of the host is exactly what changes between runs);
+    every other top-level key survives untouched.
+
+    Raises ValueError on a verdict outside the recording vocabulary
+    (fail-closed family); returns False with stderr guidance — nothing
+    written — when the existing file is a defect (refuse-to-clobber).
+    """
+    if not isinstance(verdict, str) or not verdict.strip():
+        raise ValueError(f"mem-gate verdict must be a non-empty string, "
+                         f"got {verdict!r}")
+    if verdict not in MEM_GATE_VERDICTS:
+        raise ValueError(f"mem-gate verdict {verdict!r} outside the "
+                         f"recording vocabulary {MEM_GATE_VERDICTS}")
+    for label, value in (("est_heap_gb", est_heap_gb),
+                         ("budget_gb", budget_gb)):
+        if value is not None and (isinstance(value, bool)
+                                  or not isinstance(value, (int, float))):
+            raise ValueError(f"mem-gate {label} must be a number, "
+                             f"got {value!r}")
+    path = Path(ws) / MANIFEST_FILENAME
+    existing: dict | None = None
+    if path.exists():
+        try:
+            existing = _load_manifest_file(path)
+        except ValueError as exc:
+            print(f"ERROR: {exc} — memory-gate fact refusing to overwrite "
+                  f"(fix {path} by hand)", file=sys.stderr)
+            return False
+    from datetime import datetime, timezone
+    entry = {
+        "verdict": verdict,
+        "est_heap_gb": est_heap_gb,
+        "budget_gb": budget_gb,
+        "reason": reason or "",
+        "at": at or datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    merged = dict(existing or {})
+    merged["version"] = MANIFEST_VERSION
+    merged["mem_gate"] = entry
     path.write_text(yaml.safe_dump(merged, sort_keys=False,
                                    allow_unicode=True), encoding="utf-8")
     return True

--- a/scripts/kunglao-init.py
+++ b/scripts/kunglao-init.py
@@ -904,6 +904,85 @@ def detect_sample(ws: Path, target: str) -> tuple[str, str]:
     return p.name, sha
 
 
+# issue 215: the memory gate is a PROBE run at init for the ALIGNED android
+# target (lane gating stays issue 208's work). The tool stays the sole
+# writer of evidence/apk_mem_gate.json — the provider router's authoritative
+# copy — while the verdict is mirrored into the env facts so the analysis
+# loop reads the budget state instead of re-deriving it.
+MEM_GATE_TOOL_REL = Path("tools") / "static" / "apk_mem_gate.py"
+MEM_GATE_TIMEOUT_S = 120
+
+
+def _run_mem_gate_cli(ws: Path, target_path: Path,
+                      timeout: int = MEM_GATE_TIMEOUT_S) -> dict:
+    """Run tools/static/apk_mem_gate.py <ws> <target>; return its ONE-LINE
+    JSON verdict. Fail-open: every failure path returns an explicit
+    {"verdict": "unavailable", "reason": ...} — an android init must not
+    die because the estimator could not run (and a silent skip is the
+    pathology this probe exists to kill)."""
+    tool = _SCRIPT_DIR.parent / MEM_GATE_TOOL_REL
+    if not tool.is_file():
+        return {"verdict": "unavailable",
+                "reason": f"{MEM_GATE_TOOL_REL.as_posix()} not found"}
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(tool), str(ws), str(target_path)],
+            capture_output=True, text=True, timeout=timeout,
+            encoding="utf-8", errors="replace")
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"verdict": "unavailable", "reason": str(exc)[:200]}
+    if proc.returncode != 0:
+        return {"verdict": "unavailable",
+                "reason": f"exit {proc.returncode}: "
+                          f"{(proc.stderr or '').strip()[:160]}"}
+    for line in (proc.stdout or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(data, dict) and data.get("verdict"):
+            return data
+    return {"verdict": "unavailable",
+            "reason": "no JSON verdict line on stdout"}
+
+
+def record_mem_gate_verdict(ws: Path, project_type: str | None,
+                            target: str | None) -> dict | None:
+    """Probe the memory gate for the aligned android target and record the
+    verdict as an env fact (issue 215).
+
+    Returns the recorded dict, or None when the project type keeps the
+    android lane out. An unaligned target is recorded as an explicit
+    `unavailable` — never a silent skip, never a fabricated verdict. The
+    env-fact write is best-effort: a defect in env-facts.yaml warns and
+    leaves init running (the router's evidence copy is unaffected)."""
+    if project_type != "android":
+        return None
+    target_path = (ws / "bins" / target) if target else None
+    if target_path is None or not target_path.is_file():
+        rec = {"verdict": "unavailable",
+               "reason": ("no aligned target under bins/ — align the target, "
+                          "then re-probe")}
+    else:
+        rec = _run_mem_gate_cli(ws, target_path)
+        if rec.get("verdict") not in env_manifest.MEM_GATE_VERDICTS:
+            rec = {"verdict": "unavailable",
+                   "reason": f"unrecognized verdict {rec.get('verdict')!r}"}
+    try:
+        env_manifest.record_mem_gate(
+            ws, rec["verdict"],
+            est_heap_gb=rec.get("est_heap_gb"),
+            budget_gb=rec.get("budget_gb"),
+            reason=str(rec.get("reason") or ""))
+    except (OSError, ValueError) as exc:
+        print(f"kunglao-init: WARNING mem-gate env fact not recorded: {exc}",
+              file=sys.stderr)
+    return rec
+
+
 # ---------- #455: target alignment (intake step 0) ----------
 
 # CFBF composite-document signature (MSI / legacy OLE containers).
@@ -2636,6 +2715,16 @@ def initialize(ws: Path, hooks_json: Path | None,
     sample, sample_sha = detect_sample(ws, target)
     if target_object:
         write_state_line(ws, "analysis_target_object", target_object)
+
+    # issue 215: the memory gate runs as a PROBE right after target
+    # alignment — its verdict (jadx-ok / targeted-jadx / smali-only /
+    # refuse / unavailable) lands in the env facts, so formal analysis reads
+    # the decompile-provider budget state instead of discovering it by
+    # thrashing the host.
+    mem_gate = record_mem_gate_verdict(ws, project_type, target)
+    if mem_gate is not None:
+        _mg_note = f" ({mem_gate['reason']})" if mem_gate.get("reason") else ""
+        print(f"kunglao-init: mem-gate verdict={mem_gate['verdict']}{_mg_note}")
 
     # #304: write the resolved project type
     write_project_type(ws, project_type)

--- a/scripts/lint_facts.py
+++ b/scripts/lint_facts.py
@@ -64,6 +64,11 @@ OPEN_BOUNDARY_TYPES = {"capability_not_executed", "link_not_closed",
                        "source_derived", "observation", "numeric"}
 EMPTY_GATE_TYPES = {"confirmed", "pure_negative", "contradiction", "coordinate", "anomaly"}
 VALID_VERIFY_STATUS = {"pending", "passes", "partial", "fails", "stale"}
+# issue 215: the evidence-class extension (claim gate input). triage =
+# string/byte scanning without decompilation or execution; decompile =
+# decompiled source or decompiler-grade index/taint; dynamic = runtime
+# observation. Absent/unrecognized reads as triage at the gate.
+VALID_EVIDENCE_CLASSES = {"triage", "decompile", "dynamic"}
 VALID_CONFIDENCE_ZH = {"可确认", "表明", "倾向于", "可关联", "不支持"}
 VALID_PROVENANCE_ROLES = {"sample_raw", "decompiled_c", "disassembled_s",
                           "recompute_script", "hex_bytes_inline", "capture_log",
@@ -136,6 +141,7 @@ KNOWN_FRONTMATTER_KEYS = frozenset({
     "depends_on", "alternatives", "supersedes", "superseded_by", "iocs",
     "hypothesis",
     "trace_id",  # #879 trace identity: mission chain id (worker echo channel)
+    "evidence_class",  # issue 215: evidence-grade class (claim-gate input)
 })
 
 # L-4 (#532): the body '## Status' line must reconcile with frontmatter status.
@@ -555,6 +561,14 @@ def lint_fact(fid: str, fm: dict, fact_ids: set, body: str = "") -> list:
     if src is not None and src not in VALID_SOURCE:
         issues.append(_issue("error", "BAD_SOURCE_ENUM", fid,
                              f"source {src!r} not in {sorted(VALID_SOURCE)}"))
+    ec = fm.get("evidence_class")
+    if ec is not None and str(ec) not in VALID_EVIDENCE_CLASSES:
+        issues.append(_issue("error", "BAD_EVIDENCE_CLASS", fid,
+                             f"evidence_class {ec!r} not in "
+                             f"{sorted(VALID_EVIDENCE_CLASSES)} — an "
+                             f"undeclared class reads as triage at the "
+                             f"claim gate, so a typo silently weakens "
+                             f"the fact"))
     conf = fm.get("confidence")
     if conf is not None and conf not in VALID_CONFIDENCE:
         issues.append(_issue("error", "BAD_CONFIDENCE", fid,

--- a/scripts/register_proven_gate.py
+++ b/scripts/register_proven_gate.py
@@ -32,9 +32,34 @@ WAIVER_JUSTIFY_RE = re.compile(r"^\s*justify:\s*(\S.*)$", re.M)
 # claim's lesson lineage here (see emit_settlements).
 NEGATIVE_SETTLEMENTS = {"REFUTED", "NEGATIVE", "DEAD"}
 
+# ---------------- evidence classes (issue 215) -------------------------------
+#
+# The wbtest field run proved algorithm-recovery claims with unzip+grep
+# string facts. The claim side is identified from the register's own text
+# (statement/title) — a new scope field nothing writes would be
+# self-declaration, the trust posture issue 819 exists to reject — and the
+# evidence side from the FACT frontmatter's declared class. Deliberately
+# NOT the `source` enum: triage string facts carry `static-decompile`
+# there, which is exactly the masquerade this closes.
+ALGO_SCOPE_KEYWORDS = (
+    "key_schedule", "key schedule", "key expansion",
+    "crypto_constant", "crypto constant", "crypto constants",
+    "state_machine", "state machine",
+    "algorithm_verify", "algorithm verify", "algorithm verification",
+    "algorithm recovery", "algorithm-recovery",
+)
 
-def _load_statuses(text: str) -> dict:
-    """claim-id → status; {} when the text is not a parsable register."""
+TRIAGE_GRADE_CLASS = "triage"
+VALID_EVIDENCE_CLASSES = (TRIAGE_GRADE_CLASS, "decompile", "dynamic")
+# Classes that can carry an algorithm-recovery claim: decompiled source /
+# decompiler-grade index or taint, and runtime observation. Triage-grade
+# string facts alone cannot.
+ALGO_GRADE_CLASSES = ("decompile", "dynamic")
+
+
+def _load_claims(text: str) -> dict:
+    """claim-id -> the claim mapping; {} when the text is not a parsable
+    register."""
     try:
         data = yaml.safe_load(text)
     except yaml.YAMLError:
@@ -45,10 +70,104 @@ def _load_statuses(text: str) -> dict:
     for c in data.get("claims") or []:
         if isinstance(c, dict):
             cid = str(c.get("id", "") or "").strip()
-            st = str(c.get("status", "") or "").strip().upper()
             if cid:
-                out[cid] = st
+                out[cid] = c
     return out
+
+
+def _load_statuses(text: str) -> dict:
+    """claim-id -> status (uppercased); {} when not a parsable register."""
+    return {cid: str(c.get("status", "") or "").strip().upper()
+            for cid, c in _load_claims(text).items()}
+
+
+def _fact_claim_refs(fm: dict) -> list:
+    """Every claim id a fact cites: claim_id / claim_ids / claims.
+
+    The extension-layer `claim` field is deliberately NOT read — it is the
+    claim STATEMENT (free text), not a reference (same rule as issue 532)."""
+    refs: list = []
+    for key in ("claim_id", "claim_ids", "claims"):
+        value = fm.get(key)
+        if isinstance(value, str):
+            refs.append(value.strip())
+        elif isinstance(value, (list, tuple)):
+            refs.extend(str(v).strip() for v in value)
+    return [r for r in refs if r]
+
+
+def _evidence_class(fm: dict) -> str:
+    """The fact's declared evidence class, defaulting to the WEAKEST one.
+
+    Fail-closed: absent or unrecognized reads as triage, never as a claim
+    of strength (an undeclared class is not evidence of decompilation)."""
+    value = str(fm.get("evidence_class") or "").strip().lower()
+    return value if value in VALID_EVIDENCE_CLASSES else TRIAGE_GRADE_CLASS
+
+
+def facts_by_claim(ws: Path) -> dict:
+    """claim-id -> [fact frontmatter dicts] from facts/*.md.
+
+    Single-parser rule: lint_facts owns the frontmatter dialect (PyYAML
+    plus the tolerant subset fallback) and this gate consumes it rather
+    than growing a second parser. An unreadable or unparsable fact is
+    skipped — it carries no class, and the register-side predicates still
+    gate its claim."""
+    out: dict = {}
+    facts_dir = Path(ws) / "facts"
+    if not facts_dir.is_dir():
+        return out
+    try:
+        from lint_facts import _load_fact
+    except ImportError:
+        return out
+    for p in sorted(facts_dir.glob("*.md")):
+        try:
+            fm = _load_fact(p)
+        except Exception:  # noqa: BLE001 — a broken fact never blocks the gate
+            continue
+        if not isinstance(fm, dict):
+            continue
+        for ref in _fact_claim_refs(fm):
+            out.setdefault(ref, []).append(fm)
+    return out
+
+
+def algorithm_scope(claim: dict) -> str | None:
+    """The matched scope keyword when the claim reads as algorithm-recovery
+    (issue 215), else None.
+
+    Read from the register's own text; the KEEP list is the four classes
+    the issue names, in snake_case and prose spellings."""
+    text = " ".join(str(claim.get(k) or "")
+                    for k in ("statement", "title", "answers_question"))
+    lowered = text.lower()
+    for keyword in ALGO_SCOPE_KEYWORDS:
+        if keyword in lowered:
+            return keyword
+    return None
+
+
+def evidence_class_violation(claim_id: str, claim: dict,
+                             facts: list) -> str | None:
+    """The evidence-class admission reason (issue 215), None when admitted.
+
+    Boundary: a claim with NO fact file has no fact-frontmatter class to
+    read, so the issue 819 verify/redteam predicates govern it alone — the rule
+    here is exactly the issue's "triage cannot ALONE prove an algorithm
+    claim", which needs facts to be meaningful."""
+    scope = algorithm_scope(claim)
+    if scope is None or not facts:
+        return None
+    classes = sorted({_evidence_class(fm) for fm in facts})
+    if any(c in ALGO_GRADE_CLASSES for c in classes):
+        return None
+    return (f"{claim_id}: evidence-class — algorithm-recovery claim (scope "
+            f"keyword {scope!r}) reaches PROVEN on {classes} evidence only "
+            f"({len(facts)} fact(s)); a triage-grade string fact cannot "
+            f"alone prove an algorithm claim — attach decompile-grade "
+            f"evidence (jadx source / dexdc index or taint) or declare the "
+            f"fact's evidence_class")
 
 
 def _runs_outcomes(ws: Path) -> list:
@@ -139,10 +258,12 @@ def check_register_transitions(ws: Path, new_text: str,
     transition (fresh registers cannot mint PROVEN without evidence either)."""
     old = _load_statuses(old_text or "")
     new = _load_statuses(new_text)
+    claims = _load_claims(new_text)
     violations: list = []
     waivers: list = []
     if not new:
         return {"ok": True, "violations": violations, "waivers": []}
+    facts: dict | None = None
     for cid, st in new.items():
         if st != PROVEN:
             continue
@@ -156,6 +277,16 @@ def check_register_transitions(ws: Path, new_text: str,
                     f"without a stated reason is not an exemption")
             else:
                 waivers.append(wv)
+            continue
+        # issue 215: evidence-class admission (algorithm-recovery claims).
+        # Checked at ADMISSION, ahead of the runs/ predicates, so the named
+        # reason is the evidence grade the claim actually failed on.
+        if facts is None:
+            facts = facts_by_claim(ws)
+        ec = evidence_class_violation(cid, claims.get(cid) or {},
+                                      facts.get(cid) or [])
+        if ec:
+            violations.append(ec)
             continue
         ev = latest_evidence(ws, cid)
         vn, rt = ev["verify_note"], ev["redteam"]

--- a/scripts/report_render.py
+++ b/scripts/report_render.py
@@ -257,6 +257,13 @@ FIXES: dict[str, ToolMeta] = {
             "JDWP-Handshake (jdb stays the interactive driver; never jdb -attach — side effects)",
         description="JDWP capability probe (jdb handoff, WARN tier)",
         url="https://docs.oracle.com/javase/8/docs/technotes/guides/jpda/jdwp-spec.html"),
+    "jvm": ToolMeta(
+        fix="install a JDK so `java -version` answers (jadx is a Java "
+            "program — probe the environment, never read the JVM state off "
+            "a tool description)",
+        description="JVM availability for the jadx java-source lane "
+                    "(HARD when jadx is present, WARN otherwise)",
+        url="https://adoptium.net/"),
 }
 
 # Registration guidance for MCP supply checks — fix text rendered by the

--- a/scripts/route_capability.py
+++ b/scripts/route_capability.py
@@ -477,7 +477,12 @@ def _eval_token(token: str, state: dict) -> tuple[str, str | None]:
         return ("blocked",
                 "mem budget verdict %s (#670 - jadx provider precondition, "
                 "not a pipeline stage)" % verdict)
-    if token in ("jadx_bin", "dexdc_wheel", "smali_toolchain"):
+    if token in ("jadx_bin", "dexdc_wheel", "smali_toolchain", "jvm"):
+        # `jvm` is a first-class precondition of the jadx provider (issue
+        # 215): jadx is a Java program, and "no JVM" was answered from a
+        # tool description in the field instead of probing the host — the
+        # token reads the same workspace probe channel as jadx_bin, so a
+        # probed-false JVM BLOCKS the provider rather than being assumed.
         probes = state.get("tool_probes") or {}
         if token not in probes:
             return ("unverified",

--- a/scripts/toolchain.py
+++ b/scripts/toolchain.py
@@ -139,6 +139,10 @@ _STATIC_NEXT_ACTIONS: dict[str, NextAction] = {
     "dexdc": NextAction("install",
                         "cd dex-decompiler-py && maturin build --release && pip install target/wheels/dex_decompiler-*.whl"),
     "apkid": NextAction("install", "pip install apkid"),
+    "jvm": NextAction("install",
+                      "install a JDK so `java -version` answers (jadx is a "
+                      "Java program; probe the environment, never read the "
+                      "JVM state off a tool description)"),
     "baksmali": NextAction("install",
                            "download from https://github.com/baksmali/smali/releases (or apt install baksmali)"),
     "adb": NextAction("install",
@@ -2173,6 +2177,50 @@ def _check_linux(report: ToolchainReport, ws: Path,
 
 # ---------- Android manifest ----------
 
+JAVA_VERSION_TIMEOUT_S = 10
+
+
+def _jvm_item(jadx_present: bool) -> CheckResult:
+    """The `java -version` probe item (issue 215).
+
+    Tier follows the consequence, not the tool: jadx is a Java program, so
+    a JVM miss beside a present jadx is HARD; with jadx absent nothing on
+    this lane needs one and the item stays WARN (never in the HARD exit-4
+    refusal set). Probe tier is CAPABILITY — `-version` is a real run of
+    the interpreter, the strongest layer-1 answer that executes no sample
+    code (the state-ladder lesson: answer "is it installed?" by probing,
+    never by reading a tool description).
+    """
+    java = _shutil_which("java")
+    tier = Tier.HARD if jadx_present else Tier.WARN
+    if java is None:
+        return CheckResult(
+            name="jvm", status=(Status.FAIL if jadx_present else Status.WARN),
+            tier=tier, root_cause="JVM", probe=ProbeTier.PRESENCE,
+            fix="install a JDK (java -version), then re-probe",
+            detail=("java not found in PATH — jadx cannot run without a JVM"
+                    if jadx_present else
+                    "java not found in PATH — nothing on this lane needs a "
+                    "JVM while jadx is absent"))
+    rc, out, err = _run_cmd([java, "-version"],
+                            timeout=JAVA_VERSION_TIMEOUT_S)
+    # java -version prints its banner on stderr (OpenJDK, every release);
+    # stdout is the fallback for implementations that do otherwise.
+    banner = next((ln for ln in (err or out).splitlines() if ln.strip()), "")
+    if rc == 0:
+        return CheckResult(
+            name="jvm", status=Status.PASS, tier=tier,
+            probe=ProbeTier.CAPABILITY,
+            detail=(f"java found at {java}"
+                    + (f" — {banner}" if banner else "")))
+    return CheckResult(
+        name="jvm", status=(Status.FAIL if jadx_present else Status.WARN),
+        tier=tier, root_cause="JVM", probe=ProbeTier.CAPABILITY,
+        fix="install a working JDK (java -version), then re-probe",
+        detail=(f"java at {java} but -version failed "
+                f"({banner or 'no output'}) — jadx cannot start"))
+
+
 def _check_android(report: ToolchainReport, ws: Path,
                    caps: bool = False,
                    reqs: Requirements = DEFAULT_REQUIREMENTS) -> None:
@@ -2213,8 +2261,21 @@ def _check_android(report: ToolchainReport, ws: Path,
             ))
 
     # T1: jadx + apktool
-    report.items.extend(_which_items(
-        ("jadx", "apktool"), Tier.HARD))
+    jadx_apktool = _which_items(("jadx", "apktool"), Tier.HARD)
+    report.items.extend(jadx_apktool)
+    # "jadx_bin present" = the binary resolved on PATH (PASS, or WARN when
+    # its own verify_cmd failed): either way the java-source lane needs a
+    # JVM, and only a never-found binary leaves the item WARN.
+    jadx_present = any(i.name == "jadx" and i.status != Status.FAIL
+                       for i in jadx_apktool)
+
+    # T1: JVM (java -version) — state-ladder layer 1 (issue 215): the field
+    # run answered "is there a JVM?" from dexdc's feature text ("no JVM")
+    # instead of probing the host. jadx IS a Java program, so with jadx
+    # present a missing/broken JVM is a broken environment (HARD); without
+    # jadx nothing on the android static lane needs one (WARN, so the item
+    # can never enter the HARD exit-4 refusal set on a non-jadx host).
+    report.items.append(_jvm_item(jadx_present))
 
     # T1: apkid — presence probe ONLY, WARN tier (so it can never enter the
     # HARD exit-4 refusal set). apkid is a TOOL: init probes existence and
@@ -2651,7 +2712,7 @@ CHECK_SETS: dict[str, frozenset[str]] = {
         "ebpf", "strace", "ltrace",
     }),
     "android": frozenset({
-        "aapt", "aapt2", "jadx", "apktool", "gitnexus", "apkid",
+        "aapt", "aapt2", "jadx", "apktool", "gitnexus", "apkid", "jvm",
         "decompiler", "ghidra", "ida", "uv",
         "adb", "device_root", "debug_flag", "frida_server",
         "android_server", "jdwp_debug", "ebpf_android", "unidbg",

--- a/scripts/toolchain_install.py
+++ b/scripts/toolchain_install.py
@@ -336,6 +336,10 @@ NOT_AUTO_INSTALLABLE: dict[str, str] = {
     "jdwp_debug": "capability of a running debuggable app — not a package",
     "ebpf": "target-kernel property — not installable from the host",
     "ebpf_android": "device SDK property — not installable",
+    "jvm": "a JDK is a host toolchain decision (brew install openjdk / "
+           "distro package / SDKMAN) — the package managers here install "
+           "Python wheels, never a system JVM; the item is HARD only when "
+           "jadx is present, WARN otherwise",
 }
 
 

--- a/templates/fact-frontmatter.md
+++ b/templates/fact-frontmatter.md
@@ -71,7 +71,7 @@ provenance:
 
 ## kunglao extension layer (above the schema)
 
-kunglao keeps four fields the schema does not define. They are an explicit
+kunglao keeps five fields the schema does not define. They are an explicit
 extension layer — consumed by `scripts/kunglao_verify.py`, NOT part of
 the 12 mandatory fields, but REQUIRED on every kunglao fact:
 
@@ -82,6 +82,30 @@ the 12 mandatory fields, but REQUIRED on every kunglao fact:
 | `expected` | L1 oracle: sha256 of reproduce stdout, or assignment-class `field=value` assertions |
 | `verified` | date of last L1 pass (`pending` when none yet) |
 | `trace_id` | #879 mission chain id `tr-<mission>-<seq>` (optional; worker echo, same channel as `claim_id`) |
+
+### `evidence_class` — the evidence-grade class (claim gate input)
+
+`evidence_class` is the fifth extension field, optional in the frontmatter
+but REQUIRED whenever the fact answers an algorithm-recovery claim:
+
+| value | means |
+|-------|-------|
+| `triage` | string/byte-level scanning without decompilation or execution (unzip + grep, strings, raw byte sweeps) |
+| `decompile` | decompiled source or decompiler-grade index/taint (jadx source tree, dexdc index/taint, ghidra/IDA decompile) |
+| `dynamic` | runtime observation (frida/dynamic trace, qiling emulation) |
+
+Read it as a GRADE, not a tool name: `source: static-decompile` does NOT
+imply `evidence_class: decompile` — an unzip+grep fact carries the
+`static-decompile` source enum while its evidence class stays `triage`.
+
+`scripts/register_proven_gate.py` reads this field on `→PROVEN`
+transitions: an algorithm-recovery claim (identified by scope keywords in
+its register text: key schedule / crypto constant / state machine /
+algorithm verify) whose facts are ALL triage-grade fails admission with
+`evidence-class` named in the reason. An absent or unrecognized value is
+graded `triage` (fail-closed — an undeclared class is not a claim of
+strength); `scripts/lint_facts.py` reports an unrecognized value as
+`BAD_EVIDENCE_CLASS`.
 
 Plus the verifier gate: `verify_status` ∈ `pending`/`partial`/`passes`/`fails`/`stale`
 (schema Layer-4 field). Two-layer mapping: `references/schemas/state-mapping.md`.
@@ -99,6 +123,7 @@ verify_status: passes
 created: 2026-08-13
 last_reviewed: 2026-08-14
 source: static-decompile
+evidence_class: decompile
 confidence: high
 claim_id: C-999
 boundary_type: observation

--- a/tests/test_dispatch_context_providers.py
+++ b/tests/test_dispatch_context_providers.py
@@ -61,7 +61,8 @@ def ws(tmp_path: Path) -> Path:
     (ev / "apk_mem_gate.json").write_text(
         json.dumps({"verdict": "smali-only"}), encoding="utf-8")
     (ev / "tool-probes.json").write_text(json.dumps({
-        "jadx_bin": True, "dexdc_wheel": True, "smali_toolchain": True}),
+        "jadx_bin": True, "dexdc_wheel": True, "smali_toolchain": True,
+        "jvm": True}),
         encoding="utf-8")
     (ws / "facts").mkdir()
     (ws / "facts" / "_INDEX.md").write_text(

--- a/tests/test_memgate_evidence_215.py
+++ b/tests/test_memgate_evidence_215.py
@@ -428,16 +428,26 @@ def _lint_issues(ws: Path):
     return lint_facts.lint_fact(fm.get("id", "F001-aes"), fm, set(), "")
 
 
+def _codes(issues) -> list:
+    return [code for _sev, code, _msg in issues]
+
+
+def _evidence_class_issues(issues) -> list:
+    """Only the findings that name the evidence_class key (the module also
+    reports orthogonal debt: NO_CODE_SOURCE body sections, and the
+    pre-existing schema_rev unknown-key warning)."""
+    return [msg for _sev, _code, msg in issues if "evidence_class" in msg]
+
+
 def test_lint_facts_accepts_evidence_class(tmp_path):
-    codes = [c for _sev, c, _m in _lint_issues(_lint_ws(tmp_path))]
-    assert "BAD_EVIDENCE_CLASS" not in codes, codes
-    assert "UNKNOWN_KEY" not in codes, codes
+    issues = _lint_issues(_lint_ws(tmp_path))
+    assert "BAD_EVIDENCE_CLASS" not in _codes(issues), _codes(issues)
+    assert _evidence_class_issues(issues) == [], issues
 
 
 def test_lint_facts_rejects_unknown_evidence_class(tmp_path):
-    codes = [c for _sev, c, _m in
-             _lint_issues(_lint_ws(tmp_path, evidence_class="totally-made-up"))]
-    assert "BAD_EVIDENCE_CLASS" in codes, codes
+    issues = _lint_issues(_lint_ws(tmp_path, evidence_class="totally-made-up"))
+    assert "BAD_EVIDENCE_CLASS" in _codes(issues), _codes(issues)
 
 
 def test_fact_template_documents_the_extension_field():

--- a/tests/test_memgate_evidence_215.py
+++ b/tests/test_memgate_evidence_215.py
@@ -1,0 +1,504 @@
+# -*- coding: utf-8 -*-
+"""Issue 215 — apk_mem_gate verdict gates formal analysis (env-fact wiring,
+JVM probe, evidence classes).
+
+Field pathology (wbtest run, 2026-09-10): a whole formal analysis ran on
+unzip + grep. Two premises were never probed — the apk_mem_gate verdict
+(the gate is a provider precondition agents bypassing the provider system
+never touch) and the JVM ("no JVM" was read off dexdc's FEATURE text, not
+`java -version`). String facts also satisfied algorithm-recovery claims.
+
+This module pins the four enforcement faces:
+
+  A. recording — init probes the gate for the aligned android target and
+     records the verdict into <ws>/env-facts.yaml (issue 450 env facts, the
+     issue 477 installed-ledger write-through precedent); env_manifest's
+     render_section surfaces it.
+  B. JVM probe — `java -version` joins _check_android (state-ladder
+     layer 1, issue 213); HARD when jadx is present, WARN otherwise.
+  C. evidence classes — a →PROVEN transition of an algorithm-scoped claim
+     whose facts are all triage-grade fails admission with `evidence-class`
+     named in the reason.
+  D. wording/registry — the dexdc index entries carry the environment-probe
+     caveat; jadx's provider requirements declare `jvm`.
+
+E2 spike decision (mechanism choice, recorded here as the rationale of
+record): 'algorithm-recovery claim identification' is done by SCOPE
+KEYWORDS over the claim's own register text (statement/title), NOT by a new
+claim-scope field. A new field nothing writes would be self-declaration —
+the exact trust posture issue 819 rejects — while the register text is the
+artifact of record the orchestrator already maintains. The KEEP list is the
+four classes named by the issue (key_schedule / crypto_constant /
+state_machine / algorithm_verify) in their snake_case and prose spellings.
+"""
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+
+import env_manifest  # noqa: E402
+import lint_facts  # noqa: E402
+import register_proven_gate as rpg  # noqa: E402
+import route_capability as rc  # noqa: E402
+import toolchain as tc  # noqa: E402
+import yaml  # noqa: E402
+
+_INIT_MOD = None
+
+
+def _load_init_module():
+    """Load kunglao-init.py via importlib (hyphen blocks direct import)."""
+    global _INIT_MOD
+    if _INIT_MOD is None:
+        spec = importlib.util.spec_from_file_location(
+            "kunglao_init_memgate_215", SCRIPTS / "kunglao-init.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        _INIT_MOD = mod
+    return _INIT_MOD
+
+
+# =========================================================================
+# A. gate verdict recorded as an env fact
+# =========================================================================
+
+def _android_ws(tmp_path: Path, sample: str = "wbtest.apk") -> Path:
+    ws = tmp_path / "ws"
+    (ws / "bins").mkdir(parents=True)
+    (ws / "bins" / sample).write_bytes(b"PK\x03\x04" + b"\x00" * 32)
+    return ws
+
+
+def _stub_gate(monkeypatch, mod, verdict="smali-only",
+               est=4.0, budget=2.6, reason=""):
+    calls = []
+
+    def _fake(ws, target_path, timeout=120):
+        calls.append((Path(ws), Path(target_path)))
+        return {"verdict": verdict, "est_heap_gb": est,
+                "budget_gb": budget, "reason": reason}
+
+    monkeypatch.setattr(mod, "_run_mem_gate_cli", _fake)
+    return calls
+
+
+def test_init_records_mem_gate_verdict_as_env_fact(monkeypatch, tmp_path):
+    """The gate is a PROBE, not a pipeline stage: init runs it on the
+    aligned android target and the verdict lands in the env facts."""
+    mod = _load_init_module()
+    ws = _android_ws(tmp_path)
+    calls = _stub_gate(monkeypatch, mod)
+
+    rec = mod.record_mem_gate_verdict(ws, "android", "wbtest.apk")
+
+    assert rec is not None and rec["verdict"] == "smali-only", rec
+    assert calls and calls[0][1].name == "wbtest.apk", calls
+    facts = yaml.safe_load((ws / "env-facts.yaml").read_text("utf-8"))
+    assert facts["mem_gate"]["verdict"] == "smali-only", facts
+    assert facts["mem_gate"]["est_heap_gb"] == 4.0, facts
+
+
+def test_mem_gate_unavailable_when_no_aligned_target(monkeypatch, tmp_path):
+    """No target -> `unavailable` is an EXPLICIT env fact (never a silent
+    skip, never a fabricated verdict); the gate CLI is not invoked."""
+    mod = _load_init_module()
+    ws = _android_ws(tmp_path)
+    calls = _stub_gate(monkeypatch, mod)
+
+    rec = mod.record_mem_gate_verdict(ws, "android", None)
+
+    assert rec is not None and rec["verdict"] == "unavailable", rec
+    assert rec.get("reason"), rec
+    assert calls == [], "the gate must not run without an aligned target"
+    facts = yaml.safe_load((ws / "env-facts.yaml").read_text("utf-8"))
+    assert facts["mem_gate"]["verdict"] == "unavailable", facts
+
+
+def test_mem_gate_probe_is_android_only(monkeypatch, tmp_path):
+    """Lane gating is issue 208's work — this probe fires on android only: a
+    windows/linux/web workspace records nothing at all."""
+    mod = _load_init_module()
+    ws = _android_ws(tmp_path)
+    calls = _stub_gate(monkeypatch, mod)
+    for ptype in ("windows", "linux", "web", "macos"):
+        assert mod.record_mem_gate_verdict(ws, ptype, "wbtest.apk") is None
+    assert calls == []
+    assert not (ws / "env-facts.yaml").exists()
+
+
+def test_mem_gate_cli_runner_parses_the_one_json_line(monkeypatch, tmp_path):
+    """The tool's stdout contract: ONE JSON line {verdict, est_heap_gb,
+    budget_gb}; anything else -> unavailable (fail-open, never raises)."""
+    mod = _load_init_module()
+    ws = _android_ws(tmp_path)
+    target = ws / "bins" / "wbtest.apk"
+    payload = {"verdict": "jadx-ok", "est_heap_gb": 4.0, "budget_gb": 6.1}
+
+    class _R:
+        returncode = 0
+        stdout = json.dumps(payload) + "\n"
+        stderr = ""
+
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: _R())
+    assert mod._run_mem_gate_cli(ws, target) == payload
+
+    class _Bad:
+        returncode = 1
+        stdout = ""
+        stderr = "boom"
+
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: _Bad())
+    rec = mod._run_mem_gate_cli(ws, target)
+    assert rec["verdict"] == "unavailable" and "boom" in rec["reason"], rec
+
+
+def test_init_run_wires_the_mem_gate_record():
+    """Wiring pin: a helper nobody calls would pass every unit test above."""
+    mod = _load_init_module()
+    assert "record_mem_gate_verdict(" in inspect.getsource(mod.initialize)
+
+
+def test_env_render_section_surfaces_the_recorded_verdict(tmp_path):
+    ws = _android_ws(tmp_path)
+    env_manifest.record_mem_gate(ws, "smali-only", est_heap_gb=4.0,
+                                 budget_gb=2.6)
+    section = env_manifest.render_section(env_manifest.resolve(ws))
+    assert "smali-only" in section, section
+    assert "mem" in section.lower(), section
+
+
+def test_env_render_section_names_the_unknown_verdict_honestly(tmp_path):
+    """Absent fact -> honest unknown + the exact command (never invented)."""
+    ws = _android_ws(tmp_path)
+    section = env_manifest.render_section(env_manifest.resolve(ws))
+    assert "apk_mem_gate" in section, section
+    assert "unknown" in section.lower(), section
+
+
+# =========================================================================
+# B. JVM probe joins the android check set
+# =========================================================================
+
+def _stub_probe_surface(monkeypatch, found=(), run_rc=0,
+                        out="openjdk version \"17.0.11\" 2024-04-16",
+                        err="openjdk version \"17.0.11\" 2024-04-16"):
+    monkeypatch.setattr(tc, "_shutil_which",
+                        lambda name: (f"/stub-bin/{name}"
+                                      if name in found else None))
+    monkeypatch.setattr(tc, "_run_cmd",
+                        lambda args, timeout=10: (run_rc, out, err))
+
+
+def _android_report(tmp_path) -> tc.ToolchainReport:
+    report = tc.ToolchainReport(project_type="android")
+    tc._check_android(report, tmp_path)
+    return report
+
+
+def test_android_report_carries_jvm_probe_item(monkeypatch, tmp_path):
+    _stub_probe_surface(monkeypatch, found=("jadx", "java"))
+    item = next((i for i in _android_report(tmp_path).items
+                 if i.name == "jvm"), None)
+    assert item is not None, "android report must carry a jvm probe item"
+    assert item.status == tc.Status.PASS, item
+    assert item.tier == tc.Tier.HARD, item
+    assert item.probe == tc.ProbeTier.CAPABILITY, item
+    assert "17" in item.detail, item
+
+
+def test_jvm_probe_is_hard_when_jadx_present(monkeypatch, tmp_path):
+    """jadx is a Java program: jadx without a JVM is a broken environment,
+    so the miss is HARD (the item can then enter the exit-4 refusal set)."""
+    _stub_probe_surface(monkeypatch, found=("jadx",))
+    item = next((i for i in _android_report(tmp_path).items
+                 if i.name == "jvm"), None)
+    assert item is not None and item.status == tc.Status.FAIL, item
+    assert item.tier == tc.Tier.HARD, item
+
+
+def test_jvm_probe_is_warn_without_jadx(monkeypatch, tmp_path):
+    """No jadx -> nothing needs the JVM: a WARN, never a HARD refusal."""
+    _stub_probe_surface(monkeypatch, found=())
+    item = next((i for i in _android_report(tmp_path).items
+                 if i.name == "jvm"), None)
+    assert item is not None and item.tier == tc.Tier.WARN, item
+    assert item.status == tc.Status.WARN, item
+
+
+def test_jvm_probe_fails_on_nonzero_java(monkeypatch, tmp_path):
+    _stub_probe_surface(monkeypatch, found=("jadx", "java"), run_rc=1,
+                        out="", err="Error: could not open JVM")
+    item = next((i for i in _android_report(tmp_path).items
+                 if i.name == "jvm"), None)
+    assert item is not None and item.status == tc.Status.FAIL, item
+
+
+def test_jvm_joins_the_android_check_set():
+    assert "jvm" in tc.CHECK_SETS["android"]
+    assert "jvm" not in tc.CHECK_SETS["windows"]
+    # the issue 477 coverage declaration must classify the new item
+    import toolchain_install as ti
+    assert ("jvm" in ti.INSTALL_PLANS) or ("jvm" in ti.NOT_AUTO_INSTALLABLE)
+
+
+# =========================================================================
+# C. evidence-class gate on →PROVEN
+# =========================================================================
+
+REG = (
+    "claims:\n"
+    "  - id: C-001\n"
+    "    status: {s}\n"
+    "    statement: \"{stmt}\"\n"
+)
+
+ALGO_STMT = "Recover the AES key schedule expansion used by the crypto class"
+PLAIN_STMT = "Sample package name and version strings"
+
+FACT = """---
+id: {fid}
+type: fact
+schema_rev: 2
+title: "{title}"
+status: PROVEN
+verify_status: passes
+created: 2026-09-10
+last_reviewed: 2026-09-10
+source: static-decompile
+confidence: high
+claim_id: C-001
+boundary_type: observation
+promotion_gate: "runtime capture of the same values"
+provenance:
+  - {{role: sample_raw, path: bins/x.apk, content_sha256: "{sha}", credibility: A1}}
+claim: "{title}"
+reproduce: "unzip -p bins/x.apk classes.dex | grep -a AES"
+expected: "AES"
+verified: pending
+{extra}---
+{body}
+"""
+
+SHA = "a" * 64
+
+
+def _mk_ws(tmp_path) -> Path:
+    ws = tmp_path / "ws"
+    (ws / "runs").mkdir(parents=True)
+    (ws / "facts").mkdir()
+    return ws
+
+
+def _verify(ws, claim="C-001"):
+    (ws / "runs" / f"2026-09-10-verify-{claim}.md").write_text(
+        f"---\nclaim_id: {claim}\n---\n\n## Overall verdict\npasses\n",
+        encoding="utf-8")
+
+
+def _redteam(ws, claim="C-001"):
+    (ws / "runs" / f"verify-redteam-{claim}.md").write_text(
+        f"---\ntarget: {claim}\n---\n\nRED-TEAM VERDICT: CONFIRMED\n"
+        f"claim: {claim}\n\nverifier-identity: rt-worker-1", encoding="utf-8")
+
+
+def _fact(ws, fid="F001-aes", evidence_class=None, title="AES key schedule"):
+    extra = (f"evidence_class: {evidence_class}\n" if evidence_class
+             else "")
+    (ws / "facts" / f"{fid}.md").write_text(
+        FACT.format(fid=fid, title=title, sha=SHA, extra=extra,
+                    body="unzip + grep string fact\n"), encoding="utf-8")
+
+
+def _reg(status="PROVEN", stmt=ALGO_STMT) -> str:
+    return REG.format(s=status, stmt=stmt)
+
+
+OLD = _reg("OPEN")
+
+
+def test_algorithm_claim_triage_only_evidence_is_blocked(tmp_path):
+    """The issue 215 pathology: string facts alone could mint PROVEN on an
+    algorithm-recovery claim."""
+    ws = _mk_ws(tmp_path)
+    _verify(ws)
+    _redteam(ws)
+    _fact(ws, evidence_class="triage")
+
+    res = rpg.check_register_transitions(ws, _reg(), OLD)
+
+    assert res["ok"] is False, res
+    assert any("evidence-class" in v for v in res["violations"]), \
+        res["violations"]
+
+
+def test_algorithm_claim_without_evidence_class_is_blocked(tmp_path):
+    """Fail-closed default: an UNDECLARED class is not a claim of strength
+    (the `source: static-decompile` masquerade is exactly the issue 215 blind
+    spot — the triage fact above declares that same source enum)."""
+    ws = _mk_ws(tmp_path)
+    _verify(ws)
+    _redteam(ws)
+    _fact(ws, evidence_class=None)
+
+    res = rpg.check_register_transitions(ws, _reg(), OLD)
+
+    assert res["ok"] is False, res
+    assert any("evidence-class" in v for v in res["violations"]), \
+        res["violations"]
+
+
+def test_algorithm_claim_decompile_evidence_allows(tmp_path):
+    ws = _mk_ws(tmp_path)
+    _verify(ws)
+    _redteam(ws)
+    _fact(ws, evidence_class="decompile")
+
+    res = rpg.check_register_transitions(ws, _reg(), OLD)
+
+    assert res["ok"] is True, res["violations"]
+
+
+def test_non_algorithm_claim_is_not_gated_by_evidence_class(tmp_path):
+    """Scope keywords identify algorithm-recovery claims only; ordinary
+    claims keep the issue 819 gate untouched."""
+    ws = _mk_ws(tmp_path)
+    _verify(ws)
+    _redteam(ws)
+    _fact(ws, evidence_class="triage")
+
+    res = rpg.check_register_transitions(ws, _reg(stmt=PLAIN_STMT), OLD)
+
+    assert res["ok"] is True, res["violations"]
+
+
+def test_algorithm_claim_without_facts_keeps_the_819_gate(tmp_path):
+    """Documented boundary: with no fact file there is no fact-frontmatter
+    evidence class to read — the issue 819 verify/redteam gate governs."""
+    ws = _mk_ws(tmp_path)
+    _verify(ws)
+    _redteam(ws)
+
+    res = rpg.check_register_transitions(ws, _reg(), OLD)
+
+    assert res["ok"] is True, res["violations"]
+
+
+def test_evidence_class_scope_keywords_cover_the_four_issue_classes():
+    """The KEEP list is data, not prose: one keyword per issue class."""
+    from register_proven_gate import ALGO_SCOPE_KEYWORDS
+    joined = " ".join(ALGO_SCOPE_KEYWORDS).lower()
+    for token in ("key_schedule", "crypto_constant", "state_machine",
+                  "algorithm_verify"):
+        assert token in joined, (token, ALGO_SCOPE_KEYWORDS)
+
+
+def test_819_no_evidence_still_blocks_algorithm_claim(tmp_path):
+    """Regression pin: the evidence-class predicate is ADDITIVE — the issue 819
+    predicates still fire first-class on the same claim."""
+    ws = _mk_ws(tmp_path)
+    _fact(ws, evidence_class="decompile")
+    res = rpg.check_register_transitions(ws, _reg(), OLD)
+    assert res["ok"] is False, res
+    assert any("verify-note" in v for v in res["violations"]), \
+        res["violations"]
+
+
+# =========================================================================
+# C2. lint_facts / template: the evidence_class extension field
+# =========================================================================
+
+def _lint_ws(tmp_path, evidence_class="triage") -> Path:
+    ws = tmp_path / "ws"
+    (ws / "facts").mkdir(parents=True)
+    _fact(ws, evidence_class=evidence_class)
+    return ws
+
+
+def _lint_issues(ws: Path):
+    fact = next((ws / "facts").glob("*.md"))
+    fm = lint_facts._load_fact(fact)
+    return lint_facts.lint_fact(fm.get("id", "F001-aes"), fm, set(), "")
+
+
+def test_lint_facts_accepts_evidence_class(tmp_path):
+    codes = [c for _sev, c, _m in _lint_issues(_lint_ws(tmp_path))]
+    assert "BAD_EVIDENCE_CLASS" not in codes, codes
+    assert "UNKNOWN_KEY" not in codes, codes
+
+
+def test_lint_facts_rejects_unknown_evidence_class(tmp_path):
+    codes = [c for _sev, c, _m in
+             _lint_issues(_lint_ws(tmp_path, evidence_class="totally-made-up"))]
+    assert "BAD_EVIDENCE_CLASS" in codes, codes
+
+
+def test_fact_template_documents_the_extension_field():
+    text = (ROOT / "templates" / "fact-frontmatter.md").read_text("utf-8")
+    assert "evidence_class" in text, "the extension layer must document it"
+    for value in ("triage", "decompile"):
+        assert value in text, value
+
+
+# =========================================================================
+# D. registry / index contracts
+# =========================================================================
+
+def test_route_jvm_token_reads_the_probe_state():
+    assert rc._eval_token("jvm", {"tool_probes": {"jvm": True}}) == ("ok", None)
+    verdict, reason = rc._eval_token("jvm", {"tool_probes": {"jvm": False}})
+    assert verdict == "blocked" and reason, (verdict, reason)
+    verdict, _reason = rc._eval_token("jvm", {"tool_probes": {}})
+    assert verdict == "unverified", verdict
+
+
+def test_jadx_provider_requires_jvm_in_registry():
+    data = yaml.safe_load((ROOT / "tools" / "_INDEX.yaml").read_text("utf-8"))
+    entry = next(e for e in data["tools"] if e.get("name") == "jadx-decompile")
+    assert "jvm" in entry["requires"], entry["requires"]
+    assert set(entry["requires"]) >= {"dex", "mem_budget_ok", "jadx_bin", "jvm"}
+    sys.path.insert(0, str(ROOT / "tools"))
+    import validate_index as vi
+    assert "jvm" in vi.PROVIDER_TOKENS, vi.PROVIDER_TOKENS
+    assert [e for e in vi.validate_index(data)
+            if "jadx-decompile" in e] == [], vi.validate_index(data)
+
+
+def test_dexdc_index_entries_carry_the_jvm_probe_caveat():
+    """The conflation source: 'no JVM' is a dexdc PROPERTY, not an
+    environment fact — the wording must say so and point at the probe."""
+    text = (ROOT / "tools" / "_index-static.md").read_text("utf-8")
+    for chunk in text.split("### dexdc-decompile")[1:]:
+        assert "requires no JVM" in chunk, chunk[:200]
+        assert "probe" in chunk.lower(), chunk[:400]
+    assert "no JVM - immune to jadx heap thrash" not in text
+
+
+def test_jadx_index_entry_lists_the_jvm_requirement():
+    text = (ROOT / "tools" / "_index-static.md").read_text("utf-8")
+    line = next(l for l in text.splitlines()
+                if l.startswith("- **provider**: `jadx`"))
+    assert "jvm" in line, line
+
+
+def test_apk_mem_gate_behavior_unchanged():
+    """issue 215 wires and enforces — the 12x formula itself is untouched."""
+    from apk_mem_gate import DEFAULTS, _verdict
+    assert DEFAULTS["apk_mem_dex_factor"] == 50.0
+    assert DEFAULTS["apk_mem_floor_gb"] == 4.0
+    assert DEFAULTS["apk_mem_budget_ratio"] == 0.65
+    # refuse is an EXPECTED outcome (jar target, no smali fallback)
+    assert _verdict(4.0, 10.0, ".jar", None)[0] == "refuse"
+    assert _verdict(4.0, 10.0, ".apk", None)[0] == "jadx-ok"
+    assert _verdict(4.0, 2.6, ".apk", None)[0] == "smali-only"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-q"])

--- a/tests/test_route_capability_providers.py
+++ b/tests/test_route_capability_providers.py
@@ -64,7 +64,8 @@ def _ws(tmp_path: Path, mem_verdict: str | None = None,
             encoding="utf-8")
     if tool_probes:
         (ev / "tool-probes.json").write_text(json.dumps({
-            "jadx_bin": True, "dexdc_wheel": True, "smali_toolchain": True}),
+            "jadx_bin": True, "dexdc_wheel": True, "smali_toolchain": True,
+            "jvm": True}),
             encoding="utf-8")
     return ws
 

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -415,11 +415,12 @@ def test_exit_2_warn_only(fake_bin, kunglao_ws, monkeypatch):
     """F5: all HARD checks PASS, only WARN-tier items outstanding -> exit 2.
     Android end-to-end: full fake toolchain + fake adb + TCP listeners for
     frida/android_server -> every HARD item passes; unidbg (WARN tier) keeps
-    the overall at WARN -> exit code 2."""
+    the overall at WARN -> exit code 2. `java` joins the stub set because
+    the JVM is a HARD precondition of a present jadx (issue 215)."""
     import socket as socket_mod
     # Platform-aware wrappers so shutil.which finds the fake tools on both
     # Windows (.bat via PATHEXT) and POSIX (extensionless + exec bit).
-    for tool in ("aapt", "jadx", "apktool"):
+    for tool in ("aapt", "jadx", "apktool", "java"):
         if os.name == "nt":
             (fake_bin / f"{tool}.bat").write_text("@echo off\r\nexit /b 0\r\n",
                                                   encoding="utf-8")

--- a/tools/_INDEX.yaml
+++ b/tools/_INDEX.yaml
@@ -493,11 +493,11 @@ tools:
     description: DEX-to-Java decompiler (jadx)
     tier: T1
     cost_tier: deep
-    input_output: {input: "APK/JAR via worker-dispatched external jadx CLI (mem-gated by tools/static/apk_mem_gate.py, verdict in evidence/apk_mem_gate.json)", output: "decompiled Java source tree under evidence/"}
-    when_not: "not when the apk_mem_gate verdict is smali-only/refuse (blocked - mem budget; the #670 gate is this provider's precondition, not a pipeline stage); not for 1:1 bytecode truth (baksmali-xref)"
+    input_output: {input: "APK/JAR via worker-dispatched external jadx CLI (mem-gated by tools/static/apk_mem_gate.py, verdict in evidence/apk_mem_gate.json; the jadx_bin/jvm preconditions are probed at init - java -version, never read off a tool description)", output: "decompiled Java source tree under evidence/"}
+    when_not: "not when the apk_mem_gate verdict is smali-only/refuse (blocked - mem budget; the #670 gate is this provider's precondition, not a pipeline stage); not when the jvm probe failed (jadx is a Java program - probe the environment, never assume); not for 1:1 bytecode truth (baksmali-xref)"
     provider: jadx
     produces: [android:java-source]
-    requires: [dex, mem_budget_ok, jadx_bin]
+    requires: [dex, mem_budget_ok, jadx_bin, jvm]
     cost_hint: {mem_gb: 4.0, time: deep}
     quality: {android:java-source: high}
 
@@ -549,7 +549,7 @@ tools:
     description: Rust DEX decompiler + taint
     tier: T1
     cost_tier: deep
-    input_output: {input: "APK/DEX via tools/static/dexdc_scanner.py (PyO3 wheel dex_decompiler, CLI dex-decompile fallback; no JVM)", output: "evidence/dexdc_index.json (gitnexus-shape classes/methods/xrefs + per-method cfg) + evidence/dexdc_taint.json (IssueReport issues source->sink with traces)"}
+    input_output: {input: "APK/DEX via tools/static/dexdc_scanner.py (PyO3 wheel dex_decompiler, CLI dex-decompile fallback; requires no JVM - a dexdc provider property, not an environment fact: probe the host JVM separately with java -version for jadx)", output: "evidence/dexdc_index.json (gitnexus-shape classes/methods/xrefs + per-method cfg) + evidence/dexdc_taint.json (IssueReport issues source->sink with traces)"}
     when_not: "not the highest-fidelity java source when jadx runs within budget (jadx stays high); its value is data-flow/string-decrypt/algorithm-verify which jadx lacks; not for dex rewrite (baksmali/dexlib2)"
     provider: dexdc
     produces: [android:java-source, android:call-graph, android:data-flow, android:string-decrypt, android:algorithm-verify]

--- a/tools/_index-static.md
+++ b/tools/_index-static.md
@@ -24,10 +24,10 @@
 | `ida-decompile` | IDA lane tool family over the ida-pro-vm MCP bridge (`ida:decompile` sole + `ida-py-eval` scripting face; typed surfaces: analyze_funcs/xrefs_to/find_bytes class; queue-serial, stateful REPL) | Read when a function-level decompile must come from IDA's analyzer (ghidra unavailable/insufficient) or scripting-grade in-process IDA execution is needed; not for bulk whole-binary disassembly (ghidra-decompile-functions) or dynamic-lane (x64dbg/frida) questions |
 | `yara-scan` | YARA rule scanning (built-in crypto-tables) | Read for rule-based byte scanning (family/IOC evidence); not when yara-python is missing |
 | `yara-gen` | YARA rule text generation from analysis findings | Read when generating detection rules from hex/string traits; not without a rule-generation need |
-| `jadx-decompile` | DEX-to-Java decompiler (jadx; android:java-source high) | Read when java-like source is needed AND the apk_mem_gate verdict is jadx-ok/targeted-jadx; not for 1:1 bytecode truth (baksmali-xref) |
+| `jadx-decompile` | DEX-to-Java decompiler (jadx; android:java-source high) | Read when java-like source is needed AND the apk_mem_gate verdict is jadx-ok/targeted-jadx AND the jvm probe passed; not for 1:1 bytecode truth (baksmali-xref) |
 | `baksmali-xref` | DEX 1:1 smali + xref index (android:bytecode-truth sole) | Read when bytecode truth / mechanical fact anchors are needed, or as floor java-source/call-graph fallback; not for java-like source |
 | `apkid-prescan` | APK packer/compiler/obfuscator fingerprint | Read at android intake; its obfuscator tag raises the deobf prior (WP6) only, it is not a D0-matrix provider |
-| `dexdc-decompile` | Rust DEX decompiler + taint/CFG (android:data-flow & string-decrypt & algorithm-verify sole) | Read when data-flow/source-to-sink, string decrypt via emulator, or algorithm verify is needed; no JVM - immune to jadx heap thrash; not the top java-source pick when jadx runs within budget |
+| `dexdc-decompile` | Rust DEX decompiler + taint/CFG (android:data-flow & string-decrypt & algorithm-verify sole) | Read when data-flow/source-to-sink, string decrypt via emulator, or algorithm verify is needed; requires no JVM (a dexdc property - probe the environment's JVM separately with `java -version` for jadx); not the top java-source pick when jadx runs within budget |
 | `gitnexus-query` | Source-tree graph RAG queries (android:semantic-query sole) | Read when a claim needs semantic queries over an INDEXED source tree (lazy index, marker evidence/gitnexus_index.json); not a decompiler |
 | `wakaru-unbundle` | Bundler unpack + transpiler/minifier undo for bundled JS (`js:unbundle` sole, high; #728 web labs, external wakaru CLI) | Read when a webpack/esbuild/Browserify/Metro/Closure/ncc bundle must be split into modules; not for obfuscator.io/string-array/control-flow-flattening/VM-protected code (webcrack first) |
 | `webcrack-deobfuscate` | obfuscator.io-class JS deobfuscation + unminification (`js:deobfuscate` sole, high; #728 web labs, external webcrack CLI) | Read when classic JS obfuscation must be peeled; run BEFORE wakaru on obfuscated samples; not for VM bytecode or environment-bound code (wakaru recovers module structure after deobfuscation) |
@@ -265,8 +265,8 @@
 - **Inputs**: APK/JAR target.
 - **Outputs**: decompiled Java source tree under `evidence/`.
 - **exit code**: 0 ok/unavailable from the gate (REFUSE is an expected outcome, not an error); the external jadx CLI's own exit code is the worker's concern (budget state is a PRECONDITION — verdict `smali-only`/`refuse` blocks this provider, per #692 the #670 gate is a provider precondition, not a pipeline stage).
-- **when_not**: Not when the mem-gate verdict is smali-only/refuse; not for 1:1 bytecode truth (baksmali-xref).
-- **provider**: `jadx` — requires `[dex, mem_budget_ok, jadx_bin]`; cost_hint `{mem_gb: 4.0, time: deep}`.
+- **when_not**: Not when the mem-gate verdict is smali-only/refuse; not when the `jvm` probe failed (jadx is a Java program — probe the environment with `java -version`, never read the JVM state off a tool description); not for 1:1 bytecode truth (baksmali-xref).
+- **provider**: `jadx` — requires `[dex, mem_budget_ok, jadx_bin, jvm]`; cost_hint `{mem_gb: 4.0, time: deep}`.
 
 ### baksmali-xref
 
@@ -318,6 +318,7 @@
 - **Inputs**: APK/DEX target; optional targeted methods (index mode), package filter, taint seed APIs (default: the `references/re-library/android/emulation/android-fingerprint-seeds.yaml` table).
 - **Outputs**: `evidence/dexdc_index.json` (gitnexus-shape classes/methods/xrefs + per-method cfg nodes/edges) + `evidence/dexdc_taint.json` (`issues[].{rule, source, sink, traces}`, count).
 - **exit code**: 0 ok/unavailable (fail-open, never raises) / 1 hard usage error.
+- **JVM**: requires no JVM — a dexdc property, not an environment fact. The environment's JVM is a separate question: probe it (`java -version`) when the jadx lane is in play, and never read the host's JVM state off this entry.
 - **when_not**: Not the highest-fidelity java source when jadx runs within budget (jadx stays high); its value is data-flow/string-decrypt/algorithm-verify which jadx lacks; not for dex rewrite (baksmali/dexlib2).
 - **provider**: `dexdc` — requires `[dex, dexdc_wheel]`; detection = PyO3 wheel `import dex_decompiler` first, then `dex-decompile` CLI; index mode is pyo3-face-only, taint mode is cli-face-only (each mode uses only documented upstream surfaces).
 

--- a/tools/validate_index.py
+++ b/tools/validate_index.py
@@ -173,7 +173,7 @@ TIERS = ("T1", "T2", "T3")
 COST_TIERS = ("probe", "cheap", "deep")
 # #692 WP1: closed precondition vocabulary (design D2) + quality tiers.
 PROVIDER_TOKENS = ("dex", "mem_budget_ok", "dexdc_wheel", "jadx_bin",
-                   "smali_toolchain", "source_tree", "gitnexus_index")
+                   "smali_toolchain", "source_tree", "gitnexus_index", "jvm")
 QUALITY_TIERS = ("high", "mid", "floor")
 REQUIRED_FIELDS = ("name", "category", "capability", "tier", "cost_tier",
                    "input_output", "description")


### PR DESCRIPTION
Fixes #215

The wbtest field run never touched `apk_mem_gate` and answered "is there a JVM?" from dexdc's *feature text*; unzip+grep string facts then satisfied algorithm-recovery claims. This PR wires and enforces — the estimator itself is untouched.

## E2 spike decision (smallest checkable mechanism)

Ran `register_proven_gate.check_register_transitions` end-to-end on a tmp workspace (synthetic register + two facts) before writing code. **Decision: algorithm-recovery claims are identified by SCOPE KEYWORDS over the claim's own register text (`statement`/`title`), and graded by a fact-frontmatter `evidence_class` extension.**

Why not the alternatives: a new claim-scope field nothing writes would be *self-declaration* — the exact trust posture issue 819 rejects — while the register text is the artifact of record the orchestrator already maintains. Why not grade from the existing `source` enum: the field run's triage facts already carried `source: static-decompile`, so that enum *is* the masquerade. KEEP list = the four classes the issue names (`key_schedule` / `crypto_constant` / `state_machine` / `algorithm_verify`) in snake_case and prose spellings; fact classes are `triage` / `decompile` / `dynamic`, absent-or-unrecognized grading as `triage` (fail-closed).

Spike output (verify-note + red-team both present, so only the evidence-class layer can fire):

```
TRIAGE-ONLY  -> False ["C-001: evidence-class — algorithm-recovery claim (scope keyword 'key schedule') reaches PROVEN on ['triage'] evidence only (1 fact(s)); a triage-grade string fact cannot alone prove an algorithm claim — attach decompile-grade evidence (jadx source / dexdc index or taint) or declare the fact's evidence_class", ...]
DECOMPILE    -> the same fact flipped to evidence_class: decompile -> C-001 admitted (only C-002's unrelated missing verify-note remains)
```

Boundary (deliberate, documented in the predicate): a claim with **no fact file** has no fact-frontmatter class to read, so the issue 819 verify/red-team predicates govern it alone — the issue's rule is "triage cannot **alone** prove an algorithm claim", which needs facts to be meaningful.

## Impact blast radius (GitNexus, upstream)

| symbol | risk | direct callers / affected processes |
|---|---|---|
| `check_register_transitions` | LOW | 1 direct (`hooks/write_guard.py` `adjudicate`), 2 processes |
| `load_workspace_state` | LOW | 3 direct (`dispatch_context.py`, `route_capability.py` ×2), 2 processes |
| `_check_android` | LOW | 0 direct (dispatched via `checkers` dict), `toolchain.check` process |

Adding `jvm` to the jadx `requires` makes that provider `unverified` (never blocked) in workspaces whose `tool-probes.json` lacks the token; the two existing provider fixtures that simulate a *fully-probed* workspace gained `"jvm": True` — the fixture telling the truth, not a test weakened to fit the code. `evidence/apk_mem_gate.json` (the router's authoritative input) is still written only by the tool.

## Acceptance mapping (RED → GREEN, 6 commits)

| acceptance | pinned by | status |
|---|---|---|
| fresh init records the gate verdict in env facts | `test_init_records_mem_gate_verdict_as_env_fact` + live init below | GREEN |
| `jvm` probe item exists in the android check set | `test_android_report_carries_jvm_probe_item` + 4 tier/status tests | GREEN |
| algorithm claim with ONLY string-triage evidence cannot reach PROVEN, `evidence-class` named | `test_algorithm_claim_triage_only_evidence_is_blocked` (+ undeclared-class, decompile-allows, non-algorithm-untouched, no-facts-boundary) | GREEN |
| dexdc index wording carries the environment-probe caveat | `test_dexdc_index_entries_carry_the_jvm_probe_caveat` | GREEN |
| `apk_mem_gate` behavior unchanged | `test_apk_mem_gate_behavior_unchanged` (formula + `_verdict` ladder) | GREEN |

RED commit `84587ce` was 22 failed / 5 passed; head is 27/27 in `tests/test_memgate_evidence_215.py`.

## Field verification (owner fixtures, live)

Tool matrix on this host:

```
jadx   /usr/local/bin/jadx        (1.5.5)
java   /usr/local/opt/openjdk@17/bin/java   openjdk version "17.0.19" 2026-04-21
adb    /usr/local/bin/adb
apkid  not found        <- the live AGENT-DO story (init WARNs + recommends)
dexdc  not found        <- AGENT-DO tier, install command below
```

**Both owner fixtures through the real CLI:**

```
SMALL  (wbtest.apk, 9.3 MB)               {"verdict": "smali-only", "est_heap_gb": 4.0, "budget_gb": 2.6}
LARGE  (nova_ai_…apk, 396 MB)             {"verdict": "smali-only", "est_heap_gb": 22.071, "budget_gb": 2.6}
```

Both match the 2026-09-10 baseline exactly (est 4.0 / 22.07, budget 2.6).

**On the expected idle-machine `jadx-ok` flip — it cannot happen on this host, and that is an estimator limitation, not a wiring gap:**

```
$ python3 -c "import os; os.sysconf('SC_AVPHYS_PAGES')"
ValueError: unrecognized configuration name        # darwin has no such sysconf name
=> apk_mem_gate._avail_gb() fails open to the 4.0 GB floor; budget = 0.65*4.0 = 2.6 GB const
```

`SC_AVPHYS_PAGES` is Linux-only, so on macOS `_avail_gb()` always returns the fail-open 4.0 GB floor and the budget is a constant 2.6 GB regardless of load. The `jadx-ok` flip is still demonstrable through the documented operator override (and is the state a Linux/idle host would produce):

```
apk_mem_override=jadx  ->  {"verdict": "jadx-ok", "est_heap_gb": 4.0, "budget_gb": 2.6}   (router: recommendation = jadx-decompile)
```

(`--skip-toolchain` init with `apk_mem_override=jadx` in `analysis_state.txt`; the override is a supported outcome, and I restored the workspace to the live verdict afterwards.)

**Live router block (recorded `smali-only`):**

```
workspace state mem_gate_verdict: smali-only
  jadx-decompile   blocked    mem_budget_ok: mem budget verdict smali-only (#670 - jadx provider precondition, not a pipeline stage)
  dexdc-decompile  unverified dexdc_wheel: no tool-probes evidence
  baksmali-xref    unverified smali_toolchain: no tool-probes evidence
recommendation: dexdc-decompile          <- never a grep fallback
owner(dexdc) = AGENT_DO, next_action = install
  `cd dex-decompiler-py && maturin build --release && pip install target/wheels/dex_decompiler-*.whl`
```

**Live fresh android init (real CLI, small APK):**

```
kunglao-init: mem-gate verdict=smali-only
kunglao-init: project_type=android
kunglao-init: initialized /private/tmp/init215b (scaffold=3 structural seeds project_type=android)
--- env-facts.yaml ---            --- evidence/apk_mem_gate.json ---
version: 1                        "target": ".../bins/wbtest.apk", "dex_bytes_total": 7871796,
mem_gate:                         "est_heap_gb": 4.0, "avail_gb": 4.0, "budget_gb": 2.6,
  verdict: smali-only             "verdict": "smali-only",
  est_heap_gb: 4.0                "calibration_basis": "single data point ..."
  budget_gb: 2.6
```

**Live JVM probe (real `scripts/toolchain.py <ws> --type android`):**

```
[PASS] [HARD] jadx: found at /usr/local/bin/jadx — 1.5.5
[PASS] [HARD] jvm: java found at /usr/local/opt/openjdk@17/bin/java — openjdk version "17.0.19" 2026-04-21
[WARN] [WARN] apkid: apkid not found in PATH — apkid recommended for apk fingerprinting (...); agent to run on first claim
```

The `jadx` item is HARD and the `jvm` item follows it: with jadx absent the JVM item is WARN, so a non-jadx host can never be pushed to the exit-4 refusal set.

Environment section now renders the fact (live `env_manifest --render`):

```
- APK memory gate: smali-only (est 4.0 GB, budget 2.6 GB, jadx blocked: use baksmali / dexdc, never string triage for algorithm claims)
- APK memory gate: unknown — run `python tools/static/apk_mem_gate.py <workspace> <target>`   (when unrecorded)
```

## Gates

- `ruff check scripts/ tools/ tests/` — 6 errors, identical to base, none new.
- Targeted set (apk_mem_gate / toolchain / kunglao_init / tool_tiers_812 / index_capability / lint_facts / new 215 module / register_proven_gate / route_capability_providers): **170 passed, 1 skipped**.
- `python3 scripts/deploy_manifest.py --write && --verify` — OK, 395 entries verified.
- `comment_hygiene_lint.py` — clean (the shrink-only ratchet caught three `#NNN` units I first added; rewritten to "issue NNN").
- GitNexus impact run on all three edited symbols (table above); `analyze` not run.

## Deviations (with reasons)

1. **`scripts/report_render.py` (+7)**: one `FIXES["jvm"]` `ToolMeta` entry. The coverage contract `test_every_fail_face_name_derives_next_action` source-scans `CheckResult(name="jvm")` and requires either FIXES membership or a WARN-only declaration — and declaring a FAIL-able item WARN-only would be false. Single append at the end of the android cluster, no `verify_cmd` (the capability probe lives in `_jvm_item`); the parallel decompiler-lane work owns the rest of that file.
2. **`CHECK_SETS["android"]` also had to change** (not just `_check_android`): `test_target_alignment` pins `emitted names ⊆ CHECK_SETS[project_type]`, so an emitted `jvm` item without the set entry would break the android no-VM-channel contract. `NOT_AUTO_INSTALLABLE["jvm"]` keeps the issue 477 coverage declaration total.
3. **No `tool-probes.json` writer added**: the `jvm` token reads the existing probe channel, same as `jadx_bin`. Nothing in-repo writes that file (pre-existing gap for `jadx_bin`/`dexdc_wheel`/`smali_toolchain` too), and the init-side probe supply is the toolchain report + the recorded gate verdict, which is what the issue asked for. Filing a follow-up would be the right place for a probe-supply wire.
4. **macOS available-memory finding** (above) is reported, not fixed: the issue says "apk_mem_gate behavior unchanged".
