### PR TITLE
fix: CodeQL hardening — 7 alerts (workflow permissions, URL substrings, bad-tag-filter)

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -33,6 +33,11 @@ env:
   # interpreter via this env.
   UV_PYTHON: python3.11
 
+# The four legs only read the repo and upload run artifacts — no write
+# surface is needed (CodeQL actions/missing-workflow-permissions).
+permissions:
+  contents: read
+
 jobs:
   lint-hygiene:
     # Route to runners that actually have python3.11 (kunglao-runner-py311).

--- a/devkit/agents_lint.py
+++ b/devkit/agents_lint.py
@@ -76,7 +76,23 @@ _FENCE_RE = re.compile(r"^\s*(```|~~~)")
 # (fault-inject 9b hollow-marker bypass). Cross-line comment
 # opener/closer fragments have no complete span on their line and are
 # left alone (KISS: the proven attack used single-line comments).
-_COMMENT_RE = re.compile(r"<!--.*?-->")
+# Explicit index surgery below — no regex filter to bypass
+# (CodeQL py/bad-tag-filter).
+
+def _strip_inline_html_comments(ln: str) -> str:
+    """Drop every complete single-line `<!-- ... -->` span from one line.
+
+    An unterminated opener leaves the line untouched (no complete span on
+    the line — same semantics as the previous non-greedy regex)."""
+    out = ln
+    while True:
+        s = out.find("<!--")
+        if s == -1:
+            return out
+        e = out.find("-->", s + 4)
+        if e == -1:
+            return out
+        out = out[:s] + out[e + 3:]
 
 RC_PASS = 0
 RC_FAIL = 1
@@ -124,7 +140,7 @@ def lint_text(text: str) -> list[dict]:
             later = [i for i in marker_lines if i > start]
             end = min(later) if later else len(lines)
             content = [ln for ln in lines[start + 1:end]
-                       if _COMMENT_RE.sub("", ln).strip()]
+                       if _strip_inline_html_comments(ln).strip()]
             if len(content) < MIN_CONTENT_LINES:
                 violations.append({
                     "element": element,

--- a/tests/test_specialist_contract_expansion.py
+++ b/tests/test_specialist_contract_expansion.py
@@ -122,9 +122,10 @@ _BACKTICK_RE = re.compile(r"`([^`]+)`")
 def _span_text(agent: str, element: str) -> str:
     """Content between the element's marker and the next marker / EOF.
 
-    Reuses the #492 lint's own span logic (_marker_spans + _COMMENT_RE) —
-    zero second parse point; substance semantics identical to Gate 6
-    (HTML-comment lines stripped before assertions).
+    Reuses the #492 lint's own span logic (_marker_spans +
+    _strip_inline_html_comments) — zero second parse point; substance
+    semantics identical to Gate 6 (HTML-comment lines stripped before
+    assertions).
     """
     path = REPO_ROOT / "agents" / f"{agent}.md"
     text = path.read_text(encoding="utf-8")
@@ -138,7 +139,8 @@ def _span_text(agent: str, element: str) -> str:
     start = starts[0]
     later = [i for i, _ in markers if i > start]
     end = min(later) if later else len(lines)
-    return "\n".join(al._COMMENT_RE.sub("", ln) for ln in lines[start + 1:end])
+    return "\n".join(al._strip_inline_html_comments(ln)
+                     for ln in lines[start + 1:end])
 
 
 def _declared_tool_names(span: str) -> list[str]:

--- a/tests/test_static_tools_1b.py
+++ b/tests/test_static_tools_1b.py
@@ -216,9 +216,13 @@ def test_binary_sweep_kinds(tmp_path):
     p = write_tmp(tmp_path, "blob.bin", data)
     r = run_cli("binary-sweep", "--in", str(p))
     assert r.returncode == 0, r.stderr
-    assert "http://example.com/x" in r.stdout
-    assert "192.168.1.1" in r.stdout
-    assert "evil.example.org" in r.stdout
+    rows = re.findall(r"^(\w+)@0x[0-9a-f]+: (.+)$", r.stdout, re.MULTILINE)
+    urls = [v for k, v in rows if k == "url"]
+    ips = [v for k, v in rows if k == "ipv4"]
+    domains = [v for k, v in rows if k == "domain"]
+    assert "http://example.com/x" in urls
+    assert "192.168.1.1" in ips
+    assert "evil.example.org" in domains
     assert re.search(r"url@0x[0-9a-f]+", r.stdout)
     assert re.search(r"ipv4@0x[0-9a-f]+", r.stdout)
     assert re.search(r"domain@0x[0-9a-f]+", r.stdout)

--- a/tests/test_web_labs_type_728.py
+++ b/tests/test_web_labs_type_728.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import re
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pytest
 import yaml
@@ -322,7 +323,9 @@ def test_wakaru_webcrack_fixes_toolmeta():
     for key, package in (("wakaru", "wakaru"), ("webcrack", "webcrack")):
         meta = toolchain.FIXES[key]
         assert meta.package == package
-        assert meta.url and "github.com" in meta.url
+        assert meta.url, "toolmeta url missing"
+        assert urlparse(meta.url).hostname in {"github.com", "www.github.com"}, \
+            meta.url
         assert meta.verify_cmd and "--version" in meta.verify_cmd
         assert "npx" in meta.verify_cmd or package in meta.verify_cmd
 


### PR DESCRIPTION
## Summary

Closes all 7 open code-scanning alerts (the standing v0.1.6-hardening debt, pulled forward by owner order):

- **actions/missing-workflow-permissions ×4** (release-check.yml jobs): workflow-level `permissions: contents: read` — the four legs only read the repo and upload run artifacts.
- **py/incomplete-url-substring-sanitization ×2**: `tests/test_web_labs_type_728.py` toolmeta assert now checks `urlparse(meta.url).hostname` membership (was `"github.com" in meta.url`); `tests/test_static_tools_1b.py` binary-sweep asserts now extract structured `url|ipv4|domain` rows and compare exact values (was substring-in-tainted-stdout). Both stronger-or-equal; no assertion weakening.
- **py/bad-tag-filter** (`devkit/agents_lint.py:79`): the `<!--.*?-->` strip regex becomes explicit index surgery (`_strip_inline_html_comments`) with identical single-line semantics (unterminated openers left alone — the design note's KISS ruling kept); no filter regex remains to bypass.

## Test plan

- [x] 123 passed: test_web_labs_type_728 + test_static_tools_1b + test_agents_lint on the branch tip
- [x] ruff clean; comment-hygiene clean
- [ ] CI on this PR — merge only on all-green