### PR TITLE
fix: darwin memory probe — apk_mem_gate measures real available memory on macOS (#223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,18 @@ release (see the mapping table at the end).
   `evidence/tool-probes.json`, so a probed-false JVM blocks the jadx
   provider as advertised; the env probe runs `uv run --locked`, which
   keeps the lock sha unchanged across a probe run (#225).
+- **darwin memory probe measures real availability (#223)**: the APK
+  memory gate called `os.sysconf("SC_AVPHYS_PAGES")` — a Linux-only key
+  (`ValueError: unrecognized configuration name` on macOS) — so every Mac
+  silently took the 4 GB floor and jadx was blocked for every APK behind a
+  constant 2.6 GB budget. The avail probe now dispatches per platform
+  (windows: GlobalMemoryStatusEx, linux: sysconf — both unchanged; darwin:
+  Mach `host_statistics64` VM counters via ctypes, no subprocess) and the
+  budget is `0.65 x measured avail` again; a failed probe still floors but
+  is no longer silent — the verdict carries
+  `avail_probe: "ok" | "floor-fallback"`, the reason names the failure,
+  and the marker rides the tool's stdout line into the issue 215 env fact
+  so a dead probe never reads as a genuinely-4GB host.
 
 ## [0.1.3] - 2026-08-25
 

--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -1475,7 +1475,7 @@ files:
   - src: tools/static/apk_mem_gate.py
     dest: .claude/tools/static/apk_mem_gate.py
     kind: asset
-    sha256: eea84b5bd458e0c12363ce351d1d8ca78dfc9979733502098619c936b3e94914
+    sha256: 3860a0b3bcc820342485d714f284643a328818c9f7dc16560ab69eef5f08e0d4
   - src: tools/static/baksmali_index.py
     dest: .claude/tools/static/baksmali_index.py
     kind: asset

--- a/deploy-manifest.yaml
+++ b/deploy-manifest.yaml
@@ -1475,7 +1475,7 @@ files:
   - src: tools/static/apk_mem_gate.py
     dest: .claude/tools/static/apk_mem_gate.py
     kind: asset
-    sha256: 3e3001a298646a2524830e3fece41660775b566a5434053e6b32d0877bfea609
+    sha256: eea84b5bd458e0c12363ce351d1d8ca78dfc9979733502098619c936b3e94914
   - src: tools/static/baksmali_index.py
     dest: .claude/tools/static/baksmali_index.py
     kind: asset

--- a/tests/test_apk_mem_gate.py
+++ b/tests/test_apk_mem_gate.py
@@ -11,18 +11,31 @@ Spec: openspec/changes/issue-670-mem-gated-jadx/specs/mem-gated-jadx/spec.md
 from __future__ import annotations
 
 import json
+import os
 import sys
 import zipfile
 from pathlib import Path
+
+import pytest
 
 
 _HERE = Path(__file__).parent
 sys.path.insert(0, str(_HERE.parent / "tools" / "static"))
 
 
+GB = 1024 ** 3
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _raises(exc: Exception):
+    """A zero-arg callable that raises `exc` (a dead platform probe)."""
+    def _boom():
+        raise exc
+    return _boom
+
 
 def _make_apk(tmp_path: Path, dex_files: dict) -> Path:
     """Create a synthetic APK with the named dex files + given sizes."""
@@ -49,7 +62,8 @@ def test_red1_small_apk_jadx_ok(tmp_path, monkeypatch):
     """1MB dex + 9.5GB avail -> est=4GB (floor), budget=6.175GB,
     budget >= 1.5*est (6.175 >= 6) -> jadx-ok."""
     from apk_mem_gate import run
-    monkeypatch.setattr("apk_mem_gate._avail_gb", lambda: 9.5)
+    monkeypatch.setattr("apk_mem_gate._avail_probe",
+                        lambda: (9.5, "ok", ""))
     apk = _make_apk(tmp_path, {"classes.dex": b"\x00" * (1 * 1024 * 1024)})
     rc = run(tmp_path, str(apk))
     assert rc == 0
@@ -65,7 +79,8 @@ def test_red2_large_apk_smalionly(tmp_path, monkeypatch):
     """50MB dex + 1GB avail -> est = max(4, 50*50M/1G) = 4GB (floor).
     budget = 0.65 * 1 = 0.65GB. budget (0.65) < est (4) -> smali-only."""
     from apk_mem_gate import run
-    monkeypatch.setattr("apk_mem_gate._avail_gb", lambda: 1.0)
+    monkeypatch.setattr("apk_mem_gate._avail_probe",
+                        lambda: (1.0, "ok", ""))
     apk = _make_apk(tmp_path, {"classes.dex": b"\x00" * (50 * 1024 * 1024)})
     rc = run(tmp_path, str(apk))
     assert rc == 0
@@ -82,7 +97,8 @@ def test_red3_medium_apk_targeted_jadx(tmp_path, monkeypatch):
     budget = 0.65 * 7.5 = 4.875GB. est <= budget (4.5 <= 4.875) AND
     budget < 1.5*est (4.875 < 6.75) -> targeted-jadx."""
     from apk_mem_gate import run
-    monkeypatch.setattr("apk_mem_gate._avail_gb", lambda: 7.5)
+    monkeypatch.setattr("apk_mem_gate._avail_probe",
+                        lambda: (7.5, "ok", ""))
     apk = _make_apk(tmp_path, {"classes.dex": b"\x00" * (90 * 1024 * 1024)})
     rc = run(tmp_path, str(apk))
     data = json.loads((tmp_path / "evidence" / "apk_mem_gate.json").read_text())
@@ -96,7 +112,8 @@ def test_red3_medium_apk_targeted_jadx(tmp_path, monkeypatch):
 def test_red4_jar_always_refuse(tmp_path, monkeypatch):
     """JAR target -> refuse with explicit reason, even with 100GB avail."""
     from apk_mem_gate import run
-    monkeypatch.setattr("apk_mem_gate._avail_gb", lambda: 100.0)
+    monkeypatch.setattr("apk_mem_gate._avail_probe",
+                        lambda: (100.0, "ok", ""))
     jar = _make_jar(tmp_path, 1024)
     rc = run(tmp_path, str(jar))
     data = json.loads((tmp_path / "evidence" / "apk_mem_gate.json").read_text())
@@ -113,7 +130,8 @@ def test_red5_dex_bytes_total_sums_dex_sizes(tmp_path, monkeypatch):
     """dex_bytes_total must be sum of uncompressed dex sizes inside the APK,
     not the .apk file size (which includes zip overhead + non-dex entries)."""
     from apk_mem_gate import run
-    monkeypatch.setattr("apk_mem_gate._avail_gb", lambda: 100.0)
+    monkeypatch.setattr("apk_mem_gate._avail_probe",
+                        lambda: (100.0, "ok", ""))
     apk = _make_apk(tmp_path, {
         "classes.dex": b"\x00" * (1 * 1024 * 1024),
         "classes2.dex": b"\x00" * (2 * 1024 * 1024),
@@ -150,7 +168,8 @@ def test_red6_avail_gb_fallback(tmp_path, monkeypatch):
 def test_red7_calibration_basis_always_present(tmp_path, monkeypatch):
     """calibration_basis MUST be non-empty in every verdict path."""
     from apk_mem_gate import run
-    monkeypatch.setattr("apk_mem_gate._avail_gb", lambda: 8.0)
+    monkeypatch.setattr("apk_mem_gate._avail_probe",
+                        lambda: (8.0, "ok", ""))
     apk = _make_apk(tmp_path, {"classes.dex": b"\x00" * (1024)})
     run(tmp_path, str(apk))
     data = json.loads((tmp_path / "evidence" / "apk_mem_gate.json").read_text())
@@ -165,7 +184,8 @@ def test_red7_calibration_basis_always_present(tmp_path, monkeypatch):
 def test_red8_evidence_written_on_refuse(tmp_path, monkeypatch):
     """REFUSE verdict MUST still write evidence/apk_mem_gate.json."""
     from apk_mem_gate import run
-    monkeypatch.setattr("apk_mem_gate._avail_gb", lambda: 100.0)
+    monkeypatch.setattr("apk_mem_gate._avail_probe",
+                        lambda: (100.0, "ok", ""))
     jar = _make_jar(tmp_path)
     run(tmp_path, str(jar))
     assert (tmp_path / "evidence" / "apk_mem_gate.json").exists()
@@ -180,10 +200,129 @@ def test_red8_evidence_written_on_refuse(tmp_path, monkeypatch):
 def test_red8b_operator_override_jadx(tmp_path, monkeypatch):
     """apk_mem_override=jadx forces jadx-ok regardless of memory math."""
     from apk_mem_gate import run
-    monkeypatch.setattr("apk_mem_gate._avail_gb", lambda: 0.1)
+    monkeypatch.setattr("apk_mem_gate._avail_probe",
+                        lambda: (0.1, "ok", ""))
     (tmp_path / "analysis_state.txt").write_text("apk_mem_override=jadx\n")
     apk = _make_apk(tmp_path, {"classes.dex": b"\x00" * (1024 * 1024)})
     run(tmp_path, str(apk))
     data = json.loads((tmp_path / "evidence" / "apk_mem_gate.json").read_text())
     assert data["verdict"] == "jadx-ok"
     assert "override" in data["calibration_basis"].lower()
+
+
+# ---------------------------------------------------------------------------
+# RED9 - darwin probe (issue 223): SC_AVPHYS_PAGES is a Linux-only key
+# ---------------------------------------------------------------------------
+#
+# Field pathology (owner macOS host): `_mem_posix` raised
+# `ValueError: unrecognized configuration name` on darwin, `_avail_gb`
+# swallowed it and returned the 4 GB floor -> budget = 0.65 x 4 = 2.6 GB,
+# a constant below every est -> jadx blocked for every APK on every Mac.
+# On darwin the probe reads the Mach VM counters instead.
+
+def test_darwin_dispatch_measures_not_the_sysconf_floor(monkeypatch):
+    """Review scenario: platform=darwin + the Linux-only sysconf key
+    unavailable -> MEASURE through the Mach counters, never the floor."""
+    import apk_mem_gate as g
+    page = os.sysconf("SC_PAGESIZE")
+    with monkeypatch.context() as mp:
+        mp.setattr(sys, "platform", "darwin")
+        mp.setattr(g, "_mem_posix",
+                   _raises(ValueError("unrecognized configuration name")))
+        mp.setattr(g, "_darwin_vm_page_counts", lambda: (1000, 2000, 3000),
+                   raising=False)
+        assert g._avail_gb() == (6000 * page) / GB, \
+            "darwin must measure, not floor"
+        assert g._avail_gb() != g.DEFAULTS["apk_mem_floor_gb"]
+        assert g._avail_probe() == ((6000 * page) / GB, "ok", "")
+
+
+def test_mem_darwin_sums_free_inactive_speculative_pages(monkeypatch):
+    """available = (free + inactive + speculative) pages x page size."""
+    import apk_mem_gate as g
+    page = os.sysconf("SC_PAGESIZE")
+    monkeypatch.setattr(g, "_darwin_vm_page_counts", lambda: (11, 22, 33))
+    assert g._mem_darwin() == float((11 + 22 + 33) * page)
+
+
+def test_linux_probe_path_unchanged(monkeypatch):
+    """Non-darwin dispatch still runs the sysconf probe, unmodified."""
+    import apk_mem_gate as g
+    with monkeypatch.context() as mp:
+        mp.setattr(sys, "platform", "linux")
+        mp.setattr(g, "_mem_posix", lambda: 8 * GB)
+        mp.setattr(g, "_mem_darwin",
+                   _raises(AssertionError("darwin probe ran on linux")),
+                   raising=False)
+        assert g._avail_gb() == 8.0
+        assert g._avail_probe() == (8.0, "ok", "")
+
+
+def test_windows_probe_path_unchanged(monkeypatch):
+    """Windows dispatch still runs GlobalMemoryStatusEx, unmodified."""
+    import apk_mem_gate as g
+    with monkeypatch.context() as mp:
+        mp.setattr(sys, "platform", "win32")
+        mp.setattr(g, "_mem_windows", lambda: 16 * GB)
+        mp.setattr(g, "_mem_posix",
+                   _raises(AssertionError("posix probe ran on windows")))
+        assert g._avail_gb() == 16.0
+        assert g._avail_probe() == (16.0, "ok", "")
+
+
+def test_probe_failure_floors_but_is_marked_in_the_verdict(
+        tmp_path, monkeypatch):
+    """A dead probe stays fail-safe AND visible: the floor plus a marker
+    that distinguishes it from a genuinely-4GB host."""
+    import apk_mem_gate as g
+    from apk_mem_gate import run
+    monkeypatch.setattr(g, "_probe_avail_bytes",
+                        _raises(OSError("no Mach counters")))
+    apk = _make_apk(tmp_path, {"classes.dex": b"\x00" * (1024 * 1024)})
+    run(tmp_path, str(apk))
+
+    assert g._avail_gb() == g.DEFAULTS["apk_mem_floor_gb"]
+    data = json.loads((tmp_path / "evidence" / "apk_mem_gate.json").read_text())
+    assert data["avail_gb"] == 4.0
+    assert data["avail_probe"] == "floor-fallback", data
+    assert "avail_probe: floor-fallback" in data["reason"], data
+    assert "no Mach counters" in data["reason"], data
+
+
+def test_measured_probe_leaves_no_fallback_note(tmp_path, monkeypatch):
+    """The marker is failure-only: a measured host keeps reason clean."""
+    import apk_mem_gate as g
+    from apk_mem_gate import run
+    monkeypatch.setattr(g, "_avail_probe", lambda: (9.5, "ok", ""))
+    apk = _make_apk(tmp_path, {"classes.dex": b"\x00" * (1024 * 1024)})
+    run(tmp_path, str(apk))
+    data = json.loads((tmp_path / "evidence" / "apk_mem_gate.json").read_text())
+    assert data["avail_probe"] == "ok", data
+    assert data["reason"] == "", data
+
+
+def test_cli_stdout_carries_the_marker_for_the_env_fact(
+        tmp_path, monkeypatch, capsys):
+    """The issue 215 recorder mirrors the ONE stdout line into env-facts:
+    the fallback marker must travel on it (avail_probe + reason), not die
+    at the tool boundary."""
+    import apk_mem_gate as g
+    monkeypatch.setattr(g, "_probe_avail_bytes", _raises(OSError("probe dead")))
+    apk = _make_apk(tmp_path, {"classes.dex": b"\x00" * (1024 * 1024)})
+    assert g.main([str(tmp_path), str(apk)]) == 0
+    out = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert out["verdict"] == "smali-only", out
+    assert out["avail_probe"] == "floor-fallback", out
+    assert "avail_probe: floor-fallback" in out["reason"], out
+
+
+@pytest.mark.skipif(sys.platform != "darwin",
+                    reason="Mach host_statistics64 is darwin-only")
+def test_darwin_probe_live_measures_real_memory():
+    """Field acceptance on a real Mac: the probe reports a measured value
+    (status ok) that is not the 4 GB floor constant."""
+    import apk_mem_gate as g
+    avail, probe, detail = g._avail_probe()
+    assert probe == "ok", detail
+    assert avail > 0, avail
+    assert avail != g.DEFAULTS["apk_mem_floor_gb"], avail

--- a/tests/test_apk_mem_gate.py
+++ b/tests/test_apk_mem_gate.py
@@ -150,15 +150,17 @@ def test_red5_dex_bytes_total_sums_dex_sizes(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 def test_red6_avail_gb_fallback(tmp_path, monkeypatch):
-    """When the stdlib mem detection raises (e.g., ctypes on locked-down env),
-    _avail_gb must return a positive fallback (4 GB) rather than 0."""
-    from apk_mem_gate import _avail_gb
-    monkeypatch.setattr("apk_mem_gate._mem_posix",
-                        lambda: (_ for _ in ()).throw(OSError("locked")))
-    monkeypatch.setattr("apk_mem_gate._mem_windows",
-                        lambda: (_ for _ in ()).throw(OSError("locked")))
-    val = _avail_gb()
-    assert val > 0, f"avail_gb must be > 0 even on detection failure, got {val}"
+    """When the platform mem detection raises (e.g., ctypes on a locked-down
+    env), _avail_gb must return the 4 GB floor rather than 0 — on EVERY
+    platform, darwin included (the dead probe issue 223 fixed) — and the
+    fallback must be marked as such."""
+    import apk_mem_gate as g
+    for probe in ("_mem_posix", "_mem_windows", "_mem_darwin"):
+        monkeypatch.setattr(f"apk_mem_gate.{probe}", _raises(OSError("locked")))
+    val = g._avail_gb()
+    assert val == g.DEFAULTS["apk_mem_floor_gb"], val
+    assert g._avail_probe() == (g.DEFAULTS["apk_mem_floor_gb"],
+                                "floor-fallback", "OSError: locked")
 
 
 # ---------------------------------------------------------------------------

--- a/tools/static/apk_mem_gate.py
+++ b/tools/static/apk_mem_gate.py
@@ -13,6 +13,11 @@ Calibration (single data point, declared in output per #54 numeric-fidelity):
   est = max(apk_mem_floor_gb, apk_mem_dex_factor * dex_bytes_total)
   budget = apk_mem_budget_ratio * avail_gb
 
+avail_gb comes from a platform probe (win: GlobalMemoryStatusEx; darwin:
+Mach host_statistics64; else: sysconf SC_AVPHYS_PAGES). A probe failure
+keeps the floor, and `avail_probe` records that it happened so a dead
+probe is never read as a genuinely-4GB host (issue 223).
+
 Fail-open: every error path writes evidence/apk_mem_gate.json with reason;
 never raises. Operators can audit / retry with apk_mem_override.
 
@@ -61,7 +66,16 @@ CALIBRATION_BASIS = (
     "refine with more samples"
 )
 
+# Available-memory probe provenance (issue 223): recorded in the verdict as
+# `avail_probe`, and echoed into the reason when the floor fallback is in
+# force, so a dead probe is distinguishable from a genuinely-4GB host.
+AVAIL_PROBE_OK = "ok"
+AVAIL_PROBE_FLOOR_FALLBACK = "floor-fallback"
+PROBE_DETAIL_MAX = 200
 
+# Mach host_statistics64(HOST_VM_INFO64) constants for the darwin probe.
+_HOST_VM_INFO64 = 4
+_KERN_SUCCESS = 0
 
 
 def _mem_windows() -> float:
@@ -86,8 +100,83 @@ def _mem_windows() -> float:
     raise OSError("GlobalMemoryStatusEx failed")
 
 
+def _darwin_vm_page_counts() -> tuple[int, int, int]:
+    """(free, inactive, speculative) VM page counts via Mach host_statistics64.
+
+    `SC_AVPHYS_PAGES` is a Linux-only sysconf key — darwin raises
+    `ValueError: unrecognized configuration name` — so macOS reads the Mach
+    VM statistics instead (the source vm_stat / Activity Monitor use).
+    """
+    import ctypes
+
+    class VmStatistics64(ctypes.Structure):
+        # vm_statistics64_data_t (xnu vm_statistics.h), declaration order.
+        _fields_ = [
+            ("free_count", ctypes.c_uint32),
+            ("active_count", ctypes.c_uint32),
+            ("inactive_count", ctypes.c_uint32),
+            ("wire_count", ctypes.c_uint32),
+            ("zero_fill_count", ctypes.c_uint64),
+            ("reactivations", ctypes.c_uint64),
+            ("pageins", ctypes.c_uint64),
+            ("pageouts", ctypes.c_uint64),
+            ("faults", ctypes.c_uint64),
+            ("cow_faults", ctypes.c_uint64),
+            ("lookups", ctypes.c_uint64),
+            ("hits", ctypes.c_uint64),
+            ("purges", ctypes.c_uint64),
+            ("purgeable_count", ctypes.c_uint32),
+            ("speculative_count", ctypes.c_uint32),
+            ("decompressions", ctypes.c_uint64),
+            ("compressions", ctypes.c_uint64),
+            ("swapins", ctypes.c_uint64),
+            ("swapouts", ctypes.c_uint64),
+            ("compressor_page_count", ctypes.c_uint32),
+            ("throttled_count", ctypes.c_uint32),
+            ("external_page_count", ctypes.c_uint32),
+            ("internal_page_count", ctypes.c_uint32),
+            ("total_uncompressed_pages_in_compressor", ctypes.c_uint64),
+        ]
+
+    # dlopen(NULL): libSystem is already linked into this process — no
+    # subprocess, no dylib path guessing.
+    libsystem = ctypes.CDLL(None, use_errno=True)
+    libsystem.mach_host_self.restype = ctypes.c_uint32
+    libsystem.host_statistics64.restype = ctypes.c_int
+    libsystem.host_statistics64.argtypes = [
+        ctypes.c_uint32, ctypes.c_int, ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_uint32),
+    ]
+    stats = VmStatistics64()
+    count = ctypes.c_uint32(ctypes.sizeof(stats))
+    kern_return = libsystem.host_statistics64(
+        libsystem.mach_host_self(), _HOST_VM_INFO64,
+        ctypes.byref(stats), ctypes.byref(count))
+    if kern_return != _KERN_SUCCESS:
+        raise OSError(f"host_statistics64 failed (kern_return {kern_return})")
+    return (int(stats.free_count), int(stats.inactive_count),
+            int(stats.speculative_count))
+
+
+def _mem_darwin() -> float:
+    """Avail physical memory on macOS in bytes (Mach VM counters).
+
+    available ~= (free + inactive + speculative) pages x page size — the
+    reclaimable pool Activity Monitor-style tooling reports. xnu counts
+    speculative pages inside free_count, so the third term re-includes a
+    pool already in the free list (bounded by the speculative pool, well
+    under 1% in the field); it is kept because this sum is the
+    availability definition this gate documents (issue 223).
+    """
+    free, inactive, speculative = _darwin_vm_page_counts()
+    page_size = int(os.sysconf("SC_PAGESIZE"))
+    if page_size <= 0:
+        raise OSError(f"sysconf returned non-positive (pagesize={page_size})")
+    return float((free + inactive + speculative) * page_size)
+
+
 def _mem_posix() -> float:
-    """Avail physical memory on POSIX in bytes (sysconf)."""
+    """Avail physical memory on POSIX (non-darwin) in bytes (sysconf)."""
     pagesize = os.sysconf("SC_PAGESIZE")
     avail_pages = os.sysconf("SC_AVPHYS_PAGES")
     if pagesize <= 0 or avail_pages <= 0:
@@ -95,14 +184,47 @@ def _mem_posix() -> float:
     return float(pagesize * avail_pages)
 
 
-def _avail_gb() -> float:
-    """Total avail physical memory in GB. Falls back to 4 GB on failure."""
+def _probe_avail_bytes() -> float:
+    """Platform dispatch: available physical memory in bytes (raises on
+    failure, so the caller decides between the floor fallback and the
+    provenance marker)."""
+    if sys.platform.startswith("win"):
+        return _mem_windows()
+    if sys.platform == "darwin":
+        return _mem_darwin()
+    return _mem_posix()
+
+
+def _avail_probe() -> tuple[float, str, str]:
+    """(avail_gb, avail_probe, detail) — one measurement, plus provenance.
+
+    `avail_probe` is "ok" when the platform probe measured real memory, or
+    "floor-fallback" when it failed and the floor constant is in force —
+    fail-safe, but never silent.
+    """
     try:
-        if sys.platform.startswith("win"):
-            return _mem_windows() / GB
-        return _mem_posix() / GB
-    except Exception:  # noqa: BLE001 - detection is best-effort
-        return DEFAULTS["apk_mem_floor_gb"]
+        return _probe_avail_bytes() / GB, AVAIL_PROBE_OK, ""
+    except Exception as exc:  # noqa: BLE001 - detection is best-effort
+        detail = f"{type(exc).__name__}: {exc}"[:PROBE_DETAIL_MAX]
+        return (DEFAULTS["apk_mem_floor_gb"], AVAIL_PROBE_FLOOR_FALLBACK,
+                detail)
+
+
+def _avail_gb() -> float:
+    """Total avail physical memory in GB. Falls back to the floor on
+    failure; `_avail_probe` carries the same reading with its provenance."""
+    return _avail_probe()[0]
+
+
+def _probe_note(reason: str, avail_probe: str, detail: str) -> str:
+    """Append the provenance note to the verdict reason when the floor
+    fallback is in force (no-op for a measured reading)."""
+    if avail_probe == AVAIL_PROBE_OK:
+        return reason
+    note = f"avail_probe: {avail_probe}"
+    if detail:
+        note += f" ({detail})"
+    return f"{reason} | {note}" if reason else note
 
 
 def _read_overrides(workspace: Path) -> dict[str, str]:
@@ -162,7 +284,9 @@ def _verdict(est_gb: float, budget_gb: float, target_ext: str,
 
 
 def _evaluate(target_path: Path, params: dict[str, Any],
-              override: str | None, avail_gb: float) -> dict[str, Any]:
+              override: str | None, avail_gb: float,
+              avail_probe: str = AVAIL_PROBE_OK,
+              probe_detail: str = "") -> dict[str, Any]:
     """Build the evidence dict (no I/O)."""
     target_ext = target_path.suffix.lower()
     apk_size = target_path.stat().st_size if target_path.exists() else 0
@@ -175,6 +299,7 @@ def _evaluate(target_path: Path, params: dict[str, Any],
     est_gb = max(params["floor_gb"], params["dex_factor"] * dex_bytes / GB)
     budget_gb = params["budget_ratio"] * avail_gb
     verdict, reason = _verdict(est_gb, budget_gb, target_ext, override)
+    reason = _probe_note(reason, avail_probe, probe_detail)
 
     return {
         "target": str(target_path),
@@ -184,6 +309,7 @@ def _evaluate(target_path: Path, params: dict[str, Any],
         "dex_bytes_total": dex_bytes,
         "est_heap_gb": round(est_gb, 3),
         "avail_gb": round(avail_gb, 3),
+        "avail_probe": avail_probe,
         "budget_gb": round(budget_gb, 3),
         "verdict": verdict,
         "reason": reason,
@@ -206,9 +332,10 @@ def run(workspace: Path | str, target: str) -> int:
         "budget_ratio": float(overrides.get("apk_mem_budget_ratio",
                                             DEFAULTS["apk_mem_budget_ratio"])),
     }
-    avail_gb = _avail_gb()
+    avail_gb, avail_probe, probe_detail = _avail_probe()
 
-    data = _evaluate(target_path, params, override, avail_gb)
+    data = _evaluate(target_path, params, override, avail_gb, avail_probe,
+                     probe_detail)
     write_evidence(workspace, "apk_mem_gate.json", data)
     return 0
 
@@ -227,7 +354,11 @@ def main(argv=None) -> int:
         print(json.dumps(
             {"verdict": data["verdict"],
              "est_heap_gb": data["est_heap_gb"],
-             "budget_gb": data["budget_gb"]},
+             "budget_gb": data["budget_gb"],
+             # issue 215's recorder mirrors this line into env-facts: the
+             # probe provenance must travel with it (issue 223).
+             "reason": data.get("reason", ""),
+             "avail_probe": data.get("avail_probe", AVAIL_PROBE_OK)},
             ensure_ascii=False,
         ))
     except Exception:  # noqa: BLE001 - best-effort audit line

--- a/tools/static/apk_mem_gate.py
+++ b/tools/static/apk_mem_gate.py
@@ -148,7 +148,10 @@ def _darwin_vm_page_counts() -> tuple[int, int, int]:
         ctypes.POINTER(ctypes.c_uint32),
     ]
     stats = VmStatistics64()
-    count = ctypes.c_uint32(ctypes.sizeof(stats))
+    # host_statistics64's count is in natural_t WORDS (HOST_VM_INFO64_COUNT),
+    # not bytes — the struct's own word count is the exact value.
+    count = ctypes.c_uint32(
+        ctypes.sizeof(stats) // ctypes.sizeof(ctypes.c_uint32))
     kern_return = libsystem.host_statistics64(
         libsystem.mach_host_self(), _HOST_VM_INFO64,
         ctypes.byref(stats), ctypes.byref(count))


### PR DESCRIPTION
Fixes #223

## What

`tools/static/apk_mem_gate.py` probed available memory with
`os.sysconf("SC_AVPHYS_PAGES")` — a Linux-only key. On darwin it raises
`ValueError: unrecognized configuration name`, `_avail_gb()` swallowed it and
returned the 4 GB floor, so `budget = 0.65 x 4.0 = 2.6 GB` became a constant
and `est_heap_gb >= 4.0 > 2.6` blocked jadx for **every** APK on **every**
macOS host (the v0.1.6 withdrawal path).

- New `_mem_darwin()` reads the Mach VM counters (`host_statistics64` /
  `HOST_VM_INFO64` via `ctypes.CDLL(None)` — no subprocess, no new deps):
  `avail ~= (free + inactive + speculative) x page size`.
- `_probe_avail_bytes()` dispatch: win → `_mem_windows` (unchanged), darwin →
  `_mem_darwin` (new), else → `_mem_posix` (unchanged).
- One measurement carries its own provenance: `_avail_probe() ->
  (avail_gb, avail_probe, detail)`, `avail_probe in {"ok", "floor-fallback"}`.
  A failed probe still floors (fail-safe) but is no longer silent: the verdict
  JSON carries `avail_probe`, the reason gains
  `avail_probe: floor-fallback (<Exception: detail>)`, and the tool's ONE
  stdout line now also carries `reason` + `avail_probe` — the exact line
  `kunglao-init.record_mem_gate_verdict` (issue 215) mirrors into
  `env-facts.yaml` `mem_gate.reason`. No consumer file was touched; the schema
  change is additive.

## Blast radius (GitNexus at base c0eb472)

`impact _avail_gb` (upstream): **LOW** — 1 direct caller (`run`), 3 transitive
nodes (`run` → `main` → file), 0 execution flows, affected module: tests.
`impact _evaluate`: LOW, 1 direct caller (`run`). `impact _mem_posix`: LOW, 1
direct caller (`_avail_gb`). `_mem_darwin` is net-new (no index entry at base).
External consumers are out-of-process and additive-safe: `kunglao-init` parses
the stdout dict by key, `route_capability` reads only `verdict`.

## Before / after, live on the owner macOS host

Before (base c0eb472):

```
$ python3 -c "import os; os.sysconf('SC_AVPHYS_PAGES')"
ValueError: unrecognized configuration name
$ ... apk_mem_gate._avail_gb()   ->  4.0      # floor; budget pinned at 2.6 GB
```

After, live `_avail_probe()` on the same host (samples minutes apart, all
`probe="ok"`): **2.785 / 3.977 / 4.104 / 6.196 / 3.093 / 3.031 / 8.382 / 1.875
/ 3.565 / 7.303 GB** (range 1.9–8.4 GB — the reading now tracks the host
instead of being pinned). Cross-checked against `vm_stat` in the same sampling
windows: `host_statistics64.free_count - speculative_count ~= vm_stat "Pages
free"`, confirming the counters are the real Mach VM statistics.

## Field verdicts — both owner fixtures, live

| window | target | est_heap_gb | avail_gb | budget_gb | verdict |
|---|---|---|---|---|---|
| loaded (real) | `wbtest.apk` (9.3 MB) | 4.0 | 3.977 | 2.585 | smali-only |
| loaded (real) | `nova_ai….apk` (396 MB) | 22.071 | 4.104 | 2.668 | smali-only |
| **high-availability (real)** | `wbtest.apk` (9.3 MB) | 4.0 | **6.467** | **4.204** | **targeted-jadx** |
| **high-availability (real)** | `nova_ai….apk` (396 MB) | 22.071 | 6.454 | 4.195 | smali-only |

- The SMALL fixture **flips** (smali-only → `targeted-jadx`) the moment the
  *measured* avail crosses 6.15 GB — that verdict satisfies the jadx provider
  precondition (`env_manifest.MEM_GATE_JADX_OK = ("jadx-ok", "targeted-jadx")`),
  so jadx is no longer blocked on macOS. Captured in a real high-availability
  window on this (heavily loaded) host; no override involved.
- `jadx-ok` additionally needs `budget >= 1.5 x est = 6.0 GB`, i.e.
  `avail >= 9.23 GB`. The host peaked at 8.38 GB while I polled (~9 min of
  sampling), so no `jadx-ok` capture was possible; the small fixture stays
  `smali-only` whenever the machine is genuinely loaded (budget 2.6–2.7 GB),
  which is exactly the honest, load-dependent behavior the constant prevented.
- The two fixtures' est values are unchanged (4.0 / 22.071) — est-heap model
  untouched.

## Unit evidence

- RED commit `156cf08`: **16 failed / 1 passed** — the darwin test fails
  against the unfixed module with `AssertionError: darwin must measure, not
  floor` (the reviewer's `ValueError` scenario, not a missing-symbol error).
- Following commits: `nice -n 19 python3 -m pytest tests/test_apk_mem_gate.py
  tests/test_memgate_evidence_215.py -q` → **44 passed**; related suites
  (`test_route_capability_providers` / `test_dispatch_context_providers` /
  `test_delegation_863i` / `test_harness_common_863g`) → **71 passed**.
- `ruff check` clean on both changed files; repo-wide the 7 errors present at
  base are unchanged (identical set on the dev main checkout) — zero new.
- `python3 scripts/deploy_manifest.py --write && --verify` → OK, 396 entries
  verified.

## Deviations

- The 8 pre-existing tests in `tests/test_apk_mem_gate.py` keep every
  assertion; only the injected seam moved (`_avail_gb` → `_avail_probe`) so a
  single measurement carries both value and provenance.
- `test_red6_avail_gb_fallback` was strengthened after independent review: it
  now fails all three platform probes (darwin included) and asserts the exact
  floor plus `("floor-fallback", detail)` provenance, instead of `> 0`.
- `host_statistics64`'s count argument is passed in `natural_t` words
  (`HOST_VM_INFO64_COUNT = 38`), not bytes, per the same review.
- Local env has no `pytest-xdist`, so the targeted run used `-q` without
  `-n 2` (CI runners keep their own layout).
