### PR TITLE
fix: Patch1 review findings — rank-health inversion, decision_lint normalization, lane/material guards, locked uv probe (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,23 @@ release (see the mapping table at the end).
   `kunglao-redteam`) declare `lane: malware` and are refused at dispatch
   (PreToolUse lane gate, structured REJECT naming agent + lane + routing
   fix) on any workspace declaring another lane.
+- **Patch1 train review findings — rank health, lint normalization, lane
+  guards, locked uv probe (#225)**: the adversarial review of the
+  v0.1.5-Patch1 train reproduced ten defects; each is closed with a
+  RED-first test. The rank emit-health marker now fires on the REAL writer
+  failure (`kunglao_log.emit` returns success — a failed write sets the
+  marker instead of clearing prior fault evidence) and the bounded tail
+  read keeps a complete first line in a small day file; the statusline
+  hides the rank chip rather than fabricating `0.00` from a null score;
+  `decision_lint` folds case/separators (IDAPRO / ida-pro / wheel paths)
+  and arch aliases (x64 ≡ amd64, aarch64 ≡ arm64), never blocks on an
+  uninstall or on undecodable stdin; `toolchain` degrades an unreadable
+  material dir to WARN and fails closed on an invalid lane value;
+  `register_proven_gate` folds hyphenated scope spellings
+  (`key-schedule` / `state-machine`); init persists the probed results to
+  `evidence/tool-probes.json`, so a probed-false JVM blocks the jadx
+  provider as advertised; the env probe runs `uv run --locked`, which
+  keeps the lock sha unchanged across a probe run (#225).
 
 ## [0.1.3] - 2026-08-25
 

--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -259,7 +259,7 @@ files:
   - src: scripts/decision_lint.py
     dest: .claude/scripts/decision_lint.py
     kind: scaffold
-    sha256: d0b9e3e1f1e316d10fa33684107b4d493d05a80dd053303db7b13f552bc1309f
+    sha256: e1a7d9e5b025573e50beebc5a729988ffb465939a8a8c1d9ebc04bd74d7dd65d
   - src: scripts/decision_pending.py
     dest: .claude/scripts/decision_pending.py
     kind: scaffold
@@ -315,7 +315,7 @@ files:
   - src: scripts/env_check.py
     dest: .claude/scripts/env_check.py
     kind: scaffold
-    sha256: 1a5bf3cf0c7af71b01eaec7c031094e0a70948072123a35865ca86ff02842d64
+    sha256: 1300726cef1eb603a04f12f76fd76b3eb612a60aa474b533772600f67f9e84ae
   - src: scripts/env_manifest.py
     dest: .claude/scripts/env_manifest.py
     kind: scaffold
@@ -447,7 +447,7 @@ files:
   - src: scripts/kunglao-init.py
     dest: .claude/scripts/kunglao-init.py
     kind: scaffold
-    sha256: 87da0532d0eefd71022891360e7b419cf6337f219a5717f0af99becd110ff7e4
+    sha256: dd4e4287484a250bf78c526e7b82fff6dd932a96532ff0e08eee6aa51cec22a2
   - src: scripts/kunglao-monitor.py
     dest: .claude/scripts/kunglao-monitor.py
     kind: scaffold
@@ -479,7 +479,7 @@ files:
   - src: scripts/kunglao_log.py
     dest: .claude/scripts/kunglao_log.py
     kind: scaffold
-    sha256: 7bdd8fee67381b25d3f104d2663ca55060fc91896b5511f3eee7838a65e79a6a
+    sha256: 2a5abb27fc2366d4c2222cf1ba08db461aaf96142abd6d90a6ec6ebd7e2cb6c2
   - src: scripts/kunglao_record.py
     dest: .claude/scripts/kunglao_record.py
     kind: scaffold
@@ -619,7 +619,7 @@ files:
   - src: scripts/priority_ratio.py
     dest: .claude/scripts/priority_ratio.py
     kind: scaffold
-    sha256: ea00b83aff92aaa74662ba05fddaf1a18dbfdbbc2f68117bff09521841945a1d
+    sha256: c7f46b86f0fda2a63d7c603199f91bafc3646e1bbc725e5984effec13cc4e767
   - src: scripts/progress_report.py
     dest: .claude/scripts/progress_report.py
     kind: scaffold
@@ -635,7 +635,7 @@ files:
   - src: scripts/rank_face.py
     dest: .claude/scripts/rank_face.py
     kind: scaffold
-    sha256: 3ce63798ace6d03b6f71108e8e8fd2dec80abd2d877b537dcf656f6e2e8e0d31
+    sha256: 50b1679a957b2776ca7b181461e2a5b4c2912a6a66173f0219dbe45affe13b4d
   - src: scripts/re_pin_references.py
     dest: .claude/scripts/re_pin_references.py
     kind: scaffold
@@ -671,7 +671,7 @@ files:
   - src: scripts/register_proven_gate.py
     dest: .claude/scripts/register_proven_gate.py
     kind: scaffold
-    sha256: cd4067a9583fc07267cc43358a8593331e58f2a0c9d73d34bd6f45b0a7ae24ec
+    sha256: 63e621325a2b044f7e5cede389cc37dcdc5512b01423107c676f06657e0a3526
   - src: scripts/release_check_selfcheck.py
     dest: .claude/scripts/release_check_selfcheck.py
     kind: scaffold
@@ -787,7 +787,7 @@ files:
   - src: scripts/toolchain.py
     dest: .claude/scripts/toolchain.py
     kind: scaffold
-    sha256: dcfe5240e1995569e5061b33450f89edccaf5d72bd9984e2dac86fc9cd780fdb
+    sha256: 518530fa4174b35a55f55ab05770d623e24fef4c3e4a7e76f2c3b4cdb642db08
   - src: scripts/toolchain_install.py
     dest: .claude/scripts/toolchain_install.py
     kind: scaffold
@@ -855,7 +855,7 @@ files:
   - src: scripts/statusline_render.mjs
     dest: .claude/scripts/statusline_render.mjs
     kind: scaffold
-    sha256: 96cdba73507676da987e1701bbe0761f01d3ea2f8f23b4849095ac84dd407092
+    sha256: b6d584f82aeb1618820b806c90cccd257350bc21fe91f7a9259badd3a249e5a6
   - src: references/_INDEX.md
     dest: .claude/references/_INDEX.md
     kind: asset

--- a/scripts/decision_lint.py
+++ b/scripts/decision_lint.py
@@ -34,11 +34,24 @@ from dataclasses import dataclass, field
 # the binding refuses to import against it.
 _MAX_IDAPRO_PY = (3, 13)
 
+# Canonical arch families. Only spellings listed here are judgeable — an
+# unmatched alias (e.g. a new target name) degrades to a note, never to a
+# block (see _judge_arch).
 _ARCH_ALIASES = {
     "amd64": "x86_64",
     "x86-64": "x86_64",
+    "x86_64": "x86_64",
+    "x64": "x86_64",
     "aarch64": "arm64",
+    "arm64": "arm64",
 }
+
+# The action must be an install for the install rules to apply; a removal
+# (`pip uninstall idapro`) is the repair, never the mistake.
+_INSTALL_VERBS = frozenset({"install", "add"})
+_UNINSTALL_VERBS = frozenset({"uninstall", "remove", "purge"})
+
+_SEP_RE = re.compile(r"[-_.]+")
 
 
 @dataclass
@@ -54,9 +67,9 @@ class Verdict:
     matrix: list[str] = field(default_factory=list)
 
 
-def _norm_arch(value: str) -> str:
-    v = str(value).strip().lower()
-    return _ARCH_ALIASES.get(v, v)
+def _norm_arch(value) -> str | None:
+    """Canonical arch family for a known alias spelling, else None."""
+    return _ARCH_ALIASES.get(str(value).strip().lower())
 
 
 def _parse_py(value) -> tuple[int, int] | None:
@@ -75,7 +88,38 @@ def _judge_arch(value, facts) -> str | None:
     other = facts.get("python_arch")
     if not other:
         return None  # one side missing -> cannot judge -> note
-    return "VIOLATION" if _norm_arch(value) != _norm_arch(other) else "OK"
+    mine, theirs = _norm_arch(value), _norm_arch(other)
+    if mine is None or theirs is None:
+        return None  # unmatched alias spelling -> note, never a block
+    return "VIOLATION" if mine != theirs else "OK"
+
+
+def _fold_separators(token: str) -> str:
+    """A token with -, _ and . removed (IDAPRO / ida-pro / ida_pro fold to
+    one identity)."""
+    return _SEP_RE.sub("", token)
+
+
+def _matches_package(token: str, package: str) -> bool:
+    """Case- and separator-insensitive package identity: IDAPRO, ida-pro and
+    a ./idapro-9.0.whl path all identify the idapro package."""
+    name = token.strip().lower().rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    if not name:
+        return False
+    if _fold_separators(name) == _fold_separators(package):
+        return True
+    # a version/medium-suffixed spelling: <package>-9.0.whl, <package>.zip
+    return bool(re.match(rf"{re.escape(package)}[-_.]", name))
+
+
+def _is_install_action(tokens: list[str]) -> bool:
+    """True when the action installs packages. Removal verbs are never
+    judged — the lint exists to stop a bad INSTALL, not a repair."""
+    words = {t.strip().lower() for t in tokens}
+    if words & _UNINSTALL_VERBS:
+        return False
+    return bool(words & _INSTALL_VERBS)
+
 
 
 # rules table: package -> (fact_key, demand text, judge) entries.
@@ -99,9 +143,14 @@ def check(action: str, facts: dict) -> Verdict:
     """
     facts = facts or {}
     verdict = Verdict(blocked=False)
-    tokens = set(re.findall(r"[A-Za-z0-9_][A-Za-z0-9_.-]*", action or ""))
+    tokens = re.findall(r"[A-Za-z0-9_][A-Za-z0-9_.\-]*", action or "")
+    if not _is_install_action(tokens):
+        verdict.reasons.append(
+            "note: action is not a package install — no install rule "
+            "applies (removals are never blocked); OK (unknowns never block)")
+        return verdict
     rules = {pkg: entries for pkg, entries in _RULES.items()
-             if pkg in tokens}
+             if any(_matches_package(t, pkg) for t in tokens)}
     if not rules:
         verdict.reasons.append(
             "note: no compatibility rule matches this action — OK "
@@ -135,18 +184,36 @@ def check(action: str, facts: dict) -> Verdict:
     return verdict
 
 
+def _read_facts(raw: bytes) -> dict | None:
+    """Facts parsed from raw stdin bytes; None on bad input (exit 2).
+
+    Undecodable bytes are NOT bad input and NOT a block: they read as an
+    empty fact set (unknowns never block), so a non-UTF-8 producer stream
+    cannot turn into BLOCKED-by-crash semantics."""
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        print(f"warning: facts stdin is not valid UTF-8 ({exc}) — no facts "
+              f"read; an unreadable fact set never blocks", file=sys.stderr)
+        return {}
+    try:
+        facts = json.loads(text or "{}")
+    except json.JSONDecodeError as exc:
+        print(f"facts must be a JSON object on stdin: {exc}", file=sys.stderr)
+        return None
+    if not isinstance(facts, dict):
+        print("facts must be a JSON object on stdin", file=sys.stderr)
+        return None
+    return facts
+
+
 def _main(argv: list[str]) -> int:
     if len(argv) != 2:
         print('usage: echo \'{"fact": "value"}\' | '
               'python scripts/decision_lint.py "<action>"', file=sys.stderr)
         return 2
-    try:
-        facts = json.loads(sys.stdin.read() or "{}")
-    except json.JSONDecodeError as exc:
-        print(f"facts must be a JSON object on stdin: {exc}", file=sys.stderr)
-        return 2
-    if not isinstance(facts, dict):
-        print("facts must be a JSON object on stdin", file=sys.stderr)
+    facts = _read_facts(sys.stdin.buffer.read())
+    if facts is None:
         return 2
     verdict = check(argv[1], facts)
     for line in verdict.matrix:

--- a/scripts/env_check.py
+++ b/scripts/env_check.py
@@ -518,11 +518,16 @@ def check_venv_sample(ws: Path, sample_sha256: str | None) -> tuple[bool, str]:
     if present.
 
     issue 207: the probe dispatches the REAL runtime invocation — an in-env
-    `import yaml` executed through `uv run --project <skill_root>` — never a
-    venv binary with a hand-written dependency list. The old
+    `import yaml` executed through `uv run --locked --project <skill_root>`
+    — never a venv binary with a hand-written dependency list. The old
     ``import cryptography, yaml`` list rotted: a lock-faithful
     ``uv sync --locked`` install (yaml present, cryptography dropped from the
     declared set) was falsely refused at the blocking Phase 0 row.
+
+    issue 225: `--locked` is part of the invocation. Without it `uv run`
+    auto-relocks — the probe rewrote `<skill_root>/uv.lock` + `.venv` and
+    PASSed a drifted project that `uv sync --locked` rejects. The env still
+    syncs from the lock; a probe can never mutate it.
 
     #409: the authoritative environment is the SKILL-root uv project (uv run
     --project <skill_root>) — NOT the workspace .venv. uv's default project
@@ -541,8 +546,8 @@ def check_venv_sample(ws: Path, sample_sha256: str | None) -> tuple[bool, str]:
     else:
         try:
             r = subprocess.run(
-                [uv, "run", "--project", str(SKILL_DIR), "python", "-c",
-                 "import yaml"],
+                [uv, "run", "--locked", "--project", str(SKILL_DIR), "python",
+                 "-c", "import yaml"],
                 capture_output=True, text=True,
                 timeout=UV_PROBE_TIMEOUT_SECONDS,
                 encoding="utf-8", errors="replace")

--- a/scripts/kunglao-init.py
+++ b/scripts/kunglao-init.py
@@ -3367,6 +3367,21 @@ def run(ws: Path | None, force: bool = False, hooks_json: Path | None = None,
         for _rec in apkid_summary_lines(report):
             print(f"kunglao-init: {_rec}")
 
+        # Evidence probe persistence (issue 225): route_capability's jadx
+        # preconditions (jadx_bin / jvm) read evidence/tool-probes.json,
+        # which had no production writer — the tokens could only ever be
+        # `unverified`, so a probed-false JVM could not block the provider.
+        # Best-effort: a write failure leaves the token unverified and never
+        # blocks init (the gate result itself already stands).
+        try:
+            probes_path = toolchain.persist_tool_probes(ws, report)
+        except OSError as exc:
+            print(f"kunglao-init: WARNING tool-probes not persisted: {exc}",
+                  file=sys.stderr)
+        else:
+            if probes_path is not None:
+                print(f"kunglao-init: tool probes persisted: {probes_path}")
+
     # uv env deployment (the uv-managed .venv the shipped
     # faces resolve through) + host learning-plugin detection warning.
     warn_learning_style_plugins()

--- a/scripts/kunglao_log.py
+++ b/scripts/kunglao_log.py
@@ -195,9 +195,13 @@ def emit(ws, actor: str, action: str, *, claim: str | None = None,
          trace_id=_UNSET,
          version: str | None = None,
          channel: str | None = None,
-         null_reasons: dict | None = None) -> None:
+         null_reasons: dict | None = None) -> bool:
     """Append one structured event line. Never raises — write failure degrades
     to a stderr warning so logging can never break analysis.
+
+    Returns True when the row reached the ledger, False when the write
+    failed (the caller-visible health bit: a caller that must know whether
+    observability actually landed checks this instead of assuming).
 
     #818 batch-1: arm/epoch/hypothesis_ref per #823 attribution contract;
     version auto-fills with the checkout git SHA when omitted (None on
@@ -290,6 +294,8 @@ def emit(ws, actor: str, action: str, *, claim: str | None = None,
             os.close(fd)
     except OSError as exc:
         print(f"[kunglao_log] warning: cannot write {p}: {exc}", file=sys.stderr)
+        return False
+    return True
 
 
 # ------------------- #58 S2: subagent lifecycle events ----------------------

--- a/scripts/priority_ratio.py
+++ b/scripts/priority_ratio.py
@@ -595,7 +595,11 @@ def _emit_rank_feeds(ws, claims: list[dict], evidence: EvidenceView,
     the marker runs/.rank-emit-fail.json {ts, error class} (rank_face), a
     success clears it, and the statusline snapshot / heartbeat tick report
     surface it as the rank_log health bit. Neither the ranking result nor
-    the payload is touched by the marker."""
+    the payload is touched by the marker.
+
+    The real writer reports a failed write by returning False instead of
+    raising (kunglao_log.emit never raises), so the health bit keys off
+    BOTH shapes: a payload/build crash and a plain write failure."""
     try:
         claims_hash = hashlib.sha256(json.dumps(
             claims, sort_keys=True, ensure_ascii=False, default=repr)
@@ -613,12 +617,18 @@ def _emit_rank_feeds(ws, claims: list[dict], evidence: EvidenceView,
             "ranked_order": [a.claim_id for a in actions],
             "input_fingerprint": dict(fp_doc, fingerprint=fingerprint),
         }
-        kunglao_log.emit(ws, actor="priority_ratio", action="rank_feeds",
-                         detail=json.dumps(payload, sort_keys=True,
-                                           ensure_ascii=False))
-        # Issue 218: the last attempt succeeded — the marker clears itself so
-        # the health bit recovers without operator action.
-        rank_face.clear_fail_marker(ws)
+        if kunglao_log.emit(ws, actor="priority_ratio", action="rank_feeds",
+                            detail=json.dumps(payload, sort_keys=True,
+                                              ensure_ascii=False)) is False:
+            # Issue 218/225: the health bit tracks the LAST ATTEMPT. The
+            # writer reports a failed write with False (it never raises) —
+            # the marker MUST be set here, and a failed attempt must never
+            # erase a marker left by an earlier failure.
+            rank_face.write_fail_marker(ws, "EmitWriteError")
+        else:
+            # The last attempt succeeded — the marker clears itself so the
+            # health bit recovers without operator action.
+            rank_face.clear_fail_marker(ws)
     except Exception as exc:  # noqa: BLE001 — observability never disturbs the rank
         # Issue 218: the fail-open contract stays (the ranking result is
         # untouched) — the crash just stops being silent (see rank_face).

--- a/scripts/rank_face.py
+++ b/scripts/rank_face.py
@@ -61,6 +61,10 @@ def _now_z() -> str:
 def write_fail_marker(ws, error) -> None:
     """Record ONE failed rank_feeds emit (timestamp + error class).
 
+    `error` is an exception (its class name is recorded) or a short label
+    string for a failure that has no exception object — e.g. the writer
+    reporting a failed write with False.
+
     Best-effort by contract: the marker is observability, never a ranking
     dependency, so it must not be able to raise into the ranker's fail-open
     path."""
@@ -68,7 +72,8 @@ def write_fail_marker(ws, error) -> None:
         p = Path(ws) / MARKER_REL
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(json.dumps({"ts": _now_z(),
-                                 "error": type(error).__name__},
+                                 "error": (error if isinstance(error, str)
+                                           else type(error).__name__)},
                                 ensure_ascii=False) + "\n",
                      encoding="utf-8")
     except Exception:  # noqa: BLE001 — the marker never breaks its caller
@@ -105,8 +110,11 @@ def emit_health(ws) -> dict:
 
 def _tail_rows(ws) -> list[dict]:
     """Parsed rows from the last 64KB of the newest day file (bounded read;
-    a possibly-partial first line is dropped). [] on any read failure."""
+    a possibly-partial first line is dropped ONLY when the window actually
+    starts mid-file — a complete first line in a small file survives).
+    [] on any read failure."""
     logs = Path(ws) / LOG_DIR_REL
+    start = 0
     try:
         latest = max((p for p in logs.glob("kunglao-*.jsonl") if p.is_file()),
                      key=lambda p: p.stat().st_mtime, default=None)
@@ -115,13 +123,15 @@ def _tail_rows(ws) -> list[dict]:
         with latest.open("rb") as f:
             f.seek(0, os.SEEK_END)
             size = f.tell()
-            f.seek(max(0, size - TAIL_BYTES))
+            start = max(0, size - TAIL_BYTES)
+            f.seek(start)
             tail = f.read().decode("utf-8", errors="replace")
     except OSError:
         return []
     lines = tail.splitlines()
-    if len(lines) > 1:
-        lines = lines[1:]  # drop possibly-partial first line
+    if start > 0:
+        # the window began mid-file, so line 1 is possibly partial
+        lines = lines[1:]
     rows: list[dict] = []
     for line in lines:
         try:

--- a/scripts/register_proven_gate.py
+++ b/scripts/register_proven_gate.py
@@ -49,6 +49,15 @@ ALGO_SCOPE_KEYWORDS = (
     "algorithm recovery", "algorithm-recovery",
 )
 
+_SEP_RE = re.compile(r"[-_]+")
+
+
+def _fold_separators(text: str) -> str:
+    """Lowercase with _ / - folded to spaces: the same word break whatever
+    the spelling (key_schedule == key-schedule == key schedule)."""
+    return _SEP_RE.sub(" ", text.lower())
+
+
 TRIAGE_GRADE_CLASS = "triage"
 VALID_EVIDENCE_CLASSES = (TRIAGE_GRADE_CLASS, "decompile", "dynamic")
 # Classes that can carry an algorithm-recovery claim: decompiled source /
@@ -138,12 +147,14 @@ def algorithm_scope(claim: dict) -> str | None:
     (issue 215), else None.
 
     Read from the register's own text; the KEEP list is the four classes
-    the issue names, in snake_case and prose spellings."""
+    the issue names, in snake_case and prose spellings. Separator spelling
+    is folded before matching (_ / - / space are the same word break), so
+    `key-schedule` is not a scope escape hatch."""
     text = " ".join(str(claim.get(k) or "")
                     for k in ("statement", "title", "answers_question"))
-    lowered = text.lower()
+    folded = _fold_separators(text)
     for keyword in ALGO_SCOPE_KEYWORDS:
-        if keyword in lowered:
+        if _fold_separators(keyword) in folded:
             return keyword
     return None
 

--- a/scripts/statusline_render.mjs
+++ b/scripts/statusline_render.mjs
@@ -234,8 +234,14 @@ function rankBadge(snap) {
   if (log && log.ok === false) return PALETTE.red('R✖');
   const rank = snap.rank && typeof snap.rank === 'object' ? snap.rank : null;
   if (!rank || typeof rank.claim !== 'string' || !rank.claim) return '';
-  const score = Number(rank.score);
-  const text = `R:${rank.claim}${Number.isFinite(score) ? ` ${score.toFixed(2)}` : ''}`;
+  // A missing/unusable score hides the chip entirely — Number(null) === 0
+  // once rendered a fabricated `R:C-2 0.00`, which is a value the producer
+  // never computed (the absent face, never a placeholder).
+  const score = typeof rank.score === 'number' && Number.isFinite(rank.score)
+    ? rank.score
+    : null;
+  if (score === null) return '';
+  const text = `R:${rank.claim} ${score.toFixed(2)}`;
   return rank.stale ? PALETTE.amber(text) : PALETTE.cyan(text);
 }
 

--- a/scripts/toolchain.py
+++ b/scripts/toolchain.py
@@ -2869,9 +2869,33 @@ def _check_lane_material(report: ToolchainReport, ws: Path, lane: str,
     arrives AFTER init (a capture, a dataset, a target URL), so absence is
     WARN guidance — never a HARD refusal. The deep per-lane analysis
     toolchain is a documented stub: this face checks that the workspace has
-    somewhere to mount the lane's material and says what the lane consumes."""
-    hits = sorted(d for d in LANE_MATERIAL_DIRS
-                  if (ws / d).is_dir() and any((ws / d).iterdir()))
+    somewhere to mount the lane's material and says what the lane consumes.
+
+    An unreadable material dir degrades to WARN with the real cause: a
+    permission problem is operator guidance, never a traceback out of the
+    gate (issue 225)."""
+    hits: list[str] = []
+    unreadable: list[str] = []
+    for d in LANE_MATERIAL_DIRS:
+        p = ws / d
+        try:
+            if p.is_dir() and any(p.iterdir()):
+                hits.append(d)
+        except OSError as exc:
+            unreadable.append(
+                f"{d} ({type(exc).__name__}: {exc.strerror or exc})")
+    if unreadable:
+        detail = (f"{lane} lane material probe degraded — unreadable "
+                  f"material dir(s): {', '.join(unreadable)}; fix the "
+                  f"permissions (or remount) and re-probe"
+                  + (f"; readable material present: {', '.join(sorted(hits))}/"
+                     if hits else ""))
+        report.items.append(CheckResult(
+            name=name, status=Status.WARN, tier=Tier.WARN, detail=detail,
+            probe=ProbeTier.PRESENCE,
+        ))
+        return
+    hits = sorted(hits)
     detail = (f"{lane} lane material present: {', '.join(hits)}/ — "
               f"documented stub (the deep {lane} toolchain is not implemented)"
               if hits else
@@ -3028,7 +3052,9 @@ def check(ws: Path, project_type: str | None = None,
     Issue 208: lane selects the CHECK SET. Absent (or task_spec lane
     absent, or lane=malware) = the per-type malware dispatch, byte-identical
     to the pre-lane gate; any other lane runs uv + python + the lane's
-    material probe instead of the MCP/RE analysis supply.
+    material probe instead of the MCP/RE analysis supply. A PRESENT but
+    invalid lane value raises ValueError (fail closed — a typo never runs
+    the malware gate by accident).
     """
     if project_type is None:
         project_type = read_project_type(ws)
@@ -3039,7 +3065,12 @@ def check(ws: Path, project_type: str | None = None,
             f"Set --type or add project_type=<type> to analysis_state.txt."
         )
     if lane is None and isinstance(task_spec, dict):
-        lane = lane_spec.normalize(task_spec.get(lane_spec.LANE_FIELD))
+        raw_lane = task_spec.get(lane_spec.LANE_FIELD)
+        if raw_lane is not None and str(raw_lane).strip():
+            # A PRESENT-but-invalid value fails closed here (ValueError);
+            # only a truly ABSENT/blank lane keeps the legacy malware
+            # dispatch. A typo must never silently run the malware gate.
+            lane = lane_spec.validate(raw_lane)
     if lane is not None:
         lane = lane_spec.validate(lane)  # fail closed, never a silent malware fallback
     report = ToolchainReport(project_type=project_type)
@@ -3060,6 +3091,42 @@ def check(ws: Path, project_type: str | None = None,
     report.items = [dataclasses.replace(i, owner=owner_for(i.name))
                     for i in report.items]
     return report
+
+
+# Report item -> probe token: the route_capability preconditions that read
+# evidence/tool-probes.json (a missing token stays `unverified` there; a
+# False token BLOCKS the provider). Only items actually probed in the
+# report are written — a probe answer is never invented.
+TOOL_PROBE_ITEMS: dict[str, str] = {
+    "jvm": "jvm",
+    "jadx_bin": "jadx",
+}
+
+
+def persist_tool_probes(ws: Path, report: ToolchainReport) -> Path | None:
+    """Write <ws>/evidence/tool-probes.json from the report's tool probes.
+
+    route_capability's jadx preconditions (`jadx_bin`, `jvm`) read this
+    file; before this writer existed the file appeared only in test
+    fixtures, so the tokens could never leave `unverified` and the
+    advertised probed-false JVM block could not fire (issue 225). Mapping:
+    report status PASS -> true, anything else -> false; a token whose item
+    was not probed in this report is NOT written (never a guessed answer).
+
+    Returns the written path, or None when the report probed none of the
+    tokens (nothing to say). A real write failure raises OSError — the
+    caller decides whether that is fatal (init degrades it to a warning:
+    the token just stays `unverified`)."""
+    items = {i.name: i for i in report.items}
+    probes = {token: items[name].status == Status.PASS
+              for token, name in TOOL_PROBE_ITEMS.items() if name in items}
+    if not probes:
+        return None
+    out = Path(ws) / "evidence" / "tool-probes.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(probes, indent=2, sort_keys=True) + "\n",
+                   encoding="utf-8")
+    return out
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_decision_lint_213.py
+++ b/tests/test_decision_lint_213.py
@@ -15,7 +15,11 @@ incompatibility knowable BEFORE acting. Contract pinned here:
 from __future__ import annotations
 
 import ast
+import subprocess
+import sys
 from pathlib import Path
+
+import pytest
 
 import decision_lint  # pytest.ini pythonpath includes scripts/
 
@@ -86,3 +90,98 @@ def test_module_imports_stay_pure_no_probing():
         elif isinstance(node, ast.ImportFrom) and node.module:
             imported.add(node.module.split(".")[0])
     assert imported <= {"__future__", "re", "dataclasses", "sys", "json"}, imported
+
+
+# ---------- finding 2 (issue 225): case/separator-folded package match ----------
+
+@pytest.mark.parametrize("action", [
+    "pip install IDAPRO",
+    "pip install ida-pro",
+    "pip install ida_pro",
+    "pip install ./idapro-9.0.whl",
+])
+def test_package_token_match_is_case_and_separator_folded(action):
+    """The canonical field mistake must be caught in every spelling a field
+    command uses: IDAPRO, ida-pro, ida_pro, a wheel path."""
+    v = decision_lint.check(action, {"python_version": "3.14"})
+    assert v.blocked is True, action
+    assert any("idapro" in r for r in v.reasons), v.reasons
+
+
+def test_near_miss_package_name_does_not_block():
+    """Folding must not turn every lookalike into idapro: an unknown
+    package name stays OK-with-note (unknowns never block)."""
+    v = decision_lint.check("pip install idaproduction",
+                            {"python_version": "3.14"})
+    assert v.blocked is False
+
+
+def test_cli_blocks_the_uppercase_spelling():
+    """The reviewer's CLI repro: pip install IDAPRO + python 3.14 facts on
+    stdin -> BLOCKED, exit 1 (not the literal-match miss)."""
+    r = subprocess.run(
+        [sys.executable, str(Path(decision_lint.__file__)),
+         "pip install IDAPRO"],
+        input='{"python_version": "3.14"}', capture_output=True, text=True,
+        encoding="utf-8", errors="replace", timeout=60)
+    assert r.returncode == 1, (r.returncode, r.stdout, r.stderr)
+    assert "VERDICT: BLOCKED" in r.stdout, r.stdout
+
+
+# ---------- finding 9 (issue 225): arch aliases, stdin bytes, uninstall ----------
+
+@pytest.mark.parametrize("lib_arch,python_arch", [
+    ("x64", "amd64"),
+    ("amd64", "x64"),
+    ("x86-64", "x86_64"),
+    ("aarch64", "arm64"),
+])
+def test_arch_aliases_normalize_before_judging(lib_arch, python_arch):
+    """x64 / amd64 / x86-64 are one family; so are aarch64 / arm64. A known
+    alias spelling difference is not an incompatibility."""
+    v = decision_lint.check(
+        "pip install idapro",
+        {"libidalib_arch": lib_arch, "python_arch": python_arch,
+         "python_version": "3.12"})
+    assert v.blocked is False, (lib_arch, python_arch, v.matrix)
+
+
+def test_real_arch_mismatch_still_blocks():
+    v = decision_lint.check(
+        "pip install idapro",
+        {"libidalib_arch": "x86_64", "python_arch": "arm64",
+         "python_version": "3.12"})
+    assert v.blocked is True
+
+
+def test_unknown_arch_alias_never_grounds_a_block():
+    """The docstring contract: an unmatched alias degrades to a note, it
+    cannot ground a block (a false-positive gate gets ignored)."""
+    v = decision_lint.check(
+        "pip install idapro",
+        {"libidalib_arch": "riscv64", "python_arch": "arm64",
+         "python_version": "3.12"})
+    assert v.blocked is False
+    assert any("note" in r.lower() for r in v.reasons), v.reasons
+
+
+def test_uninstall_is_not_judged_as_an_install():
+    """`pip uninstall idapro` removes the binding — it must never be blocked
+    as if it were the install the rule was written for."""
+    v = decision_lint.check("pip uninstall idapro", {"python_version": "3.14"})
+    assert v.blocked is False
+    assert any("note" in r.lower() for r in v.reasons), v.reasons
+
+
+def test_undecodable_stdin_is_ok_with_note_never_blocked_by_crash():
+    """Non-UTF-8 stdin raised UnicodeDecodeError -> traceback, exit 1 (the
+    BLOCKED exit code). Undecodable facts are unknowns: OK-with-note."""
+    r = subprocess.run(
+        [sys.executable, str(Path(decision_lint.__file__)),
+         "pip install idapro"],
+        input=b'{"python_version": "\xff\xfe not utf-8"}',
+        capture_output=True, timeout=60)
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    out = r.stdout.decode("utf-8", errors="replace")
+    assert "VERDICT: OK" in out, out
+    assert "note" in out.lower(), out

--- a/tests/test_env_check.py
+++ b/tests/test_env_check.py
@@ -475,8 +475,36 @@ def test_venv_probe_dispatches_through_uv_project(monkeypatch, tmp_path):
     ok, detail = env_check.check_venv_sample(ws, None)
     assert ok is True, detail
     assert detail == "uv env OK (yaml)"
-    assert seen == [["/fake/bin/uv", "run", "--project", str(skill_root),
-                     "python", "-c", "import yaml"]], seen
+    assert seen == [["/fake/bin/uv", "run", "--locked", "--project",
+                     str(skill_root), "python", "-c", "import yaml"]], seen
+
+
+def test_venv_probe_pins_the_lock_so_a_probe_never_relocks(
+        monkeypatch, tmp_path):
+    """Finding 10 (issue 225): `uv run` WITHOUT --locked re-locks the
+    project — it rewrites <skill_root>/uv.lock + .venv and PASSes drift
+    that `uv sync --locked` rejects. The probe must run `uv run --locked`
+    (the env still syncs from the lock; the lock is never mutated)."""
+    ws = _kunglao_ws(tmp_path)
+    monkeypatch.delenv(FLAG_NAME, raising=False)
+    import env_check
+    skill_root = tmp_path / "skill-root"
+    monkeypatch.setattr(env_check, "SKILL_DIR", skill_root)
+    seen: list[list[str]] = []
+    monkeypatch.setattr(env_check.shutil, "which",
+                        lambda name: "/fake/bin/uv" if name == "uv" else None)
+
+    def _capture(argv, **kwargs):
+        seen.append(list(argv))
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(env_check.subprocess, "run", _capture)
+
+    ok, detail = env_check.check_venv_sample(ws, None)
+    assert ok is True, detail
+    assert seen, "the probe must run"
+    assert "--locked" in seen[0], seen
+    assert seen[0][:3] == ["/fake/bin/uv", "run", "--locked"], seen
 
 
 def test_venv_probe_uv_missing_fails_naming_uv_layer(monkeypatch, tmp_path):

--- a/tests/test_init_toolchain_gate.py
+++ b/tests/test_init_toolchain_gate.py
@@ -16,6 +16,7 @@ TDD RED phase: these fail before the kunglao-init.py amendment lands.
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import subprocess
 import sys
@@ -319,6 +320,38 @@ def test_toolchain_check_runs_before_scaffold(tmp_path, monkeypatch):
     assert calls[0]["register_existed"] is False, \
         "toolchain.check must run BEFORE scaffold (claim-register must not exist yet)"
     assert (ws / "claim-register.yaml").exists(), "scaffold must complete after PASS"
+
+
+def test_init_persists_tool_probes_evidence(tmp_path, monkeypatch):
+    """Finding 7 (issue 225): init persists the probed results to
+    evidence/tool-probes.json right after the toolchain check, so
+    route_capability reads REAL probe answers (a probed-false JVM can
+    actually block the jadx provider)."""
+    ws = tmp_path / "ws"
+    (ws / "bins").mkdir(parents=True)
+    (ws / "bins" / "s.exe").write_bytes(b"MZ\x90\x00" + b"\x00" * 64)
+    monkeypatch.setenv(FLAG_NAME, "0")
+
+    mod = _load_init_module()
+    import toolchain as tc
+
+    def fake_check(ws_arg, project_type=None, **kw):
+        return tc.ToolchainReport(project_type=project_type or "windows",
+                                  items=[
+            tc.CheckResult(name="jvm", status=tc.Status.FAIL,
+                           tier=tc.Tier.WARN, detail="java not found"),
+        ])
+
+    monkeypatch.setattr(mod.toolchain, "check", fake_check)
+    seed_oracle_anchors(ws)
+    rc = mod.run(ws, project_type="windows",
+                 profile_root=tmp_path / "profile-root",
+                 answers={"host_exec_protection": "enabled"})
+    assert rc == 0, "a WARN-tier probe must not refuse init"
+    probes = ws / "evidence" / "tool-probes.json"
+    assert probes.exists(), "init must persist the probed results"
+    doc = json.loads(probes.read_text(encoding="utf-8"))
+    assert doc == {"jvm": False}, doc
 
 
 def test_library_refuse_returns_4_no_scaffold(tmp_path, monkeypatch):

--- a/tests/test_lane_routing_208.py
+++ b/tests/test_lane_routing_208.py
@@ -383,6 +383,53 @@ def test_malware_dispatch_is_unchanged_by_the_lane_gate(tmp_path):
     assert "corpora" not in [i.name for i in legacy.items]
 
 
+def test_unreadable_material_dir_degrades_to_warn_not_a_crash(tmp_path):
+    """Finding 3 repro (issue 225): an unreadable material dir made
+    iterdir() raise PermissionError straight out of toolchain.check (raw
+    traceback at the init call site). The probe degrades to WARN with a
+    readable detail, mirroring every other probe failure."""
+    import toolchain
+    if getattr(os, "geteuid", lambda: 1)() == 0:
+        pytest.skip("permission bits do not bind root")
+    ws = tmp_path / "ws"
+    (ws / "corpora").mkdir(parents=True)
+    (ws / "corpora" / "pair.txt").write_text("x", encoding="utf-8")
+    os.chmod(ws / "corpora", 0)
+    try:
+        report = toolchain.check(ws, "linux", lane="algorithm")
+        corpora = next(i for i in report.items if i.name == "corpora")
+        assert corpora.status == toolchain.Status.WARN, corpora
+        assert "unreadable" in corpora.detail.lower(), corpora.detail
+    finally:
+        os.chmod(ws / "corpora", 0o700)
+
+
+def test_invalid_lane_value_fails_closed_never_malware(tmp_path):
+    """Finding 4 repro (issue 225): an invalid lane value silently fell
+    through normalize()->None into the malware check set (17 malware items),
+    contradicting the fail-closed comment. It must fail closed with a
+    clear error instead — never a silent malware fallback."""
+    import toolchain
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    with pytest.raises(ValueError) as excinfo:
+        toolchain.check(ws, "linux", task_spec={"lane": "algorthm"})
+    assert "algorthm" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("spec", [{}, {"lane": None}, {"lane": ""}])
+def test_absent_lane_stays_the_legacy_malware_set(tmp_path, spec):
+    """Hard acceptance: an ABSENT lane (no key / null / blank) keeps the
+    per-type malware dispatch byte-for-byte — never a refusal."""
+    import toolchain
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    report = toolchain.check(ws, "windows", task_spec=spec)
+    names = [i.name for i in report.items]
+    assert "corpora" not in names
+    assert "decompiler" in names, f"{spec}: malware dispatch lost"
+
+
 def test_required_checks_has_no_malware_entry():
     """Single source: the malware lane is absent from the per-lane sets on
     purpose (it keeps the per-type CHECK_SETS dispatch)."""

--- a/tests/test_register_proven_gate.py
+++ b/tests/test_register_proven_gate.py
@@ -161,3 +161,35 @@ def test_ledger_row_alone_not_sufficient(tmp_path):
     _redteam(ws, "C-001", "CONFIRMED")
     res = check_register_transitions(ws, NEW, OLD)
     assert res["ok"] is False
+
+
+# ---------- issue 225: hyphenated scope spellings are the SAME keyword ------
+
+def test_hyphenated_scope_spellings_are_recognized():
+    """The keyword list shipped snake_case + prose spellings only, so a
+    hyphenated `key-schedule` / `state-machine` claim read as out of scope
+    and a triage-only algorithm claim was admitted at ->PROVEN. Separator
+    spelling must not change the scope verdict."""
+    import register_proven_gate as rpg
+    for spelling in ("key-schedule", "key schedule", "key_schedule",
+                     "key-expansion", "state-machine", "state machine",
+                     "state_machine", "algorithm-recovery",
+                     "algorithm recovery"):
+        scope = rpg.algorithm_scope(
+            {"statement": f"recover the {spelling} of the config blob"})
+        assert scope is not None, spelling
+
+
+def test_unrelated_statement_stays_out_of_scope():
+    import register_proven_gate as rpg
+    assert rpg.algorithm_scope(
+        {"statement": "the sample talks to a C2 over TLS"}) is None
+
+
+def test_hyphenated_claim_with_triage_fact_is_rejected():
+    import register_proven_gate as rpg
+    reason = rpg.evidence_class_violation(
+        "C-001", {"statement": "recover the key-schedule from the DEX"},
+        [{"evidence_class": "triage"}])
+    assert reason, "a hyphenated algorithm claim must not be admitted"
+    assert "algorithm-recovery" in reason

--- a/tests/test_route_capability_providers.py
+++ b/tests/test_route_capability_providers.py
@@ -132,6 +132,64 @@ def test_missing_probe_evidence_is_unverified_not_blocked(tmp_path):
     assert "jadx_bin" in jadx["unverified_reason"]
 
 
+# ---------- finding 7 (issue 225): init-written probes reach the router ----
+
+def test_writer_persisted_probes_block_a_probed_false_jvm(tmp_path):
+    """evidence/tool-probes.json had NO production writer, so the `jvm`
+    token could only ever be `unverified` and the advertised "probed-false
+    JVM BLOCKS the provider" could not fire. The writer persists the REAL
+    probe answers; a probed-false JVM then BLOCKS the jadx provider."""
+    import toolchain as tc
+
+    ws = _ws(tmp_path, mem_verdict="jadx-ok")        # no tool-probes.json
+    before = next(p for p in _select(ws)["providers"]
+                  if p["provider"] == "jadx")
+    assert before["status"] == "unverified"          # precondition: no evidence
+
+    report = tc.ToolchainReport(project_type="android", items=[
+        tc.CheckResult(name="jvm", status=tc.Status.FAIL, tier=tc.Tier.WARN,
+                       detail="java not found"),
+        tc.CheckResult(name="jadx", status=tc.Status.PASS, tier=tc.Tier.HARD,
+                       detail="found"),
+    ])
+    path = tc.persist_tool_probes(ws, report)
+    assert path == ws / "evidence" / "tool-probes.json"
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    assert doc == {"jadx_bin": True, "jvm": False}, doc
+
+    blocked = next(p for p in _select(ws)["providers"]
+                   if p["provider"] == "jadx")
+    assert blocked["status"] == "blocked", blocked
+    assert "jvm" in blocked["blocked_reason"], blocked
+
+
+def test_writer_persisted_probes_admit_a_probed_true_jvm(tmp_path):
+    import toolchain as tc
+
+    ws = _ws(tmp_path, mem_verdict="jadx-ok")
+    report = tc.ToolchainReport(project_type="android", items=[
+        tc.CheckResult(name="jvm", status=tc.Status.PASS, tier=tc.Tier.WARN,
+                       detail="java found"),
+        tc.CheckResult(name="jadx", status=tc.Status.PASS, tier=tc.Tier.HARD,
+                       detail="found"),
+    ])
+    tc.persist_tool_probes(ws, report)
+    jadx = next(p for p in _select(ws)["providers"] if p["provider"] == "jadx")
+    assert jadx["status"] == "available", jadx
+
+
+def test_writer_never_fabricates_a_token_the_report_did_not_probe(tmp_path):
+    """Only probed items are written — a lane/type whose report carries no
+    jvm item leaves the file absent (the token stays `unverified`, never a
+    guessed answer)."""
+    import toolchain as tc
+
+    ws = _ws(tmp_path)
+    report = tc.ToolchainReport(project_type="linux", items=[])
+    assert tc.persist_tool_probes(ws, report) is None
+    assert not (ws / "evidence" / "tool-probes.json").exists()
+
+
 def test_selection_never_runs_environment_probes(tmp_path):
     """load_workspace_state reads FILES only — no import/which side effects
     observable via monkeypatched importlib/shutil raising."""

--- a/tests/test_thompson_tui_face_218.py
+++ b/tests/test_thompson_tui_face_218.py
@@ -200,6 +200,40 @@ class TestRankEmitFailOpen:
         assert not marker.exists()
         assert sls.build_snapshot(ws)["rank_log"]["ok"] is True
 
+    def test_real_writer_failure_marks_and_never_erases_prior_evidence(
+            self, tmp_path):
+        """Finding 1 repro (issue 225): the ledger day-file path is a
+        DIRECTORY, so the REAL writer fails. emit() must report that failure
+        — the marker is SET (prior fault evidence survives) and rank_log is
+        ok:False; the ranking result stays byte-identical (fail-open)."""
+        ws = _make_ws(tmp_path)
+        baseline = _run_rank(ws)                  # clean run, marker absent
+        marker = ws / "runs" / ".rank-emit-fail.json"
+        assert not marker.exists()
+
+        # the reviewer's repro: the day file cannot be a file — make it a dir
+        day_file = kunglao_log.log_path(ws)
+        day_file.unlink()
+        day_file.mkdir()
+
+        # prior fault evidence: a failed attempt must not erase the marker
+        rank_face.write_fail_marker(ws, RuntimeError("earlier failure"))
+        crashed = _run_rank(ws)
+        assert [(a.claim_id, a.score) for a in crashed] == \
+            [(a.claim_id, a.score) for a in baseline], \
+            "the ranking result must stay untouched (fail-open)"
+        assert marker.exists(), \
+            "a real write failure must leave the marker (never clear it)"
+        snap = sls.build_snapshot(ws)
+        assert snap["rank_log"]["ok"] is False, snap["rank_log"]
+        assert snap["rank_log"]["error"], snap["rank_log"]
+
+        # a real success clears the marker again (last-attempt semantics)
+        day_file.rmdir()
+        _run_rank(ws)
+        assert not marker.exists()
+        assert sls.build_snapshot(ws)["rank_log"]["ok"] is True
+
     def test_marker_write_leaves_the_rank_feeds_payload_byte_identical(
             self, tmp_path, monkeypatch):
         """The emit payload is built BEFORE the crash face — the marker
@@ -221,6 +255,42 @@ class TestRankEmitFailOpen:
         _run_rank(ws)                                  # recorded + written
         assert len(captured) == 2
         assert captured[0] == captured[1]
+
+
+class TestTailReadBoundary:
+    """Finding 5 (issue 225): the bounded tail read drops a possibly-partial
+    FIRST line only when the window actually starts mid-file. A complete
+    first line in a day file smaller than the window must survive."""
+
+    def test_complete_first_line_survives_a_small_day_file(self, tmp_path):
+        ws = _make_ws(tmp_path)
+        _seed_rank_event(ws, ranked_order=("C-9",), scores={"C-9": 0.5})
+        # a second row keeps the file far below the 64KB window while the
+        # rank row no longer sits alone (the reviewer's repro shape)
+        log = kunglao_log.log_path(ws)
+        with log.open("a", encoding="utf-8") as f:
+            f.write(json.dumps({
+                "ts": _iso(datetime.now(timezone.utc)),
+                "actor": "hook", "action": "heartbeat"}) + "\n")
+        assert log.stat().st_size < rank_face.TAIL_BYTES
+        actions = [r.get("action") for r in rank_face._tail_rows(ws)]
+        assert actions == ["rank_feeds", "heartbeat"], actions
+        face = rank_face.latest_rank(ws)
+        assert face["claim"] == "C-9", face
+        assert face["stale"] is False, face
+
+    def test_partial_first_line_still_dropped_past_the_window(self, tmp_path):
+        """The drop rule survives for real: a window that starts mid-file
+        still discards its partial first line (no JSON garbage row)."""
+        ws = _make_ws(tmp_path)
+        log = kunglao_log.log_path(ws)
+        log.parent.mkdir(parents=True, exist_ok=True)
+        with log.open("w", encoding="utf-8") as f:
+            f.write("x" * (rank_face.TAIL_BYTES + 10_000) + "\n")
+        _seed_rank_event(ws, ranked_order=("C-9",), scores={"C-9": 0.5})
+        assert log.stat().st_size > rank_face.TAIL_BYTES
+        face = rank_face.latest_rank(ws)
+        assert face["claim"] == "C-9", face
 
 
 # ===========================================================================
@@ -353,6 +423,31 @@ class TestRankRenderer:
         assert out.strip(), "the line still renders"
         assert "R:" not in out
         assert "R✖" not in out
+
+    @pytest.mark.parametrize("score_present,score", [
+        (True, None),          # producer's null score (JSON null)
+        (False, None),         # key absent entirely
+        (True, "not-a-number"),
+    ])
+    def test_missing_score_hides_the_chip_never_a_fabricated_zero(
+            self, tmp_path, score_present, score):
+        """Finding 6 (issue 225): `Number(null) === 0` rendered a fabricated
+        `R:C-2 0.00`. A null/undefined/unusable score hides the chip (the
+        absent face), it never invents a value."""
+        ws = _make_ws(tmp_path)
+        rank = {"claim": "C-2", "ts": _iso(datetime.now(timezone.utc)),
+                "age_s": 3.0, "stale": False}
+        if score_present:
+            rank["score"] = score
+        _write_snapshot(ws, _snap(rank=rank,
+                                  rank_log={"ok": True, "error": None,
+                                            "ts": None}))
+        r = _run_renderer(ws)
+        assert r.returncode == 0, r.stderr
+        out = ANSI_RE.sub("", r.stdout)
+        assert "0.00" not in out, out
+        assert "R:" not in out, out
+        assert "R✖" not in out, out
 
 
 def color_prefix(stdout: str, idx: int, window: int = 20) -> str:


### PR DESCRIPTION
Fixes #225

## Summary

Closes the 10 reproduced defects from the adversarial review of the v0.1.5-Patch1 train (dev `4e3463f..5d155ec`), one RED-first test per finding: the reviewer's repro fails before the fix and passes after. No assertion weakening, no silencing, no new deps, no version bump.

## Per-finding disposition

| # | Finding | Fix | Test |
|---|---------|-----|------|
| 1 | HIGH: `priority_ratio._emit_rank_feeds` cleared the emit-fail marker even when the real writer failed (`kunglao_log.emit` swallowed the write error and returned normally) | `kunglao_log.emit` now returns `True`/`False` (additive — no caller consumed the return, verified repo-wide); `_emit_rank_feeds` sets the marker (`EmitWriteError`) on `False` and clears it only on a real success; `rank_face.write_fail_marker` also accepts a label for a failure with no exception object | `tests/test_thompson_tui_face_218.py::TestRankEmitFailOpen::test_real_writer_failure_marks_and_never_erases_prior_evidence` (day-file path is a DIRECTORY) |
| 2 | HIGH: `decision_lint` matched the package token literally and case-sensitively (`pip install IDAPRO` → OK) | case- and separator-folded package identity: IDAPRO / ida-pro / ida_pro / `./idapro-9.0.whl` all match; near-miss names (`idaproduction`) stay OK | `tests/test_decision_lint_213.py::test_package_token_match_is_case_and_separator_folded`, `::test_cli_blocks_the_uppercase_spelling`, `::test_near_miss_package_name_does_not_block` |
| 3 | MED: `toolchain._check_lane_material` unguarded `iterdir()` → `PermissionError` escaped `check()` as a raw traceback | unreadable material dir degrades to WARN with the OSError class + `strerror` (mirrors every other probe degradation) | `tests/test_lane_routing_208.py::test_unreadable_material_dir_degrades_to_warn_not_a_crash` |
| 4 | MED: an INVALID `lane:` value fell through `normalize()`→None into the malware check set | a present-but-invalid lane now raises `ValueError` (clear error, fail closed); ABSENT/null/blank lane keeps the legacy malware dispatch (pinned) | `tests/test_lane_routing_208.py::test_invalid_lane_value_fails_closed_never_malware`, `::test_absent_lane_stays_the_legacy_malware_set` |
| 5 | MED: `rank_face._tail_rows` dropped a COMPLETE first line when the day file is smaller than `TAIL_BYTES` | the possibly-partial first line is dropped only when the read window actually started mid-file (`start > 0`) | `tests/test_thompson_tui_face_218.py::TestTailReadBoundary` (small file preserved; >64KB window still drops the partial line) |
| 6 | MED: `statusline_render.mjs` rendered a fabricated `R:C-2 0.00` from a null score (`Number(null) === 0`) | a null/undefined/unusable score hides the chip (the absent face) instead of inventing a value | `tests/test_thompson_tui_face_218.py::TestRankRenderer::test_missing_score_hides_the_chip_never_a_fabricated_zero` (node renderer, 3 shapes) |
| 7 | MED: the `jvm` precondition read `evidence/tool-probes.json`, which had NO production writer | `toolchain.persist_tool_probes` writes the file from the real probe report (status PASS → true, else false; unprobed tokens are never fabricated); init calls it right after the toolchain check | `tests/test_route_capability_providers.py::test_writer_persisted_probes_block_a_probed_false_jvm` (+ true/never-fabricate), `tests/test_init_toolchain_gate.py::test_init_persists_tool_probes_evidence` (in-process init) |
| 8 | MED: `register_proven_gate` scope keywords missed hyphenated spellings (`key-schedule` / `state-machine`) | separators (`_` / `-` / space) folded on both sides before matching, so both spellings identify an algorithm-recovery claim | `tests/test_register_proven_gate.py::test_hyphenated_scope_spellings_are_recognized`, `::test_hyphenated_claim_with_triage_fact_is_rejected` |
| 9 | MED: `_judge_arch` blocked on unknown aliases (`x64` vs `amd64`); non-UTF-8 stdin → `UnicodeDecodeError` → exit 1 (BLOCKED semantics); `pip uninstall idapro` blocked as an install | alias table (x64/amd64/x86-64 ≡ x86_64; aarch64 ≡ arm64); unknown aliases degrade to a note; undecodable stdin reads as no facts → OK-with-note; only INSTALL actions are judged (removal verbs never) | `tests/test_decision_lint_213.py::test_arch_aliases_normalize_before_judging`, `::test_unknown_arch_alias_never_grounds_a_block`, `::test_uninstall_is_not_judged_as_an_install`, `::test_undecodable_stdin_is_ok_with_note_never_blocked_by_crash` |
| 10 | MED: the env probe's `uv run` (no `--locked`) relocked the project and passed drift that `uv sync --locked` rejects | probe argv is now `uv run --locked --project <skill_root> python -c "import yaml"` — the env still syncs from the lock; the lock is never mutated by a probe | `tests/test_env_check.py::test_venv_probe_pins_the_lock_so_a_probe_never_relocks` (+ the existing argv pin updated) |

## Live field evidence

**#1 — the reviewer's log-as-directory repro** (real modules, tmp workspace):

```
after clean run: marker exists = False
reviewer repro (day-file is a DIRECTORY):
  marker exists = True
  marker        = {"ts": "2026-09-10T19:23:18Z", "error": "EmitWriteError"}
  rank_log      = {"ok": false, "error": "EmitWriteError", "ts": "2026-09-10T19:23:18Z"}
after next success: marker exists = False | rank_log = {"ok": true, "error": null, "ts": null}
```

**#4 — invalid vs absent lane** (`toolchain.check`, live):

```
== invalid lane ('algorthm') ==
ValueError: lane 'algorthm' is not a lane; lane must be one of malware | algorithm | protocol | web | data | app (or absent: a lane-less contract keeps the malware lane's current behavior)
== absent lane (task_spec without the key) ==
items: ['file', 'readelf', 'objdump', 'uv', 'decompiler', 'vm_reachable', 'remote_debugger', 'docker', 'mcp:ghidra', 'mcp:sequential-thinking', 'mcp:ida-pro-vm', 'mcp:ssh-mcp', 'mcp:virustotal', 'gdbserver', 'ebpf', 'strace', 'ltrace']
overall: FAIL
```

**#7 — real probe → writer → router** (live on this host; `java -version` really ran):

```
REAL probe on this host: jvm = PASS | java found at /usr/local/opt/openjdk@17/bin/java — openjdk version "17.0.19"
                        jadx = PASS
router token BEFORE writer: ('unverified', 'jvm: no tool-probes evidence')
writer path: <tmp>/ws/evidence/tool-probes.json
file: {   "jadx_bin": true,   "jvm": true }
router token AFTER  writer: ('ok', None)
  provider jadx -> unverified mem_budget_ok: ... (no apk_mem_gate verdict in the bare tmp ws)

probed-false JVM (the advertised block):
probed-false jvm token: ('blocked', 'jvm: probe failed')
jadx provider status: blocked | jvm: jvm: probe failed
recommendation: dexdc-decompile
```

**#10 — lock sha across a real probe run**:

```
lock sha BEFORE: 3022a912dc8c94e0d4c37eeee1e2ad10332ce73e539de1af6cf25ad2698a6d39
SKILL_DIR = /Users/mikenike/workprojects/kunglao-wt-225
probe rc ok = True | detail = uv env OK (yaml)
lock sha AFTER:  3022a912dc8c94e0d4c37eeee1e2ad10332ce73e539de1af6cf25ad2698a6d39
```

## Impact blast radius (GitNexus, index at base 5d155ec)

- `kunglao_log.emit` — **CRITICAL**: 264 impacted (88 direct callers, 24 execution flows, 3 modules). The change is additive: `emit` returns `True`/`False` where it returned `None`; a repo-wide grep shows no caller consumes the return value, so the fail-open emit contract is unchanged.
- `priority_ratio._emit_rank_feeds` — **HIGH**: 27 impacted (1 direct, 4 processes).
- `toolchain.check` — **MEDIUM**: 22 impacted (6 direct, 2 processes).
- `env_check.check_venv_sample` — **LOW**: 4 impacted (1 direct).
- Symbols newer than the index (`rank_face.write_fail_marker` / `_tail_rows`, `toolchain.persist_tool_probes`, `decision_lint` internals, `register_proven_gate.algorithm_scope`) are not in the base index; the newly added writer is called only from `kunglao-init.run` and the new tests.
- `detect-changes (compare vs dev)`: 18 files / 24 symbols / 34 affected execution flows (index-staleness warning noted; the symbol list includes line-shift artifacts from the stale index).

## Gates

- `ruff check scripts/ tests/` — 6 errors, byte-identical to the base set (all pre-existing, none in touched regions).
- `nice -n 19 uv run --locked pytest -n 2 <21 targeted modules>` — **516 passed** (includes every touched surface + comment-hygiene + statusline suites).
- `python3 scripts/deploy_manifest.py --write && --verify` — 396 entries verified.
- `python3 scripts/comment_hygiene_lint.py` — clean (662 files, 4058 flagged units; ratchet not grown).
- Known pre-existing, environment-only red: `tests/test_env_check.py::test_all_pass_exit_0` under the system Python 3.14 (the pinned interpreter is 3.11; the row is an advisory WARN) — reproduced on the base tree before any change; green under `uv run`.

## Notes

- `priority_ratio.py`: marker/emit-health only — the ranking math and the `rank_feeds` payload are byte-identical (pinned by the existing payload test).
- No `(#NNN)`-shaped code comments added; comment-hygiene ratchet stayed clean.
